### PR TITLE
Fix: Major city pickup/dropoff works for outposts and centers (closes #24)

### DIFF
--- a/src/client/components/TrainInteractionManager.ts
+++ b/src/client/components/TrainInteractionManager.ts
@@ -273,40 +273,12 @@ export class TrainInteractionManager {
     });
   }
   
-  private lookupMajorCityCenterForOutpost(point: GridPoint): CityData | undefined {
-    // majorCityGroups: { [name: string]: any[] }
-    for (const [name, group] of Object.entries(majorCityGroups)) {
-      // The center is always group[0]
-      const center = group[0];
-      // Outposts are group[1..n]
-      for (let i = 1; i < group.length; i++) {
-        const outpost = group[i];
-        if (outpost.GridX === point.col && outpost.GridY === point.row) {
-          // Return the center's city data
-          return {
-            type: center.Type === 'Major City' ? 2 : center.Type, // 2 = TerrainType.MajorCity
-            name: name,
-            connectedPoints: group.slice(1, 7).map(op => ({ col: op.GridX, row: op.GridY })),
-            availableLoads: [],
-          };
-        }
-      }
-    }
-    return undefined;
-  }
-
   private async handleCityArrival(
     currentPlayer: Player, 
     nearestMilepost: any
   ): Promise<void> {
-    // If this is a major city outpost, look up the center's city data
-    let cityData = nearestMilepost.city;
-    if (
-      nearestMilepost.terrain === 2 && // TerrainType.MajorCity
-      !nearestMilepost.city
-    ) {
-      cityData = this.lookupMajorCityCenterForOutpost(nearestMilepost);
-    }
+    // Always use the city property on the grid point
+    const cityData = nearestMilepost.city;
     if (!cityData) return;
     // Get the LoadService instance to check available loads
     const loadService = LoadService.getInstance();

--- a/src/client/components/map/MapElementFactory.ts
+++ b/src/client/components/map/MapElementFactory.ts
@@ -21,7 +21,13 @@ export class MapElementFactory {
     if (point && point.city) {
       switch (point.city.type) {
         case TerrainType.MajorCity:
-          return new MajorCity(scene, point, x, y);
+          // Only render as MajorCity if this is the center (has connectedPoints and non-empty)
+          if (point.city.connectedPoints && point.city.connectedPoints.length > 0) {
+            return new MajorCity(scene, point, x, y);
+          } else {
+            // Outposts: fall through to default rendering below
+            break;
+          }
         case TerrainType.MediumCity:
           return new MediumCity(scene, point, x, y);
         case TerrainType.SmallCity:

--- a/src/client/components/map/MapElementFactory.ts
+++ b/src/client/components/map/MapElementFactory.ts
@@ -21,8 +21,8 @@ export class MapElementFactory {
     if (point && point.city) {
       switch (point.city.type) {
         case TerrainType.MajorCity:
-          // Only render as MajorCity if this is the center (has connectedPoints and non-empty)
-          if (point.city.connectedPoints && point.city.connectedPoints.length > 0) {
+          // Only render as MajorCity if this is the center (connectedPoints is an array)
+          if (Array.isArray(point.city.connectedPoints)) {
             return new MajorCity(scene, point, x, y);
           } else {
             // Outposts: fall through to default rendering below

--- a/src/client/config/mapConfig.ts
+++ b/src/client/config/mapConfig.ts
@@ -62,6 +62,20 @@ const points: GridPoint[] = [];
     const terrain = mapTypeToTerrain(mp.Type);
     const { x, y } = calculateWorldCoordinates(col, row);
     // Build the GridPoint directly
+    let cityData: any = undefined;
+    if ((mp.Type === "Small City" || mp.Type === "Medium City" || mp.Type === "Ferry Port") && mp.Name) {
+      cityData = {
+        type: terrain,
+        name: mp.Name,
+        availableLoads: [],
+      };
+    } else if (mp.Type === "Major City Outpost" && mp.Name) {
+      cityData = {
+        type: TerrainType.MajorCity,
+        name: mp.Name,
+        availableLoads: [],
+      };
+    }
     const gridPoint: GridPoint = {
       x: x,
       y: y,
@@ -69,14 +83,7 @@ const points: GridPoint[] = [];
       row,
       terrain,
       id: mp.Id,
-      // Only assign city for small, medium, and ferry port cities
-      city: (mp.Type === "Small City" || mp.Type === "Medium City" || mp.Type === "Ferry Port") && mp.Name
-        ? {
-            type: terrain,
-            name: mp.Name,
-            availableLoads: [],
-          }
-        : undefined,
+      city: cityData,
       // Set ocean if present
       ...(mp.Ocean ? { ocean: mp.Ocean } : {})
     };


### PR DESCRIPTION
This PR fixes issue #24 by:
- Assigning city data to all major city outpost grid points for logic purposes
- Ensuring only city centers are rendered as MajorCity (outposts are rendered as mileposts)
- Removing the fragile outpost-to-center lookup logic
- Simplifying arrival and load dialog handling to always use the city property on the grid point

If merged, this will close #24 and make major city pickup/dropoff work as expected for both city centers and outposts.