### PR TITLE
fix: allow exiting train movement mode by clicking train again

### DIFF
--- a/src/client/components/TrainInteractionManager.ts
+++ b/src/client/components/TrainInteractionManager.ts
@@ -469,7 +469,6 @@ export class TrainInteractionManager {
       // 1. This is the current player's train
       // 2. Not in drawing mode
       // 3. Player has track
-      // 4. Not already in train movement mode
       const isCurrentPlayer =
         playerId ===
         this.gameState.players[this.gameState.currentPlayerIndex].id;
@@ -478,15 +477,21 @@ export class TrainInteractionManager {
       if (
         isCurrentPlayer &&
         hasTrack &&
-        !this.isDrawingMode &&
-        !this.isTrainMovementMode
+        !this.isDrawingMode
       ) {
         // First stop event propagation to prevent it from being handled by the scene
         if (pointer.event) {
           pointer.event.stopPropagation();
         }
-        // Then enter train movement mode
-        this.enterTrainMovementMode();
+        // Toggle movement mode: if already in movement mode, exit; otherwise, enter
+        if (this.isTrainMovementMode) {
+          // Prevent immediate exit if just entered movement mode
+          if (!this.justEnteredMovementMode) {
+            this.exitTrainMovementMode();
+          }
+        } else {
+          this.enterTrainMovementMode();
+        }
       }
     });
   }


### PR DESCRIPTION
This PR fixes issue #38. Now, clicking your own train while in movement mode will exit movement mode and revert the icon/cursor, improving usability and matching expected behavior.