### PR TITLE
Track and reset segments built this turn for undo (closes #41)

### DIFF
--- a/src/client/__tests__/TrackDrawingManagerUndo.test.ts
+++ b/src/client/__tests__/TrackDrawingManagerUndo.test.ts
@@ -1,0 +1,76 @@
+import { TrackDrawingManager } from '../components/TrackDrawingManager';
+import { GameState, TerrainType, GridPoint } from '../../shared/types/GameTypes';
+import { PlayerTrackState } from '../../shared/types/TrackTypes';
+
+// Minimal fetch mock for tests
+(global as any).fetch = jest.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+
+// Mock Phaser dependencies
+const mockScene = { add: { graphics: () => ({ setDepth: () => {}, clear: () => {}, destroy: () => {} }) }, events: { on: () => {}, off: () => {} }, input: { on: () => {}, off: () => {} }, cameras: { main: { getWorldPoint: () => ({ x: 0, y: 0 }) } }, scale: { height: 1000 } } as any;
+const mockMapContainer = { add: () => {} } as any;
+const mockGameState: GameState = {
+  id: 'game1',
+  players: [{ id: 'p1', color: '#ff0000', money: 50 }],
+  currentPlayerIndex: 0
+} as any;
+const mockGridPoints: GridPoint[][] = [[{ x: 0, y: 0, row: 0, col: 0, terrain: TerrainType.Clear, id: '0,0' }]];
+
+describe('TrackDrawingManager Undo Feature', () => {
+  it('should initialize segmentsDrawnThisTurn as an empty array', () => {
+    const manager = new TrackDrawingManager(
+      mockScene,
+      mockMapContainer,
+      mockGameState,
+      mockGridPoints
+    );
+    expect(manager.segmentsDrawnThisTurn).toEqual([]);
+  });
+
+  it('should accumulate segmentsDrawnThisTurn across multiple drawing sessions in a turn', async () => {
+    const manager = new TrackDrawingManager(
+      mockScene,
+      mockMapContainer,
+      mockGameState,
+      mockGridPoints
+    );
+    // Simulate first drawing session
+    const segment1 = { from: { x: 0, y: 0, row: 0, col: 0, terrain: TerrainType.Clear }, to: { x: 1, y: 1, row: 0, col: 1, terrain: TerrainType.Clear }, cost: 1 };
+    (manager as any)["currentSegments"] = [segment1];
+    (manager as any)["turnBuildCost"] = 1;
+    await (manager as any)["saveCurrentTracks"]();
+    expect(manager.segmentsDrawnThisTurn).toEqual([segment1]);
+
+    // Simulate second drawing session in the same turn
+    const segment2 = { from: { x: 1, y: 1, row: 0, col: 1, terrain: TerrainType.Clear }, to: { x: 2, y: 2, row: 0, col: 2, terrain: TerrainType.Clear }, cost: 1 };
+    (manager as any)["currentSegments"] = [segment2];
+    (manager as any)["turnBuildCost"] = 1;
+    await (manager as any)["saveCurrentTracks"]();
+    expect(manager.segmentsDrawnThisTurn).toEqual([segment1, segment2]);
+  });
+
+  it('should reset segmentsDrawnThisTurn and build cost on endTurnCleanup', async () => {
+    const manager = new TrackDrawingManager(
+      mockScene,
+      mockMapContainer,
+      mockGameState,
+      mockGridPoints
+    );
+    // Simulate drawing and committing two segments
+    const segment1 = { from: { x: 0, y: 0, row: 0, col: 0, terrain: TerrainType.Clear }, to: { x: 1, y: 1, row: 0, col: 1, terrain: TerrainType.Clear }, cost: 1 };
+    const segment2 = { from: { x: 1, y: 1, row: 0, col: 1, terrain: TerrainType.Clear }, to: { x: 2, y: 2, row: 0, col: 2, terrain: TerrainType.Clear }, cost: 1 };
+    (manager as any)["currentSegments"] = [segment1];
+    (manager as any)["turnBuildCost"] = 1;
+    await (manager as any)["saveCurrentTracks"]();
+    (manager as any)["currentSegments"] = [segment2];
+    (manager as any)["turnBuildCost"] = 1;
+    await (manager as any)["saveCurrentTracks"]();
+    expect(manager.segmentsDrawnThisTurn).toEqual([segment1, segment2]);
+    // Simulate a nonzero build cost
+    const playerId = mockGameState.players[0].id;
+    expect(manager.getLastBuildCost(playerId)).toBeGreaterThan(0);
+    // Call endTurnCleanup
+    await manager.endTurnCleanup(playerId);
+    expect(manager.segmentsDrawnThisTurn).toEqual([]);
+    expect(manager.getLastBuildCost(playerId)).toBe(0);
+  });
+}); 

--- a/src/client/components/TrackDrawingManager.ts
+++ b/src/client/components/TrackDrawingManager.ts
@@ -63,6 +63,8 @@ export class TrackDrawingManager {
     // Add property to store the update event handler
     private updateEventHandler: (() => void) | null = null;
     
+    public segmentsDrawnThisTurn: TrackSegment[] = [];
+    
     constructor(
         scene: Phaser.Scene, 
         mapContainer: Phaser.GameObjects.Container, 
@@ -76,6 +78,7 @@ export class TrackDrawingManager {
         this.gridPoints = gridPoints;
         this.playerTracks = new Map();
         this.gameStateService = gameStateService;
+        this.segmentsDrawnThisTurn = [];
         
         // Initialize drawing graphics
         this.drawingGraphics = this.scene.add.graphics();
@@ -297,6 +300,10 @@ export class TrackDrawingManager {
             playerTrackState.turnBuildCost += this.turnBuildCost;
             
             playerTrackState.lastBuildTimestamp = new Date();
+            
+            // --- NEW: Track segments built this turn ---
+            this.segmentsDrawnThisTurn.push(...this.currentSegments);
+            // --- END NEW ---
             
             try {
                 // Save track state to database
@@ -1318,5 +1325,12 @@ export class TrackDrawingManager {
         this.lastClickedPoint = null;
         this.lastHoverPoint = null;
         this.pendingHoverPoint = null;
+        this.segmentsDrawnThisTurn = [];
+    }
+
+    // End-of-turn cleanup: resets build cost and segments drawn this turn
+    public async endTurnCleanup(playerId: string): Promise<void> {
+        await this.clearLastBuildCost(playerId);
+        this.segmentsDrawnThisTurn = [];
     }
 }

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -322,7 +322,7 @@ export class GameScene extends Phaser.Scene {
       }
 
       // Clear the build cost after processing it to avoid double-counting
-      await this.trackManager.clearLastBuildCost(currentPlayer.id);
+      await this.trackManager.endTurnCleanup(currentPlayer.id);
     }
 
     // Use the game state service to handle player turn changes


### PR DESCRIPTION
This PR implements tracking of all track segments built during the current turn, and resets them at end of turn. This is the foundation for the undo feature. Resolves #41.