### PR TITLE
Implement undo logic and UI for track segments built this turn (closes #43)

### DIFF
--- a/src/client/__tests__/TrackDrawingManagerUndo.test.ts
+++ b/src/client/__tests__/TrackDrawingManagerUndo.test.ts
@@ -6,7 +6,23 @@ import { PlayerTrackState } from '../../shared/types/TrackTypes';
 (global as any).fetch = jest.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
 
 // Mock Phaser dependencies
-const mockScene = { add: { graphics: () => ({ setDepth: () => {}, clear: () => {}, destroy: () => {} }) }, events: { on: () => {}, off: () => {} }, input: { on: () => {}, off: () => {} }, cameras: { main: { getWorldPoint: () => ({ x: 0, y: 0 }) } }, scale: { height: 1000 } } as any;
+const mockGraphics = {
+  setDepth: jest.fn(),
+  clear: jest.fn(),
+  destroy: jest.fn(),
+  lineStyle: jest.fn(),
+  beginPath: jest.fn(),
+  moveTo: jest.fn(),
+  lineTo: jest.fn(),
+  strokePath: jest.fn(),
+};
+const mockScene = {
+  add: { graphics: () => mockGraphics },
+  events: { on: () => {}, off: () => {} },
+  input: { on: () => {}, off: () => {} },
+  cameras: { main: { getWorldPoint: () => ({ x: 0, y: 0 }) } },
+  scale: { height: 1000 }
+} as any;
 const mockMapContainer = { add: () => {} } as any;
 const mockGameState: GameState = {
   id: 'game1',
@@ -109,6 +125,85 @@ describe('TrackDrawingManager Undo Feature', () => {
     // Call endTurnCleanup
     await manager.endTurnCleanup(playerId);
     expect(manager.segmentsDrawnThisTurn).toEqual([]);
+    expect(manager.getLastBuildCost(playerId)).toBe(0);
+  });
+
+  it('should undo the last segment built this turn', async () => {
+    const manager = new TrackDrawingManager(
+      mockScene,
+      mockMapContainer,
+      mockGameState,
+      mockGridPoints
+    );
+    // Simulate drawing and committing two segments
+    const segment1 = { from: { x: 0, y: 0, row: 0, col: 0, terrain: TerrainType.Clear }, to: { x: 1, y: 1, row: 0, col: 1, terrain: TerrainType.Clear }, cost: 1 };
+    const segment2 = { from: { x: 1, y: 1, row: 0, col: 1, terrain: TerrainType.Clear }, to: { x: 2, y: 2, row: 0, col: 2, terrain: TerrainType.Clear }, cost: 2 };
+    (manager as any)["currentSegments"] = [segment1];
+    (manager as any)["turnBuildCost"] = 1;
+    await (manager as any)["saveCurrentTracks"]();
+    (manager as any)["currentSegments"] = [segment2];
+    (manager as any)["turnBuildCost"] = 2;
+    await (manager as any)["saveCurrentTracks"]();
+    // Undo last segment
+    manager.undoLastSegment();
+    // Only segment1 should remain
+    expect(manager.segmentsDrawnThisTurn).toEqual([segment1]);
+    const playerId = mockGameState.players[0].id;
+    const playerTrackState = (manager as any).playerTracks.get(playerId);
+    expect(playerTrackState.segments).toEqual([segment1]);
+    // Cost should be updated
+    expect(manager.getLastBuildCost(playerId)).toBe(1);
+  });
+
+  it('should do nothing if undoLastSegment is called with no segments', () => {
+    const manager = new TrackDrawingManager(
+      mockScene,
+      mockMapContainer,
+      mockGameState,
+      mockGridPoints
+    );
+    // Should not throw or change state
+    expect(() => manager.undoLastSegment()).not.toThrow();
+    expect(manager.segmentsDrawnThisTurn).toEqual([]);
+    const playerId = mockGameState.players[0].id;
+    expect(manager.getLastBuildCost(playerId)).toBe(0);
+  });
+
+  it('should support multiple undos in LIFO order', async () => {
+    const manager = new TrackDrawingManager(
+      mockScene,
+      mockMapContainer,
+      mockGameState,
+      mockGridPoints
+    );
+    // Simulate drawing and committing three segments
+    const segment1 = { from: { x: 0, y: 0, row: 0, col: 0, terrain: TerrainType.Clear }, to: { x: 1, y: 1, row: 0, col: 1, terrain: TerrainType.Clear }, cost: 1 };
+    const segment2 = { from: { x: 1, y: 1, row: 0, col: 1, terrain: TerrainType.Clear }, to: { x: 2, y: 2, row: 0, col: 2, terrain: TerrainType.Clear }, cost: 2 };
+    const segment3 = { from: { x: 2, y: 2, row: 0, col: 2, terrain: TerrainType.Clear }, to: { x: 3, y: 3, row: 0, col: 3, terrain: TerrainType.Clear }, cost: 3 };
+    (manager as any)["currentSegments"] = [segment1];
+    (manager as any)["turnBuildCost"] = 1;
+    await (manager as any)["saveCurrentTracks"]();
+    (manager as any)["currentSegments"] = [segment2];
+    (manager as any)["turnBuildCost"] = 2;
+    await (manager as any)["saveCurrentTracks"]();
+    (manager as any)["currentSegments"] = [segment3];
+    (manager as any)["turnBuildCost"] = 3;
+    await (manager as any)["saveCurrentTracks"]();
+    const playerId = mockGameState.players[0].id;
+    // Undo last (segment3)
+    manager.undoLastSegment();
+    expect(manager.segmentsDrawnThisTurn).toEqual([segment1, segment2]);
+    expect((manager as any).playerTracks.get(playerId).segments).toEqual([segment1, segment2]);
+    expect(manager.getLastBuildCost(playerId)).toBe(3);
+    // Undo again (segment2)
+    manager.undoLastSegment();
+    expect(manager.segmentsDrawnThisTurn).toEqual([segment1]);
+    expect((manager as any).playerTracks.get(playerId).segments).toEqual([segment1]);
+    expect(manager.getLastBuildCost(playerId)).toBe(1);
+    // Undo again (segment1)
+    manager.undoLastSegment();
+    expect(manager.segmentsDrawnThisTurn).toEqual([]);
+    expect((manager as any).playerTracks.get(playerId).segments).toEqual([]);
     expect(manager.getLastBuildCost(playerId)).toBe(0);
   });
 }); 

--- a/src/client/components/PlayerHandDisplay.ts
+++ b/src/client/components/PlayerHandDisplay.ts
@@ -9,6 +9,8 @@ export class PlayerHandDisplay {
   private container: Phaser.GameObjects.Container;
   private gameState: GameState;
   private toggleDrawingCallback: () => void;
+  private onUndo: () => void;
+  private canUndo: () => boolean;
   public trainCard: TrainCard | null = null;
   private readonly CARD_SPACING = 180;
   private readonly START_X = 110;
@@ -20,11 +22,15 @@ export class PlayerHandDisplay {
   constructor(
     scene: Phaser.Scene,
     gameState: GameState,
-    toggleDrawingCallback: () => void
+    toggleDrawingCallback: () => void,
+    onUndo: () => void,
+    canUndo: () => boolean
   ) {
     this.scene = scene;
     this.gameState = gameState;
     this.toggleDrawingCallback = toggleDrawingCallback;
+    this.onUndo = onUndo;
+    this.canUndo = canUndo;
     this.container = this.scene.add.container(0, 0);
   }
   
@@ -223,6 +229,30 @@ export class PlayerHandDisplay {
     }
       
     targetContainer.add([nameAndMoney, buildCostText, crayonButton]);
+
+    // --- Undo button below crayon ---
+    if (this.canUndo()) {
+      const undoButton = this.scene.add
+        .text(
+          crayonButton.x,
+          crayonButton.y + 50, // 50px below crayon
+          '⟲ Undo',
+          {
+            color: '#ffffff',
+            fontSize: '18px',
+            fontStyle: 'bold',
+            backgroundColor: '#444',
+            padding: { left: 8, right: 8, top: 4, bottom: 4 },
+          }
+        )
+        .setOrigin(0.5, 0)
+        .setInteractive({ useHandCursor: true });
+      undoButton.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+        if (pointer.event) pointer.event.stopPropagation();
+        this.onUndo();
+      });
+      targetContainer.add(undoButton);
+    }
   }
 
   public destroy(): void {

--- a/src/client/components/TrackDrawingManager.ts
+++ b/src/client/components/TrackDrawingManager.ts
@@ -1359,10 +1359,11 @@ export class TrackDrawingManager {
                     break;
                 }
             }
-            // Subtract cost from both turnBuildCost and this.turnBuildCost
+            // Subtract cost only from turnBuildCost
             playerTrackState.turnBuildCost = Math.max(0, playerTrackState.turnBuildCost - lastSegment.cost);
         }
-        this.turnBuildCost = Math.max(0, this.turnBuildCost - lastSegment.cost);
+        // Clear network cache to avoid stale pathfinding
+        this.networkNodesCache.clear();
         // Redraw
         this.drawAllTracks();
         // Update cost display

--- a/src/client/components/TrackDrawingManager.ts
+++ b/src/client/components/TrackDrawingManager.ts
@@ -1333,4 +1333,43 @@ export class TrackDrawingManager {
         await this.clearLastBuildCost(playerId);
         this.segmentsDrawnThisTurn = [];
     }
+
+    // Undo the last segment built this turn
+    public undoLastSegment(): void {
+        if (this.segmentsDrawnThisTurn.length === 0) {
+            return;
+        }
+        // Remove the last segment from the turn array
+        const lastSegment = this.segmentsDrawnThisTurn.pop();
+        if (!lastSegment) return;
+        // Remove from permanent track state
+        const currentPlayer = this.gameState.players[this.gameState.currentPlayerIndex];
+        const playerTrackState = this.playerTracks.get(currentPlayer.id);
+        if (playerTrackState) {
+            // Remove the last matching segment (LIFO)
+            for (let i = playerTrackState.segments.length - 1; i >= 0; i--) {
+                const seg = playerTrackState.segments[i];
+                if (
+                    seg.from.row === lastSegment.from.row &&
+                    seg.from.col === lastSegment.from.col &&
+                    seg.to.row === lastSegment.to.row &&
+                    seg.to.col === lastSegment.to.col
+                ) {
+                    playerTrackState.segments.splice(i, 1);
+                    break;
+                }
+            }
+            // Subtract cost from both turnBuildCost and this.turnBuildCost
+            playerTrackState.turnBuildCost = Math.max(0, playerTrackState.turnBuildCost - lastSegment.cost);
+        }
+        this.turnBuildCost = Math.max(0, this.turnBuildCost - lastSegment.cost);
+        // Redraw
+        this.drawAllTracks();
+        // Update cost display
+        if (this.onCostUpdateCallback) {
+            const previousSessionsCost = playerTrackState ? playerTrackState.turnBuildCost : 0;
+            const totalCost = previousSessionsCost + this.turnBuildCost;
+            this.onCostUpdateCallback(totalCost);
+        }
+    }
 }

--- a/src/client/components/UIManager.ts
+++ b/src/client/components/UIManager.ts
@@ -99,7 +99,17 @@ export class UIManager {
     this.playerHandDisplay = new PlayerHandDisplay(
       this.scene,
       this.gameState,
-      this.toggleDrawingCallback
+      this.toggleDrawingCallback,
+      () => {
+        this.trackDrawingManager.undoLastSegment();
+        // Refresh the hand display after undo
+        const currentPlayer = this.gameState.players[this.gameState.currentPlayerIndex];
+        const previousSessionsCost = this.trackDrawingManager.getPlayerTrackState(currentPlayer.id)?.turnBuildCost || 0;
+        const currentSessionCost = this.trackDrawingManager.getCurrentTurnBuildCost();
+        const totalCost = previousSessionsCost + currentSessionCost;
+        this.setupPlayerHand(this.isDrawingMode, totalCost);
+      },
+      () => this.trackDrawingManager.segmentsDrawnThisTurn.length > 0
     );
 
     // Connect PlayerHandDisplay and UIManager to TrainInteractionManager


### PR DESCRIPTION
This PR implements the undo logic for track segments built in the current turn, including UI integration with a context-aware undo button in the player hand display. All edge cases and UI refreshes are handled. Resolves #43.