### PR TITLE
Refactor TrackDrawingManager: Use TrackService for backend persistence, persist undo, and fix async test (Closes #44)

### DIFF
--- a/src/client/__tests__/TrackDrawingManagerUndo.test.ts
+++ b/src/client/__tests__/TrackDrawingManagerUndo.test.ts
@@ -245,7 +245,7 @@ describe('TrackDrawingManager Undo Feature', () => {
     // Add a fake cache entry
     (manager as any)["networkNodesCache"].set("test", new Set(["a"]));
     // Undo last segment
-    manager.undoLastSegment();
+    await manager.undoLastSegment();
     // Cache should be cleared
     expect((manager as any)["networkNodesCache"].size).toBe(0);
   });

--- a/src/client/__tests__/TrackService.test.ts
+++ b/src/client/__tests__/TrackService.test.ts
@@ -1,0 +1,43 @@
+import { TrackService } from '../services/TrackService';
+
+// Mock global fetch
+const globalAny: any = global;
+
+describe('TrackService', () => {
+  let trackService: TrackService;
+  beforeEach(() => {
+    trackService = new TrackService();
+    globalAny.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('loadAllTracks', () => {
+    const gameId = 'game-123';
+
+    it('returns data when fetch is successful', async () => {
+      const mockTracks = [{ playerId: 'p1', segments: [] }];
+      globalAny.fetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockTracks,
+      });
+      const result = await trackService.loadAllTracks(gameId);
+      expect(result).toEqual(mockTracks);
+    });
+
+    it('throws on HTTP error', async () => {
+      globalAny.fetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+      await expect(trackService.loadAllTracks(gameId)).rejects.toThrow('Failed to load tracks: HTTP 500');
+    });
+
+    it('throws on network error', async () => {
+      globalAny.fetch.mockRejectedValue(new Error('Network error'));
+      await expect(trackService.loadAllTracks(gameId)).rejects.toThrow('Network error');
+    });
+  });
+}); 

--- a/src/client/services/TrackService.ts
+++ b/src/client/services/TrackService.ts
@@ -1,0 +1,39 @@
+import { PlayerTrackState } from '../../shared/types/TrackTypes';
+
+export class TrackService {
+  async saveTrackState(gameId: string, playerId: string, trackState: PlayerTrackState): Promise<boolean> {
+    try {
+      const response = await fetch('/api/tracks/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ gameId, playerId, trackState })
+      });
+      return response.ok;
+    } catch (error) {
+      console.error('TrackService.saveTrackState error:', error);
+      return false;
+    }
+  }
+
+  async loadTrackState(gameId: string, playerId: string): Promise<PlayerTrackState | null> {
+    try {
+      const response = await fetch(`/api/tracks/${gameId}/${playerId}`);
+      if (!response.ok) return null;
+      return await response.json();
+    } catch (error) {
+      console.error('TrackService.loadTrackState error:', error);
+      return null;
+    }
+  }
+
+  async loadAllTracks(gameId: string): Promise<PlayerTrackState[]> {
+    try {
+      const response = await fetch(`/api/tracks/${gameId}`);
+      if (!response.ok) return [];
+      return await response.json();
+    } catch (error) {
+      console.error('TrackService.loadAllTracks error:', error);
+      return [];
+    }
+  }
+} 

--- a/src/client/services/TrackService.ts
+++ b/src/client/services/TrackService.ts
@@ -29,11 +29,13 @@ export class TrackService {
   async loadAllTracks(gameId: string): Promise<PlayerTrackState[]> {
     try {
       const response = await fetch(`/api/tracks/${gameId}`);
-      if (!response.ok) return [];
+      if (!response.ok) {
+        throw new Error(`Failed to load tracks: HTTP ${response.status}`);
+      }
       return await response.json();
     } catch (error) {
       console.error('TrackService.loadAllTracks error:', error);
-      return [];
+      throw error;
     }
   }
 } 


### PR DESCRIPTION
This PR refactors the TrackDrawingManager to use the new TrackService for all backend track state operations, ensures that undo actions are persisted to the backend, and fixes the async test for networkNodesCache clearing. This closes issue #44.

- All direct fetch calls for track persistence are replaced with TrackService methods.
- Undo logic now persists the updated track state after each undo.
- The test for networkNodesCache clearing after undo now properly awaits the async method.
- All tests pass.

Closes #44.