### PR TITLE
fix: await track commit before cleanup to prevent disappearing track on drawing mode end (fixes #53)

### DIFF
--- a/src/client/components/TrackDrawingManager.ts
+++ b/src/client/components/TrackDrawingManager.ts
@@ -193,7 +193,7 @@ export class TrackDrawingManager {
         });
     }
 
-    public toggleDrawingMode(): boolean {
+    public async toggleDrawingMode(): Promise<boolean> {
         // Toggle drawing mode state
         const oldMode = this.isDrawingMode;
         this.isDrawingMode = !this.isDrawingMode;
@@ -201,7 +201,7 @@ export class TrackDrawingManager {
         if (this.isDrawingMode) {
             this.initializeDrawingMode();
         } else {
-            this.saveCurrentTracks();
+            await this.saveCurrentTracks();
             this.cleanupDrawingMode();
         }
         

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -266,8 +266,8 @@ export class GameScene extends Phaser.Scene {
     return buttonContainer;
   }
 
-  private toggleDrawingMode(): void {
-    const isDrawingMode = this.trackManager.toggleDrawingMode();
+  private async toggleDrawingMode(): Promise<void> {
+    const isDrawingMode = await this.trackManager.toggleDrawingMode();
 
     // Update UIManager's drawing mode state
     this.uiManager.setDrawingMode(isDrawingMode);
@@ -299,7 +299,7 @@ export class GameScene extends Phaser.Scene {
     // If in drawing mode, finalize track drawing first by toggling it off
     // This will handle saving tracks and cleanup through TrackDrawingManager
     if (this.trackManager.isInDrawingMode) {
-      const isDrawingMode = this.trackManager.toggleDrawingMode();
+      const isDrawingMode = await this.trackManager.toggleDrawingMode();
       // Make sure UIManager's drawing mode state stays in sync
       this.uiManager.setDrawingMode(isDrawingMode);
 


### PR DESCRIPTION
### Problem
When a player ended drawing mode, the track they just drew could disappear if the save was not complete before cleanup, causing the UI and state to be out of sync. Undo and cost display could also be incorrect.

### Solution
- Make `toggleDrawingMode` async and await `saveCurrentTracks` before cleanup.
- Update all usages to await the method, ensuring UI and state are correct after commit.
- Resolves bug where track would disappear if drawing mode was ended before save completed.

Fixes #53.