### PR TITLE
fix: Resolve TypeScript build errors for requestId property

### DIFF
--- a/src/server/middleware/errorHandler.ts
+++ b/src/server/middleware/errorHandler.ts
@@ -1,6 +1,15 @@
 import { Request, Response, NextFunction } from 'express';
 import { LobbyError } from '../services/lobbyService';
 
+// Extend the Request type to include requestId
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
+    }
+  }
+}
+
 // Error response interface
 interface ErrorResponse {
   error: string;

--- a/src/server/middleware/errorHandler.ts
+++ b/src/server/middleware/errorHandler.ts
@@ -1,15 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { LobbyError } from '../services/lobbyService';
 
-// Extend the Request type to include requestId
-declare global {
-  namespace Express {
-    interface Request {
-      requestId?: string;
-    }
-  }
-}
-
 // Error response interface
 interface ErrorResponse {
   error: string;

--- a/src/server/routes/lobbyRoutes.ts
+++ b/src/server/routes/lobbyRoutes.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from 'express';
 import { LobbyService, CreateGameData } from '../services/lobbyService';
 import { asyncHandler } from '../middleware/errorHandler';
 
-// Extend the Request type to include requestId
+// Extend the Request type to include requestId (needed for this file)
 declare global {
   namespace Express {
     interface Request {

--- a/src/server/routes/lobbyRoutes.ts
+++ b/src/server/routes/lobbyRoutes.ts
@@ -2,6 +2,15 @@ import express, { Request, Response } from 'express';
 import { LobbyService, CreateGameData } from '../services/lobbyService';
 import { asyncHandler } from '../middleware/errorHandler';
 
+// Extend the Request type to include requestId
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
+    }
+  }
+}
+
 const router = express.Router();
 
 // Request/Response interfaces

--- a/src/server/types/express.d.ts
+++ b/src/server/types/express.d.ts
@@ -1,7 +1,0 @@
-declare global {
-  namespace Express {
-    interface Request {
-      requestId?: string;
-    }
-  }
-}


### PR DESCRIPTION
- Add global Express Request interface extension directly to files that use it
- Remove separate express.d.ts file that wasn't being properly recognized
- Add declaration to errorHandler.ts and lobbyRoutes.ts
- Fixes TypeScript compilation errors: 'Property requestId does not exist on type Request'

Build now successful (server + client) 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves TypeScript build errors by standardizing the declaration of the requestId property on the Express Request object. Changes include adding the global Request interface extension directly in errorHandler.ts and lobbyRoutes.ts to ensure consistent type support. The previously separate express.d.ts file has been removed to avoid redundancy and conflicts.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>