### PR TITLE
Jeff/fixtrainstate

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,18 @@
+{
+  "watch": ["src/server"],
+  "ext": "ts,js,json",
+  "ignore": [
+    "src/server/__tests__",
+    "node_modules",
+    "dist",
+    "*.test.ts",
+    "*.spec.ts"
+  ],
+  "exec": "npx ts-node src/server/index.ts",
+  "env": {
+    "NODE_ENV": "development",
+    "CLEAN_DB_ON_START": "false"
+  },
+  "delay": 1000,
+  "verbose": true
+}

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "build": "npm run build:server && npm run build:client",
     "start": "npm run build && node dist/server/index.js",
     "dev:client": "webpack serve --mode development --open",
-    "dev:server": "NODE_ENV=development npx ts-node-dev --respawn --transpile-only src/server/index.ts",
+    "dev:server": "npx nodemon",
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "debug": "NODE_ENV=development node --inspect -r ts-node-dev/register src/server/index.ts"
+    "debug": "npx nodemon --exec \"node --inspect -r ts-node/register src/server/index.ts\""
   },
   "keywords": [],
   "author": "",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -19,16 +19,16 @@ interface ProtectedRouteProps {
 
 function ProtectedRoute({ children }: ProtectedRouteProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  
-  // Only allow development bypass for localhost in development mode
-  const isLocalhost = typeof window !== 'undefined' && 
+  const devAuthEnabled = process.env.REACT_APP_DEV_AUTH === 'true';
+
+  // Only allow development bypass for localhost when explicitly enabled
+  const isLocalhost = typeof window !== 'undefined' &&
     (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
-  
-  if (!isAuthenticated && !(isDevelopment && isLocalhost)) {
+
+  if (!isAuthenticated && !(devAuthEnabled && isLocalhost)) {
     return <Navigate to="/login" replace />;
   }
-  
+
   return <>{children}</>;
 }
 
@@ -47,29 +47,21 @@ function PublicRoute({ children }: PublicRouteProps) {
 }
 
 export default function App() {
-  const { loadPersistedAuth, setDevAuth, isLoading } = useAuthStore();
-  const isDevelopment = process.env.NODE_ENV === 'development';
+  const { loadPersistedAuth, isLoading } = useAuthStore();
 
   React.useEffect(() => {
-    // In development mode, set dev authentication
-    if (isDevelopment) {
-      debug.log('Development mode detected, setting dev authentication...');
-      setDevAuth();
-      return;
-    }
-    
-    // Load persisted authentication on app start
+    // Load persisted authentication on app start (works for both dev and prod)
     debug.log('App starting, loading persisted auth...');
-    
+
     try {
       loadPersistedAuth();
     } catch (error) {
       debug.error('Error loading persisted auth:', error);
     }
-    
+
     // Log current location for debugging route issues
     debug.log('Current location:', window.location.href);
-  }, [loadPersistedAuth, setDevAuth, isDevelopment]);
+  }, [loadPersistedAuth]);
 
   if (isLoading) {
     return (

--- a/src/client/__tests__/SettingsScene.test.ts
+++ b/src/client/__tests__/SettingsScene.test.ts
@@ -1,6 +1,6 @@
 import 'jest-canvas-mock';
 import { SettingsScene } from '../scenes/SettingsScene';
-import { PlayerColor, GameStatus } from '../../shared/types/GameTypes';
+import { PlayerColor, GameStatus, TrainType } from '../../shared/types/GameTypes';
 import { MockScene } from './setupTests';
 
 // Mock fetch globally
@@ -111,7 +111,7 @@ describe('SettingsScene Unit Tests', () => {
             name: 'Test Player',
             color: PlayerColor.RED,
             money: 50,
-            trainType: 'Freight',
+            trainType: TrainType.Freight,
             turnNumber: 1,
             trainState: {
                 position: {x: 0, y: 0, row: 0, col: 0},
@@ -135,7 +135,7 @@ describe('SettingsScene Unit Tests', () => {
                 name: '',
                 color: '#0000FF',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -157,7 +157,7 @@ describe('SettingsScene Unit Tests', () => {
                 name: 'Test',
                 color: '#0000FF',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},

--- a/src/client/__tests__/SetupScene.test.ts
+++ b/src/client/__tests__/SetupScene.test.ts
@@ -1,7 +1,7 @@
 import 'jest-canvas-mock';
 import { Scene } from 'phaser';
 import { SetupScene } from '../scenes/SetupScene';
-import { GameState, GameStatus, PlayerColor, INITIAL_PLAYER_MONEY } from '../../shared/types/GameTypes';
+import { GameState, GameStatus, PlayerColor, INITIAL_PLAYER_MONEY, TrainType } from '../../shared/types/GameTypes';
 import { mocks } from './setupTests';
 import { GameObjects } from 'phaser';
 import { IdService } from '../../shared/services/IdService';
@@ -145,7 +145,7 @@ describe('SetupScene Unit Tests', () => {
                 name: 'Test Player',
                 color: PlayerColor.BLUE,
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -167,7 +167,7 @@ describe('SetupScene Unit Tests', () => {
                 name: 'Player 1',
                 color: PlayerColor.RED,
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -192,7 +192,7 @@ describe('SetupScene Unit Tests', () => {
                 name: 'Player 1',
                 color: PlayerColor.RED,
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -214,7 +214,7 @@ describe('SetupScene Unit Tests', () => {
                     name: 'Player 1',
                     color: PlayerColor.RED,
                     money: 50,
-                    trainType: 'Freight',
+                    trainType: TrainType.Freight,
                     turnNumber: 1,
                     trainState: {
                         position: {x: 0, y: 0, row: 0, col: 0},
@@ -229,7 +229,7 @@ describe('SetupScene Unit Tests', () => {
                     name: 'Player 2',
                     color: PlayerColor.BLUE,
                     money: 50,
-                    trainType: 'Freight',
+                    trainType: TrainType.Freight,
                     turnNumber: 1,
                     trainState: {
                         position: {x: 0, y: 0, row: 0, col: 0},

--- a/src/client/__tests__/TrackDrawingManager.test.ts
+++ b/src/client/__tests__/TrackDrawingManager.test.ts
@@ -1,7 +1,7 @@
 import 'jest-canvas-mock';
 import { TrackDrawingManager } from '../components/TrackDrawingManager';
 import { MockScene } from './setupTests';
-import { TerrainType, GameState, GridPoint } from '../../shared/types/GameTypes';
+import { TerrainType, GameState, GridPoint, TrainType } from '../../shared/types/GameTypes';
 import { MapRenderer } from '../components/MapRenderer';
 
 describe('TrackDrawingManager', () => {
@@ -51,12 +51,12 @@ describe('TrackDrawingManager', () => {
         gameState = {
             id: 'test-game-id',
             players: [
-                { 
-                    id: 'player1', 
-                    name: 'Player 1', 
-                    color: '#FF0000', 
-                    money: 50, 
-                    trainType: 'basic',
+                {
+                    id: 'player1',
+                    name: 'Player 1',
+                    color: '#FF0000',
+                    money: 50,
+                    trainType: TrainType.Freight,
                     turnNumber: 1,
                     trainState: {
                         position: {x: 0, y: 0, row: 0, col: 0},
@@ -65,7 +65,7 @@ describe('TrackDrawingManager', () => {
                         loads: []
                     },
                     hand: []
-                }   
+                }
             ],
             currentPlayerIndex: 0,
             status: 'active',
@@ -597,12 +597,12 @@ describe('TrackDrawingManager', () => {
             gameState = {
                 id: 'test-game-id',
                 players: [
-                    { 
-                        id: 'player1', 
-                        name: 'Player 1', 
-                        color: '#FF0000', 
-                        money: 50, 
-                        trainType: 'Freight',
+                    {
+                        id: 'player1',
+                        name: 'Player 1',
+                        color: '#FF0000',
+                        money: 50,
+                        trainType: TrainType.Freight,
                         turnNumber: 1,
                         trainState: {
                             position: {x: 100, y: 100, row: 1, col: 1},
@@ -611,7 +611,7 @@ describe('TrackDrawingManager', () => {
                             loads: []
                         },
                         hand: []
-                    }   
+                    }
                 ],
                 currentPlayerIndex: 0,
                 status: 'active',
@@ -934,12 +934,12 @@ describe('State consistency on backend failure', () => {
         const gameState = {
             id: 'test-game-id',
             players: [
-                { 
-                    id: 'player1', 
-                    name: 'Player 1', 
-                    color: '#FF0000', 
-                    money: 50, 
-                    trainType: 'basic',
+                {
+                    id: 'player1',
+                    name: 'Player 1',
+                    color: '#FF0000',
+                    money: 50,
+                    trainType: TrainType.Freight,
                     turnNumber: 1,
                     trainState: {
                         position: {x: 0, y: 0, row: 0, col: 0},

--- a/src/client/__tests__/TrainCard.test.ts
+++ b/src/client/__tests__/TrainCard.test.ts
@@ -1,5 +1,5 @@
 import { TrainCard } from '../components/TrainCard';
-import { Player } from '../../shared/types/GameTypes';
+import { Player, TrainType } from '../../shared/types/GameTypes';
 import { LoadType } from '../../shared/types/LoadTypes';
 
 describe("TrainCard", () => {
@@ -43,7 +43,7 @@ describe("TrainCard", () => {
       name: "Test Player",
       color: "#FF0000",
       money: 50,
-      trainType: "Freight",
+      trainType: TrainType.Freight,
       turnNumber: 1,
       trainState: {
         position: null,
@@ -69,15 +69,15 @@ describe("TrainCard", () => {
     jest.clearAllMocks();
 
     // Test Heavy Freight train (3 slots)
-    mockPlayer.trainType = "Heavy Freight";
+    mockPlayer.trainType = TrainType.HeavyFreight;
     trainCard = new TrainCard(mockScene, 0, 0, mockPlayer);
     expect(mockScene.add.rectangle).toHaveBeenCalledTimes(3);
   });
 
   it("should update train card image when train type changes", () => {
-    mockPlayer.trainType = "Fast Freight";
+    mockPlayer.trainType = TrainType.FastFreight;
     trainCard.updateTrainType();
-    expect(mockScene.add.image().setTexture).toHaveBeenCalledWith("train_card_fastfreight");
+    expect(mockScene.add.image().setTexture).toHaveBeenCalledWith("train_card_fast_freight");
   });
 
   it("should update load slots based on current loads", () => {

--- a/src/client/__tests__/TrainMovementManager.test.ts
+++ b/src/client/__tests__/TrainMovementManager.test.ts
@@ -1,5 +1,5 @@
 import { TrainMovementManager } from '../components/TrainMovementManager';
-import { TerrainType, TrackSegment, GridPoint, GameState, Player, FerryConnection, FerryPoint, Point, PlayerTrackState } from '../../shared/types/GameTypes';
+import { TerrainType, TrackSegment, GridPoint, GameState, Player, FerryConnection, FerryPoint, Point, PlayerTrackState, TrainType } from '../../shared/types/GameTypes';
 
 describe('TrainMovementManager calculateDistance', () => {
   let manager: TrainMovementManager;
@@ -167,7 +167,7 @@ describe('TrainMovementManager calculateDistance', () => {
         name: 'Test Player',
         color: '#FF0000',
         money: 100,
-        trainType: 'Freight',
+        trainType: TrainType.Freight,
         turnNumber: 1,
         trainState: {
           position: null,
@@ -265,7 +265,7 @@ describe('TrainMovementManager calculateDistance', () => {
         name: 'Test Player',
         color: '#FF0000',
         money: 100,
-        trainType: 'Freight',
+        trainType: TrainType.Freight,
         turnNumber: 1,
         trainState: {
           position: null,
@@ -314,7 +314,7 @@ describe('TrainMovementManager calculateDistance', () => {
         name: 'Test Player',
         color: '#FF0000',
         money: 100,
-        trainType: 'Freight',
+        trainType: TrainType.Freight,
         turnNumber: 1,
         trainState: {
           position: { row: 30, col: 34, x: 1630, y: 1300 },
@@ -453,7 +453,7 @@ describe('TrainMovementManager Ferry Movement', () => {
       id: 'p1',
       name: 'Test',
       color: '#000000',
-      trainType: 'Freight',
+      trainType: TrainType.Freight,
       money: 100,
       trainState: {
         position: { ...ferryPort },

--- a/src/client/__tests__/lobby/lobby.store.error-handling.test.ts
+++ b/src/client/__tests__/lobby/lobby.store.error-handling.test.ts
@@ -397,7 +397,7 @@ describe('LobbyStore Error Handling', () => {
           name: 'Player 1',
           color: '#FF0000',
           money: 50,
-          trainType: 'Freight' as const,
+          trainType: 'freight' as const,
           turnNumber: 1,
           isOnline: true,
           createdAt: new Date().toISOString(),

--- a/src/client/components/CitySelectionManager.ts
+++ b/src/client/components/CitySelectionManager.ts
@@ -131,7 +131,7 @@ export class CitySelectionManager {
     document.body.appendChild(dropdown);
     
     // Store reference for cleanup
-    this.dropdownDomElement = null; // We're not using Phaser DOM element anymore
+    this.dropdownDomElement = dropdown as any; // Store direct reference for cleanup
     
     } catch (error) {
       console.error('Error in city selection:', error);
@@ -139,15 +139,13 @@ export class CitySelectionManager {
   }
   
   public cleanupCityDropdowns(): void {
-    // Remove dropdown from document body
-    const existingDropdown = document.querySelector('.city-selection-dropdown');
-    if (existingDropdown) {
-      existingDropdown.remove();
-    }
-    
-    // Also clean up Phaser DOM element if it exists
+    // Remove dropdown using stored reference
     if (this.dropdownDomElement) {
-      this.dropdownDomElement.destroy();
+      if (this.dropdownDomElement instanceof HTMLElement) {
+        this.dropdownDomElement.remove();
+      } else {
+        this.dropdownDomElement.destroy();
+      }
       this.dropdownDomElement = null;
     }
   }

--- a/src/client/components/CitySelectionManager.ts
+++ b/src/client/components/CitySelectionManager.ts
@@ -41,27 +41,28 @@ export class CitySelectionManager {
       return;
     }
 
-    // Remove any existing dropdown DOM element
-    this.cleanupCityDropdowns();
+    try {
+      // Remove any existing dropdown DOM element
+      this.cleanupCityDropdowns();
 
-    // Find all major cities from the grid
-    const majorCities = [
-      ...new Map(
-        this.mapRenderer.gridPoints
-          .flat()
-          .filter((point) => point?.city?.type === TerrainType.MajorCity)
-          .map((point) => [
-            point.city!.name, // use name as key for uniqueness
-            {
-              name: point.city!.name,
-              x: point.x,
-              y: point.y,
-              row: point.row,
-              col: point.col,
-            },
-          ])
-      ).values(),
-    ];
+      // Find all major cities from the grid
+      const majorCities = [
+        ...new Map(
+          this.mapRenderer.gridPoints
+            .flat()
+            .filter((point) => point?.city?.type === TerrainType.MajorCity)
+            .map((point) => [
+              point.city!.name, // use name as key for uniqueness
+              {
+                name: point.city!.name,
+                x: point.x,
+                y: point.y,
+                row: point.row,
+                col: point.col,
+              },
+            ])
+        ).values(),
+      ];
 
     // Create dropdown (as a DOM element)
     const dropdown = document.createElement("select");
@@ -116,18 +117,35 @@ export class CitySelectionManager {
         selectedCity.row,
         selectedCity.col
       );
-      // Note: No longer removing dropdown here - it will be removed when track is built
     };
 
-    // Add the dropdown as a Phaser DOM element at the player info area (x=820, y=hand area)
+    // Position the dropdown in the player hand area (above player name)
     const handY = this.scene.scale.height - 280 + 20; // 20px from top of hand area
-    this.dropdownDomElement = this.scene.add.dom(820, handY, dropdown);
-    this.dropdownDomElement.setOrigin(0, 0);
-    this.dropdownDomElement.setDepth(1000); // Ensure it appears above other elements
+    dropdown.style.position = 'fixed';
+    dropdown.style.left = '820px'; // Right side of hand area
+    dropdown.style.top = `${handY}px`;
+    dropdown.style.zIndex = '10000';
+    dropdown.style.pointerEvents = 'auto';
+    
+    // Add to document body
+    document.body.appendChild(dropdown);
+    
+    // Store reference for cleanup
+    this.dropdownDomElement = null; // We're not using Phaser DOM element anymore
+    
+    } catch (error) {
+      console.error('Error in city selection:', error);
+    }
   }
   
   public cleanupCityDropdowns(): void {
-    // Remove dropdown DOM element from scene if present
+    // Remove dropdown from document body
+    const existingDropdown = document.querySelector('.city-selection-dropdown');
+    if (existingDropdown) {
+      existingDropdown.remove();
+    }
+    
+    // Also clean up Phaser DOM element if it exists
     if (this.dropdownDomElement) {
       this.dropdownDomElement.destroy();
       this.dropdownDomElement = null;

--- a/src/client/components/TrainCard.ts
+++ b/src/client/components/TrainCard.ts
@@ -1,5 +1,5 @@
 import "phaser";
-import { Player } from "../../shared/types/GameTypes";
+import { Player, TrainType, TRAIN_PROPERTIES } from "../../shared/types/GameTypes";
 import { LoadType } from "../../shared/types/LoadTypes";
 
 export class TrainCard {
@@ -24,7 +24,7 @@ export class TrainCard {
     this.trainCard.setScale(0.165); // Scale down to 18% of original size
     
     // Create load slots based on train capacity
-    const capacity = player.trainType === "Heavy Freight" || player.trainType === "Superfreight" ? 3 : 2;
+    const capacity = TRAIN_PROPERTIES[player.trainType].capacity;
     this.createLoadSlots(capacity);
     
     // Add all elements to container
@@ -107,7 +107,7 @@ export class TrainCard {
     this.trainCard.setTexture(`train_card_${trainType}`);
     
     // Update load slots
-    const capacity = this.player.trainType === "Heavy Freight" || this.player.trainType === "Superfreight" ? 3 : 2;
+    const capacity = TRAIN_PROPERTIES[this.player.trainType].capacity;
     const currentCapacity = this.loadSlots.length;
     
     if (currentCapacity !== capacity) {

--- a/src/client/components/TrainInteractionManager.ts
+++ b/src/client/components/TrainInteractionManager.ts
@@ -7,6 +7,7 @@ import {
   TrackSegment,
   CityData,
   Point,
+  TRAIN_PROPERTIES,
 } from "../../shared/types/GameTypes";
 import { GameStateService } from "../services/GameStateService";
 import { MapRenderer } from "./MapRenderer";
@@ -485,10 +486,8 @@ export class TrainInteractionManager {
     };
 
     const trainColor = colorMap[player.color.toUpperCase()] || "black";
-    const trainTexture =
-      player.trainType === "Freight"
-        ? `train_${trainColor}`
-        : `train_12_${trainColor}`;
+    const trainProps = TRAIN_PROPERTIES[player.trainType];
+    const trainTexture = `${trainProps.spritePrefix}_${trainColor}`;
 
     const trainSprite = this.scene.add.image(x, y, trainTexture);
     trainSprite.setScale(0.1); // Adjust scale as needed

--- a/src/client/components/TrainInteractionManager.ts
+++ b/src/client/components/TrainInteractionManager.ts
@@ -487,7 +487,8 @@ export class TrainInteractionManager {
 
     const trainColor = colorMap[player.color.toUpperCase()] || "black";
     const trainProps = TRAIN_PROPERTIES[player.trainType];
-    const trainTexture = `${trainProps.spritePrefix}_${trainColor}`;
+    const spritePrefix = trainProps ? trainProps.spritePrefix : 'train';
+    const trainTexture = `${spritePrefix}_${trainColor}`;
 
     const trainSprite = this.scene.add.image(x, y, trainTexture);
     trainSprite.setScale(0.1); // Adjust scale as needed

--- a/src/client/lobby/App.tsx
+++ b/src/client/lobby/App.tsx
@@ -7,40 +7,32 @@ import { ErrorBoundary } from './shared/ErrorBoundary';
 import { debug } from './shared/config';
 
 export default function App() {
-  const { loadPersistedAuth, setDevAuth, isLoading: authLoading } = useAuthStore();
+  const { loadPersistedAuth, isLoading: authLoading } = useAuthStore();
   const { restoreGameState, isLoading: lobbyLoading } = useLobbyStore();
-  const isDevelopment = process.env.NODE_ENV === 'development';
 
   useEffect(() => {
-    // In development mode, set dev authentication
-    if (isDevelopment) {
-      debug.log('Development mode detected, setting dev authentication...');
-      setDevAuth();
-      return;
-    }
-    
     // Load persisted authentication on app start
     debug.log('App starting, loading persisted auth...');
-    
+
     try {
       loadPersistedAuth();
     } catch (error) {
       debug.error('Error loading persisted auth:', error);
     }
-    
+
     // Log current location for debugging route issues
     debug.log('Current location:', window.location.href);
-  }, [loadPersistedAuth, setDevAuth, isDevelopment]);
+  }, [loadPersistedAuth]);
 
   // Restore game state on app load (after auth is loaded)
   useEffect(() => {
-    if (!authLoading && !isDevelopment) {
+    if (!authLoading) {
       // Try to restore game state from localStorage
       restoreGameState().catch(error => {
         console.warn('Failed to restore game state on app load:', error);
       });
     }
-  }, [authLoading, isDevelopment, restoreGameState]);
+  }, [authLoading, restoreGameState]);
 
   const isLoading = authLoading || lobbyLoading;
 

--- a/src/client/lobby/app/Router.tsx
+++ b/src/client/lobby/app/Router.tsx
@@ -17,16 +17,16 @@ interface ProtectedRouteProps {
 
 function ProtectedRoute({ children }: ProtectedRouteProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  
-  // Only allow development bypass for localhost in development mode
-  const isLocalhost = typeof window !== 'undefined' && 
+  const devAuthEnabled = process.env.REACT_APP_DEV_AUTH === 'true';
+
+  // Only allow development bypass for localhost when explicitly enabled
+  const isLocalhost = typeof window !== 'undefined' &&
     (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
-  
-  if (!isAuthenticated && !(isDevelopment && isLocalhost)) {
+
+  if (!isAuthenticated && !(devAuthEnabled && isLocalhost)) {
     return <Navigate to="/login" replace />;
   }
-  
+
   return <>{children}</>;
 }
 

--- a/src/client/lobby/features/lobby/LobbyPage.tsx
+++ b/src/client/lobby/features/lobby/LobbyPage.tsx
@@ -171,9 +171,9 @@ export function LobbyPage() {
             <p className="text-sm text-muted-foreground">
               Welcome, {user?.username}
             </p>
-            {process.env.NODE_ENV === 'development' && (
+            {process.env.REACT_APP_MOCK_MODE === 'true' && (
               <p className="text-xs text-orange-600 bg-orange-100 px-2 py-1 rounded mt-1 inline-block">
-                🧪 Development Mode - Using Mock Data
+                🧪 Mock Mode - Using Mock Data
               </p>
             )}
           </div>
@@ -260,12 +260,12 @@ export function LobbyPage() {
               </CardContent>
             </Card>
 
-            {/* Development Mode - Available Test Games */}
-            {process.env.NODE_ENV === 'development' && (
+            {/* Mock Mode - Available Test Games */}
+            {process.env.REACT_APP_MOCK_MODE === 'true' && (
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
-                    🧪 Development Mode
+                    🧪 Mock Mode
                   </CardTitle>
                   <CardDescription>
                     Available test games for development and testing

--- a/src/client/lobby/store/auth.store.ts
+++ b/src/client/lobby/store/auth.store.ts
@@ -104,27 +104,27 @@ export const useAuthStore = create<AuthStore>((set) => ({
   loadPersistedAuth: async () => {
     const token = localStorage.getItem(JWT_STORAGE_KEY);
     const userJson = localStorage.getItem(USER_STORAGE_KEY);
-    const isDevelopment = process.env.NODE_ENV === 'development';
-    
-    // In development mode, only set authenticated state for localhost
-    if (isDevelopment && typeof window !== 'undefined') {
-      const isLocalhost = window.location.hostname === 'localhost' || 
+    const devAuthEnabled = process.env.REACT_APP_DEV_AUTH === 'true';
+
+    // In dev auth mode, only set authenticated state for localhost
+    if (devAuthEnabled && typeof window !== 'undefined') {
+      const isLocalhost = window.location.hostname === 'localhost' ||
                          window.location.hostname === '127.0.0.1';
-      
+
       if (isLocalhost) {
-        const devUser = { 
-          id: '123e4567-e89b-12d3-a456-426614174000', 
-          username: 'dev-user', 
+        const devUser = {
+          id: '123e4567-e89b-12d3-a456-426614174000',
+          username: 'dev-user',
           email: 'dev@example.com',
           emailVerified: true,
           createdAt: new Date(),
           lastActive: new Date()
         };
-        
+
         // Store in localStorage for API client
         localStorage.setItem('eurorails.jwt', 'dev-token');
         localStorage.setItem('eurorails.user', JSON.stringify(devUser));
-        
+
         set({
           user: devUser,
           token: 'dev-token',

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -1,5 +1,5 @@
 import "phaser";
-import { GameState, TerrainType, Player, TrainType, TRAIN_PROPERTIES } from "../../shared/types/GameTypes";
+import { GameState, Player, TrainType, TRAIN_PROPERTIES } from "../../shared/types/GameTypes";
 import { MapRenderer } from "../components/MapRenderer";
 import { CameraController } from "../components/CameraController";
 import { TrackDrawingManager } from "../components/TrackDrawingManager";
@@ -355,7 +355,12 @@ export class GameScene extends Phaser.Scene {
     await this.handleFerryTurnTransition(newCurrentPlayer);
 
     // Reset movement points for the new player using TRAIN_PROPERTIES
-    const maxMovement = TRAIN_PROPERTIES[newCurrentPlayer.trainType].speed;
+    const trainProps = TRAIN_PROPERTIES[newCurrentPlayer.trainType];
+    if (!trainProps) {
+      console.error(`Invalid train type: ${newCurrentPlayer.trainType}`);
+      return; // Prevent further execution with invalid data
+    }
+    const maxMovement = trainProps.speed;
 
     // Set movement based on ferry crossing
     if (newCurrentPlayer.trainState.justCrossedFerry) {

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -1,5 +1,5 @@
 import "phaser";
-import { GameState, TerrainType, Player } from "../../shared/types/GameTypes";
+import { GameState, TerrainType, Player, TrainType, TRAIN_PROPERTIES } from "../../shared/types/GameTypes";
 import { MapRenderer } from "../components/MapRenderer";
 import { CameraController } from "../components/CameraController";
 import { TrackDrawingManager } from "../components/TrackDrawingManager";
@@ -36,6 +36,7 @@ export class GameScene extends Phaser.Scene {
 
   constructor() {
     super({ key: "GameScene" });
+    console.log('🚀 GameScene: constructor() called');
     // Initialize with empty game state
     this.gameState = {
       id: "", // Will be set by SetupScene
@@ -48,6 +49,8 @@ export class GameScene extends Phaser.Scene {
   }
 
   init(data: { gameState?: GameState }) {
+    console.log('🚀 GameScene: init() called with data:', data);
+    
     // If we get a gameState, always use it
     if (data.gameState) {
       this.gameState = {
@@ -114,6 +117,9 @@ export class GameScene extends Phaser.Scene {
   }
 
   async create() {
+    console.log('🚀 GameScene: create() called');
+    console.log('🚀 GameScene: gameState in create:', this.gameState);
+    
     // Clear any existing containers
     this.children.removeAll(true);
     // Initialize services and load initial state
@@ -230,10 +236,22 @@ export class GameScene extends Phaser.Scene {
     await this.uiManager.setupPlayerHand(this.trackManager.isInDrawingMode);
 
     // Show city selection for current player if needed - do this last to prevent cleanup
+    console.log('GameScene: Checking for city selection');
+    console.log('GameScene: gameState:', this.gameState);
+    console.log('GameScene: players:', this.gameState.players);
+    console.log('GameScene: currentPlayerIndex:', this.gameState.currentPlayerIndex);
+    
     const currentPlayer =
       this.gameState.players[this.gameState.currentPlayerIndex];
+    console.log('GameScene: currentPlayer:', currentPlayer);
+    console.log('GameScene: currentPlayer.trainState:', currentPlayer?.trainState);
+    console.log('GameScene: currentPlayer.trainState?.position:', currentPlayer?.trainState?.position);
+    
     if (!currentPlayer.trainState?.position) {
+      console.log('GameScene: No position found, showing city selection');
       this.uiManager.showCitySelectionForPlayer(currentPlayer.id);
+    } else {
+      console.log('GameScene: Player has position, not showing city selection');
     }
 
     // Set a low frame rate for the scene
@@ -336,12 +354,8 @@ export class GameScene extends Phaser.Scene {
     // Handle ferry state transitions and teleportation at turn start
     await this.handleFerryTurnTransition(newCurrentPlayer);
 
-    // Reset movement points for the new player
-    const maxMovement =
-      newCurrentPlayer.trainType === "Fast Freight" ||
-      newCurrentPlayer.trainType === "Superfreight"
-        ? 12 // Fast trains
-        : 9; // Regular trains
+    // Reset movement points for the new player using TRAIN_PROPERTIES
+    const maxMovement = TRAIN_PROPERTIES[newCurrentPlayer.trainType].speed;
 
     // Set movement based on ferry crossing
     if (newCurrentPlayer.trainState.justCrossedFerry) {

--- a/src/client/scenes/LoadDialogScene.ts
+++ b/src/client/scenes/LoadDialogScene.ts
@@ -1,6 +1,6 @@
 // src/client/scenes/LoadDialogScene.ts
 import { Scene } from 'phaser';
-import { CityData, Player, GameState } from '../../shared/types/GameTypes';
+import { CityData, Player, GameState, TRAIN_PROPERTIES } from '../../shared/types/GameTypes';
 import { LoadService } from '../services/LoadService';
 import { GameStateService } from '../services/GameStateService';
 import { LoadType } from '../../shared/types/LoadTypes';
@@ -289,9 +289,8 @@ export class LoadDialogScene extends Scene {
                 this.player.trainState.loads = [];
             }
             
-            // Calculate train capacity
-            const maxCapacity = this.player.trainType === "Heavy Freight" || 
-                              this.player.trainType === "Superfreight" ? 3 : 2;
+            // Calculate train capacity using TRAIN_PROPERTIES
+            const maxCapacity = TRAIN_PROPERTIES[this.player.trainType].capacity;
                               
             // Check if train has space
             if (this.player.trainState.loads.length >= maxCapacity) {

--- a/src/client/scenes/SettingsScene.ts
+++ b/src/client/scenes/SettingsScene.ts
@@ -1,5 +1,5 @@
 import 'phaser';
-import { GameState, Player, PlayerColor } from '../../shared/types/GameTypes';
+import { GameState, Player, PlayerColor, TrainType } from '../../shared/types/GameTypes';
 import { GameScene } from './GameScene';
 
 export class SettingsScene extends Phaser.Scene {
@@ -212,7 +212,7 @@ export class SettingsScene extends Phaser.Scene {
             name: '',
             color: PlayerColor.YELLOW, // Default color
             money: 50,
-            trainType: 'Freight',
+            trainType: TrainType.Freight,
             turnNumber: 1,
             trainState: {
                 position: {x: 0, y: 0, row: 0, col: 0},
@@ -519,7 +519,7 @@ export class SettingsScene extends Phaser.Scene {
                 name: newName,
                 color: this.selectedColor || PlayerColor.YELLOW,
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 trainState: {
                     position: null,
                     remainingMovement: 9,

--- a/src/client/scenes/SetupScene.ts
+++ b/src/client/scenes/SetupScene.ts
@@ -1,5 +1,5 @@
 import 'phaser';
-import { Player, PlayerColor, GameState, INITIAL_PLAYER_MONEY } from '../../shared/types/GameTypes';
+import { Player, PlayerColor, GameState, INITIAL_PLAYER_MONEY, TrainType } from '../../shared/types/GameTypes';
 import { IdService } from '../../shared/services/IdService';
 import { DemandDeckService } from '../../shared/services/DemandDeckService';
 import { DemandCard } from '../../shared/types/DemandCard';
@@ -115,7 +115,7 @@ export class SetupScene extends Phaser.Scene {
                     name: lobbyPlayer.name,
                     color: lobbyPlayer.color,
                     money: INITIAL_PLAYER_MONEY, // Use the constant from GameTypes
-                    trainType: 'freight',
+                    trainType: TrainType.Freight,
                     turnNumber: 0,
                     trainState: {
                     position: null,
@@ -158,7 +158,16 @@ export class SetupScene extends Phaser.Scene {
             // If game is in initialBuild or active status, transition to game scene
             if (game.gameStatus === 'initialBuild' || game.gameStatus === 'active') {
                 console.log('Game is in', game.gameStatus, 'status, transitioning to game scene');
-                this.scene.start('GameScene', { gameState: this.gameState });
+                console.log('Starting GameScene with gameState:', this.gameState);
+                console.log('Players in gameState:', this.gameState.players);
+                this.gameState.players.forEach((player, index) => {
+                    console.log(`Player ${index}:`, player);
+                });
+                try {
+                    this.scene.start('GameScene', { gameState: this.gameState });
+                } catch (error) {
+                    console.error('Error starting GameScene:', error);
+                }
                 return;
             }
             
@@ -709,7 +718,7 @@ export class SetupScene extends Phaser.Scene {
                         name,
                         color: this.selectedColor,
                         money: INITIAL_PLAYER_MONEY,
-                        trainType: 'Freight',  // Default train type
+                        trainType: TrainType.Freight,  // Default train type
                         turnNumber: 1,
                         trainState: {
                             position: {x: 0, y: 0, row: 0, col: 0},
@@ -730,7 +739,7 @@ export class SetupScene extends Phaser.Scene {
             const newPlayer = await response.json();
             this.gameState.players.push(newPlayer);
             // Update the train movement which isn't stored in the database.
-            newPlayer.trainType == 'Fast Freight' || newPlayer.trainType == 'Superfreight' ? newPlayer.trainState.remainingMovement = 12 : newPlayer.trainState.remainingMovement = 9;
+            newPlayer.trainType == TrainType.FastFreight || newPlayer.trainType == TrainType.Superfreight ? newPlayer.trainState.remainingMovement = 12 : newPlayer.trainState.remainingMovement = 9;
             this.updatePlayerList();
 
             // Reset input

--- a/src/client/scenes/SetupScene.ts
+++ b/src/client/scenes/SetupScene.ts
@@ -31,17 +31,13 @@ export class SetupScene extends Phaser.Scene {
     }
 
     init(data: { gameState?: GameState; gameId?: string }) {
-        console.log('SetupScene init called with data:', data);
         // If we have a specific gameId, try to load that game
         if (data.gameId) {
-            console.log('Loading specific game with ID:', data.gameId);
             this.isLobbyGame = true;
             this.loadSpecificGame(data.gameId);
         } else {
-            console.log('No gameId provided, fetching active game');
-            this.isLobbyGame = false;
-            // Always try to fetch the active game from the backend
-            this.fetchAndSetActiveGame();
+            console.log('No gameId provided, redirecting to lobby');
+            window.location.href = '/lobby';
         }
     }
 
@@ -70,11 +66,6 @@ export class SetupScene extends Phaser.Scene {
             if (!game.id || !game.joinCode || !game.status) {
                 throw new Error('Missing required game properties (id, joinCode, status)');
             }
-            
-            console.log('Raw game data from API:', game);
-            console.log('Game created at:', game.createdAt);
-            console.log('Game lobby status:', game.status);
-            console.log('Game status:', game.gameStatus);
 
             // Then, fetch the players for this game
             const playersResponse = await fetch(`/api/lobby/games/${gameId}/players`);
@@ -131,8 +122,6 @@ export class SetupScene extends Phaser.Scene {
             // Use gameStatus (actual game state) instead of status (lobby status)
             // Treat null gameStatus as 'setup'
             const effectiveGameStatus = game.gameStatus || 'setup';
-            console.log('Effective game status:', effectiveGameStatus);
-
             this.gameState = {
                 id: game.id,
                 players: gamePlayers,
@@ -144,25 +133,24 @@ export class SetupScene extends Phaser.Scene {
 
             // If game is in setup status (or null, which we treat as setup), show the setup screen
             if (effectiveGameStatus === 'setup') {
-                console.log('Game is in setup status, checking player count:', this.gameState.players.length);
-                if (this.gameState.players.length > 0) {
-                    console.log('Showing setup screen with', this.gameState.players.length, 'players');
-                    this.setupExistingPlayers();
-                } else {
-                    console.log('Game in setup but no players yet');
-                    this.setupExistingPlayers(); // This will show the waiting message
-                }
+                this.setupExistingPlayers();
                 return;
             }
             
             // If game is in initialBuild or active status, transition to game scene
             if (game.gameStatus === 'initialBuild' || game.gameStatus === 'active') {
-                console.log('Game is in', game.gameStatus, 'status, transitioning to game scene');
-                console.log('Starting GameScene with gameState:', this.gameState);
-                console.log('Players in gameState:', this.gameState.players);
-                this.gameState.players.forEach((player, index) => {
-                    console.log(`Player ${index}:`, player);
-                });
+                try {
+                    const response = await fetch(`/api/game/${game.id}`);
+                    if (!response.ok) {
+                        throw new Error('Failed to fetch active game state');
+                    }
+                    const activeGameState = await response.json();
+                    console.log('Active game state:', activeGameState);
+                    this.gameState = activeGameState;
+                } catch (error) {
+                    console.error('Error fetching active game state:', error);
+                    throw error; // Re-throw to handle it in the outer try-catch
+                }
                 try {
                     this.scene.start('GameScene', { gameState: this.gameState });
                 } catch (error) {
@@ -189,8 +177,6 @@ export class SetupScene extends Phaser.Scene {
     }
 
     private setupExistingPlayers() {
-        console.log('DEBUG: setupExistingPlayers called with', this.gameState.players.length, 'players');
-        console.log('DEBUG: this.gameState:', this.gameState);
         
         // Add a full-screen white background rectangle to ensure complete coverage
         this.add.rectangle(
@@ -485,29 +471,6 @@ export class SetupScene extends Phaser.Scene {
         }
     }
 
-    private async fetchAndSetActiveGame() {
-        try {
-            const response = await fetch('/api/players/game/active');
-            if (response.ok) {
-                const activeGame = await response.json();
-                this.gameState = activeGame;
-                // Start game scene with active game
-                this.scene.start('GameScene', { gameState: activeGame });
-                return;
-            }
-        } catch (error) {
-            console.error('Error checking for active game:', error);
-        }
-        // No active game found, create a new one
-        const gameId = IdService.generateGameId();
-        this.gameState = {
-            id: gameId,
-            players: [],
-            currentPlayerIndex: 0,
-            status: 'setup',
-            maxPlayers: 6
-        };
-    }
 
     preload() {
         // Set background color

--- a/src/client/shared/Router.tsx
+++ b/src/client/shared/Router.tsx
@@ -15,13 +15,16 @@ interface ProtectedRouteProps {
 
 function ProtectedRoute({ children }: ProtectedRouteProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  
-  // Allow access in development mode or if authenticated
-  if (!isAuthenticated && !isDevelopment) {
+  const devAuthEnabled = process.env.REACT_APP_DEV_AUTH === 'true';
+
+  // Only allow development bypass for localhost when explicitly enabled
+  const isLocalhost = typeof window !== 'undefined' &&
+    (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+
+  if (!isAuthenticated && !(devAuthEnabled && isLocalhost)) {
     return <Navigate to="/login" replace />;
   }
-  
+
   return <>{children}</>;
 }
 

--- a/src/server/__tests__/playerService.test.ts
+++ b/src/server/__tests__/playerService.test.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import '@jest/globals';
 import { LoadType } from '../../shared/types/LoadTypes';
 import { cleanDatabase } from '../db/index';
+import { TrainType } from '../../shared/types/GameTypes';
 
 // Force Jest to run this test file serially
 export const test = { concurrent: false };
@@ -60,7 +61,7 @@ describe('PlayerService Integration Tests', () => {
                 name: 'Test Player',
                 color: '#FF0000',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -83,7 +84,7 @@ describe('PlayerService Integration Tests', () => {
                 name: 'Test Player',
                 color: '#FF0000',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -119,7 +120,7 @@ describe('PlayerService Integration Tests', () => {
                 name: 'Player 1',
                 color: '#FF0000',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -136,7 +137,7 @@ describe('PlayerService Integration Tests', () => {
                 name: 'Player 2',
                 color: '#FF0000',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -156,7 +157,7 @@ describe('PlayerService Integration Tests', () => {
                 name: 'Test Player',
                 color: 'invalid-color',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -177,7 +178,7 @@ describe('PlayerService Integration Tests', () => {
                 name: 'Test Player',
                 color: '#FF0000',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},
@@ -202,7 +203,7 @@ describe('PlayerService Integration Tests', () => {
                 name: 'Test Player',
                 color: '#FF0000',
                 money: 50,
-                trainType: 'Freight',
+                trainType: TrainType.Freight,
                 turnNumber: 1,
                 trainState: {
                     position: {x: 0, y: 0, row: 0, col: 0},

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -9,7 +9,7 @@ dotenv.config();
 // Development mode flag
 const DEV_MODE = process.env.NODE_ENV === 'development';
 const TEST_MODE = process.env.NODE_ENV === 'test';
-const CLEAN_DB_ON_START = process.env.CLEAN_DB_ON_START === 'false';
+const CLEAN_DB_ON_START = process.env.CLEAN_DB_ON_START === 'true';
 
 // Create a connection pool
 const pool = new Pool({

--- a/src/server/services/gameService.ts
+++ b/src/server/services/gameService.ts
@@ -1,5 +1,6 @@
 import { db } from '../db';
 import { GameState } from '../../shared/types/GameTypes';
+import { PlayerService } from './playerService';
 
 export class GameService {
     static async updateCameraState(gameId: string, cameraState: GameState['cameraState']): Promise<void> {
@@ -20,9 +21,13 @@ export class GameService {
         }
 
         const row = result.rows[0];
+
+        // Fetch players from the players table
+        const players = await PlayerService.getPlayers(gameId);
+
         return {
             id: row.id,
-            players: row.players,
+            players: players,
             currentPlayerIndex: row.current_player_index,
             status: row.status,
             maxPlayers: row.max_players,

--- a/src/server/services/playerService.ts
+++ b/src/server/services/playerService.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/index";
-import { Player, Game, GameStatus } from "../../shared/types/GameTypes";
+import { Player, Game, GameStatus, TrainType } from "../../shared/types/GameTypes";
 import { QueryResult } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { demandDeckService } from "./demandDeckService";
@@ -85,7 +85,7 @@ export class PlayerService {
       player.name,
       normalizedColor,
       typeof player.money === "number" ? player.money : 50,
-      player.trainType || "Freight",
+      player.trainType || TrainType.Freight,
       player.trainState.position?.x || null,
       player.trainState.position?.y || null,
       player.trainState.position?.row || null,
@@ -157,7 +157,7 @@ export class PlayerService {
       }
 
       // Normalize the train type to match database format
-      const trainType = player.trainType || "Freight";
+      const trainType = player.trainType || TrainType.Freight;
 
       const query = `
                 UPDATE players 
@@ -347,8 +347,12 @@ export class PlayerService {
         // Log the processed hand data
         console.log(`Processed hand for player ${row.id}:`, handCards);
 
+        // Cast trainType from database string to TrainType enum
+        const trainType = row.trainType as TrainType;
+
         return {
           ...row,
+          trainType,
           trainState: {
             position:
               row.position_x !== null
@@ -414,7 +418,7 @@ export class PlayerService {
         name: "Player 1",
         color: "#ff0000",
         money: 50,
-        trainType: "Freight",
+        trainType: TrainType.Freight,
         turnNumber: 1,
         trainState: {
           position: { x: 0, y: 0, row: 0, col: 0 },

--- a/src/shared/types/GameTypes.ts
+++ b/src/shared/types/GameTypes.ts
@@ -9,12 +9,32 @@ export enum PlayerColor {
     BROWN = '#8B4513'   // Using saddle brown for better visibility
 }
 
+export enum TrainType {
+    Freight = 'freight',           // 2 loads, 9 mileposts
+    FastFreight = 'fast_freight',  // 2 loads, 12 mileposts
+    HeavyFreight = 'heavy_freight', // 3 loads, 9 mileposts
+    Superfreight = 'superfreight'   // 3 loads, 12 mileposts
+}
+
+export interface TrainProperties {
+    speed: number;
+    capacity: number;
+    spritePrefix: string;
+}
+
+export const TRAIN_PROPERTIES: Record<TrainType, TrainProperties> = {
+    [TrainType.Freight]: { speed: 9, capacity: 2, spritePrefix: 'train' },
+    [TrainType.FastFreight]: { speed: 12, capacity: 2, spritePrefix: 'train_12' },
+    [TrainType.HeavyFreight]: { speed: 9, capacity: 3, spritePrefix: 'train' },
+    [TrainType.Superfreight]: { speed: 12, capacity: 3, spritePrefix: 'train_12' }
+};
+
 export interface Player {
     id: string;  // Add unique identifier for database
     name: string;
     color: string;  // Hex color code
     money: number;
-    trainType: string;  // We'll expand this later with proper train types
+    trainType: TrainType;
     turnNumber: number;
     trainState: TrainState;
     hand: DemandCard[];  // Array of demand cards in player's hand
@@ -66,7 +86,7 @@ export interface GameState {
         scrollX: number;
         scrollY: number;
     };
-    trainSprites?: Map<string, Phaser.GameObjects.Image>; // Map of player ID to train sprite}
+    trainSprites?: Map<string, any>; // Map of player ID to train sprite (client-side only)
 }
 
 export const INITIAL_PLAYER_MONEY = 50; // 50M ECU starting money
@@ -128,8 +148,8 @@ export interface GridPoint extends Point {
     ferryConnection?: FerryConnection;  // Updated to use full FerryConnection type
     city?: CityData;
     ocean?: string;
-    // Runtime properties
-    sprite?: Phaser.GameObjects.Graphics | Phaser.GameObjects.Image;
+    // Runtime properties (client-side only)
+    sprite?: any; // Phaser sprite object
     tracks?: Array<{ playerId: string }>;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,9 @@ module.exports = {
           /src\/client_backup_/
         ],
         options: {
-          configFile: 'tsconfig.webpack.json'
+          configFile: 'tsconfig.webpack.json',
+          transpileOnly: true,
+          experimentalWatchApi: true
         }
       },
       {
@@ -67,6 +69,8 @@ module.exports = {
     compress: true,
     port: 3000,
     hot: true,
+    liveReload: true,
+    watchFiles: ['src/**/*'],
     historyApiFallback: {
       index: '/',
       rewrites: [
@@ -93,5 +97,11 @@ module.exports = {
       }
     ]
   },
-  devtool: 'eval-source-map',
+  devtool: 'eval-cheap-module-source-map',
+  cache: {
+    type: 'filesystem',
+    buildDependencies: {
+      config: [__filename],
+    },
+  },
 }; 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   entry: './src/client/index.tsx',
@@ -60,6 +61,10 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: './src/client/index.html',
+    }),
+    new webpack.DefinePlugin({
+      'process.env.REACT_APP_MOCK_MODE': JSON.stringify(process.env.REACT_APP_MOCK_MODE || 'false'),
+      'process.env.REACT_APP_DEV_AUTH': JSON.stringify(process.env.REACT_APP_DEV_AUTH || 'false'),
     }),
   ],
   devServer: {


### PR DESCRIPTION
A number of fixes for train placement after lobby integration changed routes and state.
1. use a train type enum instead of magic string on the player
2. active games should pull game state from gameservice not construct on the fly. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request refactors authentication by replacing NODE_ENV checks with explicit environment variables, standardizes train type handling using a TrainType enum with TRAIN_PROPERTIES lookup, improves city selection dropdown components, and enhances build configuration. These changes improve security, maintainability, and type safety across the codebase.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
-->
</div>