### PR TITLE
Fix: Resolve Dependabot security alert #17 - Update vite to 7.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14841,9 +14841,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
-      "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
+      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Security Fix: Dependabot Alert #17

This PR resolves the security vulnerability identified by Dependabot in vite.

### Vulnerability Details
- **CVE**: GHSA-93m4-6634-74q7
- **Severity**: Moderate
- **Issue**: vite allows server.fs.deny bypass via backslash on Windows
- **CWE**: CWE-22 (Path Traversal)
- **Vulnerable Range**: 7.1.0 - 7.1.10

### Changes Made
- Updated `vite` from `7.1.7` → `7.1.12` (patched version)
- Updated `package-lock.json` with secure dependency versions

### Verification
- ✅ Build successful (`npm run build`)
- ✅ All tests passing (`npm test`)
- ✅ Security audit clean (`npm audit`)
- ✅ No breaking changes to functionality

### Impact
- **Low Risk**: vite is a dev dependency only
- **Windows-specific**: Affects Windows development environments
- **Fixed**: Vulnerability resolved with patched version

This fix addresses the security alert at: https://github.com/jeffgabriel/eurorails_ai/security/dependabot/17

Closes dependabot alert #17