### PR TITLE
Add .dockerignore for production builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,11 +26,10 @@ dist
 *.swo
 *~
 
-# Testing
+# Testing (exclude outputs, but include test source files for CI)
 coverage
 .nyc_output
 test-results
-__tests__
 
 # Documentation (optional - include if needed)
 # *.md


### PR DESCRIPTION
This PR adds the `.dockerignore` file to exclude unnecessary files from Docker builds in production.

This is the first incremental change being ported from `jeff/railway` branch to test CI builds one file at a time. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Introduces a new .dockerignore file that excludes dependencies, logs, build outputs, environment files, version control data, IDE configurations, testing directories, and other miscellaneous files to make Docker builds lighter and more secure.</li>

<li>Represents the initial incremental change for testing CI builds by porting changes one file at a time.</li>

<li>Overall summary: Introduces a .dockerignore file to optimize production Docker builds and enhance security, with exclusions for various file types, as part of incremental CI testing.</li>

</ul>

</div>