### PR TITLE
Fix player hand UI showing wrong player data after turn change

### DIFF
--- a/src/client/scenes/PlayerHandScene.ts
+++ b/src/client/scenes/PlayerHandScene.ts
@@ -159,19 +159,22 @@ export class PlayerHandScene extends Phaser.Scene {
   }
 
   private refreshDynamicUI(): void {
-    const currentPlayer = this.gameStateService.getCurrentPlayer();
-    if (!currentPlayer) return;
+    const localPlayerId = this.gameStateService.getLocalPlayerId();
+    const localPlayer = localPlayerId
+      ? this.gameState.players.find((p) => p.id === localPlayerId)
+      : null;
+    if (!localPlayer) return;
 
     // Update name/money if it changed
     if (this.nameAndMoneyText) {
       this.nameAndMoneyText.setText(
-        `${currentPlayer.name}\nMoney: ECU ${currentPlayer.money}M`
+        `${localPlayer.name}\nMoney: ECU ${localPlayer.money}M`
       );
     }
 
     // Update build cost text + color
     if (this.buildCostText) {
-      const display = this.getBuildCostDisplay(currentPlayer);
+      const display = this.getBuildCostDisplay(localPlayer);
       this.buildCostText.setText(display.text);
       this.buildCostText.setColor(display.color);
     }
@@ -427,12 +430,15 @@ export class PlayerHandScene extends Phaser.Scene {
   }
 
   private createNameAndMoneySection(parentSizer: any): void {
-    const currentPlayer = this.gameStateService.getCurrentPlayer();
-    if (!currentPlayer) {
+    const localPlayerId = this.gameStateService.getLocalPlayerId();
+    const localPlayer = localPlayerId
+      ? this.gameState.players.find((p) => p.id === localPlayerId)
+      : null;
+    if (!localPlayer) {
       return;
     }
 
-    const playerInfoText = `${currentPlayer.name}\nMoney: ECU ${currentPlayer.money}M`;
+    const playerInfoText = `${localPlayer.name}\nMoney: ECU ${localPlayer.money}M`;
     const nameAndMoney = this.add
       .text(0, 0, playerInfoText, {
         color: "#ffffff",
@@ -454,11 +460,14 @@ export class PlayerHandScene extends Phaser.Scene {
   }
 
   private createBuildCostSection(parentSizer: any): void {
-    const currentPlayer = this.gameStateService.getCurrentPlayer();
-    if (!currentPlayer) {
+    const localPlayerId = this.gameStateService.getLocalPlayerId();
+    const localPlayer = localPlayerId
+      ? this.gameState.players.find((p) => p.id === localPlayerId)
+      : null;
+    if (!localPlayer) {
       return;
     }
-    const display = this.getBuildCostDisplay(currentPlayer);
+    const display = this.getBuildCostDisplay(localPlayer);
     const buildCostText = this.add
       .text(0, 0, display.text, {
         color: display.color,


### PR DESCRIPTION
## Summary
- Fixed bug where player info section displayed the other player's data after turn changes
- Changed refreshDynamicUI, createNameAndMoneySection, and createBuildCostSection to use getLocalPlayerId() instead of getCurrentPlayer()
- The player hand now consistently shows the local player's name, money, and build cost regardless of whose turn it is

## Test plan
- [ ] Start a multiplayer game with 2 players
- [ ] Verify player hand shows your own player info on your turn
- [ ] End your turn and verify player hand still shows your own player info (not the other player's)
- [ ] Verify build cost display updates correctly for the local player

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Fixes a critical bug in the player hand UI by updating code to use local player identification instead of the current player.</li>

<li>Changes were made in refreshDynamicUI, createNameAndMoneySection, and createBuildCostSection to ensure displayed player information is consistent with the local user's data after turn changes.</li>

<li>Overall, the update fixes a critical bug in the player hand UI, updates refreshDynamicUI, createNameAndMoneySection, and createBuildCostSection, and improves the accuracy of the player hand display in a multiplayer context.</li>

</ul>

</div>