### PR TITLE
Enforce move-before-draw (block movement after track drawing)

### DIFF
--- a/src/client/components/TrackDrawingManager.ts
+++ b/src/client/components/TrackDrawingManager.ts
@@ -228,6 +228,17 @@ export class TrackDrawingManager {
         return this.playerTracks.get(playerId);
     }
 
+    /**
+     * Derived per-turn state: has this player drawn/built any track this turn?
+     */
+    public hasDrawnThisTurn(): boolean {
+        const currentPlayer = this.gameState.players?.[this.gameState.currentPlayerIndex];
+        const committedTurnSpend = (this.playerTracks.get(currentPlayer?.id)?.turnBuildCost ?? 0) > 0;
+        const uncommittedThisSession = this.currentSegments.length > 0;
+
+        return committedTurnSpend || uncommittedThisSession;
+    }
+
     public async loadExistingTracks(): Promise<void> {
         try {
             // Fetch all tracks for the current game

--- a/src/client/components/TrainInteractionManager.ts
+++ b/src/client/components/TrainInteractionManager.ts
@@ -165,6 +165,15 @@ export class TrainInteractionManager {
       return;
     }
 
+    // Movement-before-drawing rule:
+    // If the player has drawn/built any track this turn, they cannot move again until next turn.
+    if (this.trackDrawingManager.hasDrawnThisTurn()) {
+      this.uiManager?.showHandToast?.(
+        "You cannot move again this turn after you start drawing track."
+      );
+      return;
+    }
+
     const hasTrack = this.playerHasTrack(playerId);
     if (!hasTrack) {
       this.uiManager?.showHandToast?.(


### PR DESCRIPTION
### Summary
- Enforces the rule: **train movement must happen before track drawing**.
- Shows a warning toast when entering drawing with remaining movement.
- Blocks entering movement mode after drawing has started.
- Extends toast visibility by ~2 seconds.

### Notes
- Uses existing server-authoritative track state / per-turn spend to determine whether drawing has occurred this turn.
- Undoing all track drawn this turn re-enables movement (when per-turn spend returns to 0). 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Introduces new checks and UI feedback mechanisms to enforce that train movement must occur before track drawing begins.</li>

<li>Updates business logic and user interface to block further movement once track drawing is initiated until a reset occurs.</li>

<li>Includes testing enhancements and method improvements to ensure consistent behavior across the application.</li>

<li>Overall summary: The pull request introduces new checks and UI feedback in business logic and user interface, with testing enhancements and method improvements, reinforcing game integrity by aligning drawing state with movement restrictions.</li>

</ul>

</div>