### PR TITLE
PT2-1: Track preview warns immediately when unaffordable

### DIFF
--- a/src/client/__tests__/TrackDrawingManager.test.ts
+++ b/src/client/__tests__/TrackDrawingManager.test.ts
@@ -931,6 +931,41 @@ describe('TrackDrawingManager', () => {
             // Should use red color (0xff0000)
             expect(mockGraphics6.lineStyle).toHaveBeenCalledWith(2, 0xff0000, 0.5);
         });
+
+        it('should still render a red preview (and update cost) when over the turn build limit', () => {
+            const mockGraphics = {
+                clear: jest.fn(),
+                lineStyle: jest.fn(),
+                beginPath: jest.fn(),
+                moveTo: jest.fn(),
+                lineTo: jest.fn(),
+                strokePath: jest.fn()
+            };
+            (trackDrawingManager as any).previewGraphics = mockGraphics;
+
+            trackDrawingManager.onCostUpdate(costUpdateCallback);
+            trackDrawingManager.toggleDrawingMode();
+            costUpdateCallback.mockClear();
+
+            // Force over-limit scenario: 20M limit, but already spent 20M this turn
+            (trackDrawingManager as any).turnBuildCost = 20;
+            gameState.players[0].money = 999; // Not cash-limited
+
+            const startPoint = gridPoints[2][2];
+            (trackDrawingManager as any).lastClickedPoint = startPoint;
+
+            const targetPoint = gridPoints[2][3];
+
+            // Use real pathfinding (no mock) so we validate the preview doesn't disappear.
+            (trackDrawingManager as any).processHoverUpdate(targetPoint);
+
+            // Flush queued cost update
+            (trackDrawingManager as any).updateEventHandler?.();
+
+            // Cost should include 20 already spent + 1 preview = 21
+            expect(costUpdateCallback).toHaveBeenCalledWith(21);
+            expect(mockGraphics.lineStyle).toHaveBeenCalledWith(2, 0xff0000, 0.5);
+        });
     });
 });
 

--- a/src/client/components/TrackDrawingManager.ts
+++ b/src/client/components/TrackDrawingManager.ts
@@ -184,8 +184,14 @@ export class TrackDrawingManager {
 
                 // Provide immediate feedback when the preview is unaffordable (or transitions back to affordable),
                 // otherwise keep the 100ms debounce to reduce flicker during fast dragging.
-                const isUnaffordableNow = totalCost > currentPlayer.money;
-                const wasUnaffordable = this.lastDisplayedCost > currentPlayer.money;
+                const isOverMoneyNow = totalCost > currentPlayer.money;
+                const isOverTurnLimitNow = totalCost > this.turnBuildLimit;
+                const isUnaffordableNow = isOverMoneyNow || isOverTurnLimitNow;
+
+                const wasOverMoney = this.lastDisplayedCost > currentPlayer.money;
+                const wasOverTurnLimit = this.lastDisplayedCost > this.turnBuildLimit;
+                const wasUnaffordable = wasOverMoney || wasOverTurnLimit;
+
                 const shouldFlushImmediately = isUnaffordableNow || (wasUnaffordable && !isUnaffordableNow);
 
                 const minHoverMs = shouldFlushImmediately ? 0 : 100;
@@ -1099,10 +1105,10 @@ export class TrackDrawingManager {
                     }
                 }
 
-                // Use the true build cost for the validity check
-                if (!this.isValidCost(trueBuildCost)) {
-                    return null;
-                }
+                // Preview-only behavior:
+                // Even if this path is unaffordable (money or per-turn build limit), we still return it so
+                // the UI can render a red preview and show an explanation in the cost display.
+                // The hard affordability check is enforced on click/commit in `handleDrawingClick`.
 
                 return path;
             }


### PR DESCRIPTION
Closes #166.

- Make preview cost updates flush immediately when the preview crosses the player’s available cash (so the UI can show the insufficient-funds warning while dragging quickly).
- Keep the existing debounce for affordable previews to reduce flicker.
- Add a unit test covering the immediate flush behavior.

Parent tracking: #152. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Modifies the logic to immediately flush cost updates when the preview exceeds the player’s available funds, ensuring insufficient-funds warnings are shown promptly.</li>

<li>Adjusts the cost computation and debounce mechanism for handling rapid interactions.</li>

<li>Adds a new unit test to ensure the immediate flush behavior works as expected.</li>

<li>Overall summary: Improves track preview cost update behavior by modifying cost computation and debounce mechanism, and adds a unit test.</li>

</ul>

</div>