### PR TITLE
PT2-4: Add “Take me to…” city dropdown (RexUI) to center camera

### DIFF
--- a/src/client/components/CityListDropDown.ts
+++ b/src/client/components/CityListDropDown.ts
@@ -2,7 +2,6 @@ import "phaser";
 import SimpleDropDownList from "phaser3-rex-plugins/templates/ui/simpledropdownlist/SimpleDropDownList";
 import { TerrainType } from "../../shared/types/GameTypes";
 import { MapRenderer } from "./MapRenderer";
-
 export type CityListItem = {
   name: string;
   terrain: TerrainType;

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -63,6 +63,25 @@ export class GameScene extends Phaser.Scene {
   }
 
   /**
+   * Expose MapRenderer for other scenes (e.g., Settings) without reaching into private fields via `as any`.
+   */
+  public getMapRenderer(): MapRenderer | null {
+    return this.mapRenderer ?? null;
+  }
+
+  /**
+   * Persist the current camera position/zoom to the per-player camera state (and server) so it survives reloads.
+   * Safe to call after any external camera changes (e.g., "Take me to…" jump).
+   */
+  public persistLocalCameraState(): void {
+    try {
+      void this.cameraController?.saveCameraState?.();
+    } catch (_e) {
+      // Non-fatal
+    }
+  }
+
+  /**
    * Build a list of all cities currently available on the board (from MapRenderer grid points).
    * Returns a stable, alphabetized list for UI search/autocomplete.
    */
@@ -114,7 +133,7 @@ export class GameScene extends Phaser.Scene {
     const x = sumX / count;
     const y = sumY / count;
     this.cameras.main.centerOn(x, y);
-    this.cameras.main.dirty = true;
+    this.persistLocalCameraState();
     return true;
   }
 

--- a/src/client/scenes/SettingsScene.ts
+++ b/src/client/scenes/SettingsScene.ts
@@ -2,7 +2,8 @@ import 'phaser';
 import { GameState, Player, PlayerColor, TrainType } from '../../shared/types/GameTypes';
 import { GameScene } from './GameScene';
 import { config } from '../config/apiConfig';
-import { CityListDropDown, CityListItem } from '../components/CityListDropDown';
+import { CityListDropDown } from '../components/CityListDropDown';
+import { CityListItem } from '../components/CityListDropDown';
 
 export class SettingsScene extends Phaser.Scene {
     private gameState: GameState;
@@ -205,6 +206,7 @@ export class SettingsScene extends Phaser.Scene {
 
         // --- City search ("Take me to...") ---
         const gameScene = this.scene.get('GameScene') as GameScene;
+        const mapRenderer = gameScene.getMapRenderer();
         const citySearchLabelY = blockTopY - 70;
         const citySearchRowY = blockTopY - 40;
 
@@ -221,10 +223,12 @@ export class SettingsScene extends Phaser.Scene {
 
         // RexUI dropdown (more reliable than HTML DOM inside Phaser scenes)
         this.cityDropDown?.destroy();
-        this.cityDropDown = new CityListDropDown(this, (gameScene as any).mapRenderer);
-        this.cityDropDown.setPosition(buttonX - 70, citySearchRowY);
-        this.cityDropDown.init();
-        this.add.existing(this.cityDropDown);
+        if (mapRenderer) {
+            this.cityDropDown = new CityListDropDown(this, mapRenderer);
+            this.cityDropDown.setPosition(buttonX - 70, citySearchRowY);
+            this.cityDropDown.init();
+            this.add.existing(this.cityDropDown);
+        }
 
         const goButton = this.add.rectangle(
             buttonX + 180,
@@ -753,7 +757,7 @@ export class SettingsScene extends Phaser.Scene {
     private centerGameCameraOnCity(city: CityListItem, gameScene: GameScene): void {
         // Prefer centering for predictable "jump to" behavior (no animation).
         gameScene.cameras.main.centerOn(city.x, city.y);
-        gameScene.cameras.main.dirty = true;
+        gameScene.persistLocalCameraState();
     }
 
     private async endGame() {


### PR DESCRIPTION
Closes #169.

Adds a RexUI-powered city dropdown in Settings (“Take me to…”) that lists all cities from the map and centers the camera on the selected city.

- Uses a reusable `CityListDropDown` component built from `MapRenderer.gridPoints` (deduped + alphabetized)
- Centers camera (no animation) and closes Settings so the result is immediately visible

Parent tracking: #152. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Introduces a new 'Take me to…' city dropdown feature in the settings scene to enable quick navigation to desired cities.</li>

<li>Adds a reusable CityListDropDown component for the dropdown functionality.</li>

<li>Updates the game scene with methods to extract and center on city locations, providing immediate camera centering with no animation.</li>

<li>Overall summary: Introduces a new UI feature in the settings scene and game scene, adds the CityListDropDown component, and updates city data handling to deduplicate and alphabetically sort while integrating UI and camera functionality.</li>

</ul>

</div>