### PR TITLE
PT2-10: Improve readability of small/medium city labels

### DIFF
--- a/src/client/components/map/MediumCity.ts
+++ b/src/client/components/map/MediumCity.ts
@@ -34,7 +34,7 @@ export class MediumCity extends City {
     );
     this.drawMilepostDot(graphics);
     // Add city name
-    this.addCityName(container, "8px");
+    this.addCityName(container, "10px");
     this.addLoadSpritesToCity(this.x, this.y, this.cityData.name, this.cityData.type, container);
   }
 } 

--- a/src/client/components/map/SmallCity.ts
+++ b/src/client/components/map/SmallCity.ts
@@ -29,7 +29,7 @@ export class SmallCity extends City {
     graphics.stroke();
     this.drawMilepostDot(graphics);
     // Add city name
-    this.addCityName(container, "10px");
+    this.addCityName(container, "11px");
     this.addLoadSpritesToCity(this.x, this.y, this.cityData.name, this.cityData.type, container);
   }
 } 


### PR DESCRIPTION
Implements [#175](https://github.com/jeffgabriel/eurorails_ai/issues/175).

- Increase Medium city label font size: 8px → 10px
- Increase Small city label font size: 10px → 11px

Closes #175. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Updates font size parameters in the addCityName method for medium and small cities to improve readability of city labels in map components.</li>

<li>Modifies two files to adjust font sizes, ensuring labels are clearer for users.</li>

<li>Aligns changes with design enhancements outlined in the issue.</li>

<li>Overall summary: Improves readability of city labels in map components by adjusting font sizes in the addCityName method across two files, providing a smoother visual experience on the map interface.</li>

</ul>

</div>