### PR TITLE
Fix duplicate card bug on delivery undo

### DIFF
--- a/src/client/services/PlayerStateService.ts
+++ b/src/client/services/PlayerStateService.ts
@@ -561,9 +561,9 @@ export class PlayerStateService {
                 this.localPlayer.money = result.updatedMoney;
                 this.localPlayer.debtOwed = result.updatedDebtOwed;
                 this.localPlayer.trainState.loads = result.updatedLoads;
-                this.localPlayer.hand = (this.localPlayer.hand || [])
-                    .filter((card: any) => card.id !== result.removedCardId);
-                this.localPlayer.hand.push(result.restoredCard);
+                // Hand will be updated via socket patch (server is authoritative)
+                // Do not manually update hand here to avoid race condition duplicates (Issue #195)
+                // The server broadcasts the updated hand via state:patch after undo
                 return true;
             }
 


### PR DESCRIPTION
## Summary
Fixes #195 - Duplicate card appears in hand after undoing a delivery

## Root Cause
The bug occurred due to a race condition between two hand update mechanisms:
1. Direct client update in `PlayerStateService.undoLastAction()` 
2. Server socket patch broadcast after undo

Both updates were applying the restored card to the hand, causing duplicates to appear temporarily in the UI.

## Solution
Removed the manual client-side hand update during delivery undo. The server is already authoritative for hand state and broadcasts updates via `state:patch` event after processing the undo.

## Changes
- **`src/client/services/PlayerStateService.ts`**: Removed manual hand manipulation (filter + push) in delivery undo handler
- Added explanatory comment referencing Issue #195

## Consistency
This aligns with:
- Issue #176 design where hands are public and server-managed
- How delivery itself works (doesn't manually update hand client-side)
- The socket patch handler which correctly merges server hand state

## Testing
- All 165 client tests pass
- Verified that other state updates (money, debt, loads) still provide immediate feedback

## Test Plan
1. Deliver a load (hand updates correctly)
2. Undo the delivery (restored card appears once, drawn card removed)
3. Check browser console for no duplicate card IDs in hand signature
4. Verify UI shows exactly 3 cards with correct content
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request fixes a duplicate card bug that occurred during delivery undo operations in the Eurorails AI game. The issue stemmed from a race condition between client-side manual hand updates and server-broadcasted state patches, causing cards to appear twice temporarily. The solution removes the manual hand manipulation in the PlayerStateService, ensuring the server remains authoritative for hand state and broadcasts updates correctly via socket events.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes manual hand update logic (filtering removed card and pushing restored card) in the delivery undo handler within PlayerStateService.ts to eliminate race condition duplicates</li>

<li>Adds explanatory comment referencing Issue #195 and noting reliance on server socket patches for hand state updates</li>

</ul>
</details>

</div>