### PR TITLE
Add real-time train sprite updates for multiplayer

### DIFF
--- a/src/client/components/UIManager.ts
+++ b/src/client/components/UIManager.ts
@@ -401,14 +401,16 @@ export class UIManager {
     x: number,
     y: number,
     row: number,
-    col: number
+    col: number,
+    opts?: { persist?: boolean }
   ): Promise<void> {
     await this.trainInteractionManager.updateTrainPosition(
       playerId,
       x,
       y,
       row,
-      col
+      col,
+      opts
     );
   }
 

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -365,7 +365,27 @@ export class GameScene extends Phaser.Scene {
                     };
                   } else {
                     // For other players: use server data (authoritative)
+                    const oldPosition = existingPlayer.trainState?.position;
+                    const newPosition = updatedPlayer.trainState?.position;
+                    
                     this.gameState.players[index] = { ...existingPlayer, ...updatedPlayer };
+                    
+                    // If position changed, update visual sprite
+                    if (newPosition && 
+                        (oldPosition?.row !== newPosition.row || oldPosition?.col !== newPosition.col)) {
+                      const gridPoint = this.mapRenderer.gridPoints[newPosition.row]?.[newPosition.col];
+                      if (gridPoint) {
+                        // Use persist: false to avoid sending position back to server
+                        this.uiManager.updateTrainPosition(
+                          updatedPlayer.id,
+                          gridPoint.x,
+                          gridPoint.y,
+                          newPosition.row,
+                          newPosition.col,
+                          { persist: false }
+                        );
+                      }
+                    }
                   }
                 } else {
                   // Add new player (shouldn't happen in normal gameplay)


### PR DESCRIPTION
## Summary
Implements real-time visual updates of train sprites when players move their trains in multiplayer games. Other players now see train movements instantly on their screens.

## Changes
- **GameScene**: Added visual sprite update logic in the socket patch handler for other players' position changes
- **UIManager**: Updated `updateTrainPosition` signature to support optional `persist` parameter
- Uses `persist: false` to avoid sending position updates back to server (server is already authoritative)

## Technical Details
- Leverages existing `state:patch` socket events (no new events needed)
- Detects position changes by comparing old vs new row/col
- Converts grid coordinates to world coordinates using `mapRenderer.gridPoints`
- Local player movements remain client-side optimistic (immediate feedback)
- Other players' positions are server-authoritative (prevents desync)

## Test Plan
1. Open game in two browser windows as different players
2. Move train in window 1 during your turn
3. Verify train sprite moves visually in window 2
4. Test multiple consecutive moves
5. Test ferry crossings and city arrivals across clients

## Closes
Closes #152 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR implements real-time visual updates for train sprites in multiplayer games, allowing players to see other players' train movements instantly on their screens.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds optional `persist` parameter to `updateTrainPosition` method in UIManager to control server synchronization.</li>

<li>Implements position change detection in GameScene's socket patch handler for other players.</li>

<li>Updates visual train sprites using grid coordinates when position changes are detected, with persist: false to prevent server feedback loops.</li>

</ul>
</details>

</div>