### PR TITLE
refactor(MapTopology): relocate MapTopology out of ai/ to services/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ test-results/
 
 # Compounds local session data
 .compounds/
+
+# AI tool local data
+.claude/
+.cursor/
+
+# SQLite databases
+*.db

--- a/src/server/__tests__/MapTopology.ai.test.ts
+++ b/src/server/__tests__/MapTopology.ai.test.ts
@@ -1,4 +1,4 @@
-import { estimateHopDistance, estimatePathCost, hexDistance, _resetCache } from '../../services/ai/MapTopology';
+import { estimateHopDistance, estimatePathCost, hexDistance, _resetCache } from '../services/MapTopology';
 
 describe('estimateHopDistance', () => {
   afterEach(() => {

--- a/src/server/__tests__/MapTopology.test.ts
+++ b/src/server/__tests__/MapTopology.test.ts
@@ -14,7 +14,7 @@ import {
   makeKey,
   _resetCache,
   GridPointData,
-} from '../services/ai/MapTopology';
+} from '../services/MapTopology';
 
 describe('MapTopology', () => {
   describe('loadGridPoints', () => {

--- a/src/server/__tests__/TurnExecutor.test.ts
+++ b/src/server/__tests__/TurnExecutor.test.ts
@@ -23,7 +23,7 @@ jest.mock('../db/index', () => ({
   },
 }));
 jest.mock('../services/playerService');
-jest.mock('../services/ai/MapTopology', () => ({
+jest.mock('../services/MapTopology', () => ({
   loadGridPoints: jest.fn(() => new Map()),
   getHexNeighbors: jest.fn(() => []),
   getTerrainCost: jest.fn(() => 1),
@@ -624,7 +624,7 @@ describe('TurnExecutor — handlePickupLoad', () => {
   });
 
   it('should insert pickup action into turn_actions table', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -645,7 +645,7 @@ describe('TurnExecutor — handlePickupLoad', () => {
   });
 
   it('should still succeed when turn_actions insert fails', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -692,7 +692,7 @@ describe('TurnExecutor — handleDeliverLoad', () => {
   });
 
   it('should delegate to PlayerService.deliverLoadForUser', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -706,7 +706,7 @@ describe('TurnExecutor — handleDeliverLoad', () => {
   });
 
   it('should return success with payment and new card ID', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -734,7 +734,7 @@ describe('TurnExecutor — handleDeliverLoad', () => {
   });
 
   it('should return failure when bot is not at a named city', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map()); // empty grid = no city
 
     const plan = makeDeliveryPlan('Coal', 42);
@@ -745,7 +745,7 @@ describe('TurnExecutor — handleDeliverLoad', () => {
   });
 
   it('should emit bot:demandRankingUpdate with refreshed demand ranking after delivery (FE-001)', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -778,7 +778,7 @@ describe('TurnExecutor — handleDeliverLoad', () => {
   });
 
   it('should still succeed when demand ranking emit fails (FE-001)', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -800,7 +800,7 @@ describe('TurnExecutor — handleDeliverLoad', () => {
 
 describe('JIRA-83: MultiAction DELIVER/DROP skip at unnamed milepost', () => {
   it('should skip DELIVER step when bot is not at a named city and continue remaining steps', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     // Empty grid = no city at bot position
     (loadGridPoints as jest.Mock).mockReturnValue(new Map());
 
@@ -837,7 +837,7 @@ describe('JIRA-83: MultiAction DELIVER/DROP skip at unnamed milepost', () => {
   });
 
   it('should skip DROP step when bot is not at a named city', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map());
 
     // Mock PlayerService for build step
@@ -871,7 +871,7 @@ describe('JIRA-83: MultiAction DELIVER/DROP skip at unnamed milepost', () => {
   });
 
   it('should execute DELIVER normally when bot IS at a named city', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, name: 'Berlin', terrain: 2 }],
     ]));
@@ -1095,7 +1095,7 @@ describe('TurnExecutor — handleDropLoad', () => {
   });
 
   it('should call PlayerService.dropLoadForPlayer with correct params', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -1115,7 +1115,7 @@ describe('TurnExecutor — handleDropLoad', () => {
   });
 
   it('should return success with zero cost', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -1130,7 +1130,7 @@ describe('TurnExecutor — handleDropLoad', () => {
   });
 
   it('should update snapshot.bot.loads after drop', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -1158,7 +1158,7 @@ describe('TurnExecutor — handleDropLoad', () => {
 
   it('should return failure when bot is not at a named city', async () => {
     // Position not in grid points — returns empty city name
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map());
 
     const plan = makeDropOption('Coal');
@@ -1170,7 +1170,7 @@ describe('TurnExecutor — handleDropLoad', () => {
   });
 
   it('should insert audit record (best-effort)', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -1187,7 +1187,7 @@ describe('TurnExecutor — handleDropLoad', () => {
   });
 
   it('should still succeed when audit insert fails', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));
@@ -1200,7 +1200,7 @@ describe('TurnExecutor — handleDropLoad', () => {
   });
 
   it('should throw when PlayerService.dropLoadForPlayer throws', async () => {
-    const { loadGridPoints } = require('../services/ai/MapTopology');
+    const { loadGridPoints } = require('../services/MapTopology');
     (loadGridPoints as jest.Mock).mockReturnValue(new Map([
       ['29,32', { row: 29, col: 32, terrain: TerrainType.MajorCity, name: 'Berlin' }],
     ]));

--- a/src/server/__tests__/ai/AIStrategyEngine.test.ts
+++ b/src/server/__tests__/ai/AIStrategyEngine.test.ts
@@ -27,7 +27,7 @@ jest.mock('../../services/socketService', () => ({
   getSocketIO: jest.fn<() => any>().mockReturnValue(null),
 }));
 
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   loadGridPoints: jest.fn(() => new Map()),
   getHexNeighbors: jest.fn(() => []),
   getTerrainCost: jest.fn(() => 1),
@@ -198,7 +198,7 @@ import { TurnComposer } from '../../services/ai/TurnComposer';
 import { db } from '../../db/index';
 import { emitToGame } from '../../services/socketService';
 import { getMemory, updateMemory } from '../../services/ai/BotMemory';
-import { loadGridPoints } from '../../services/ai/MapTopology';
+import { loadGridPoints } from '../../services/MapTopology';
 import { PlayerService } from '../../services/playerService';
 import {
   AIActionType,
@@ -4082,7 +4082,7 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
       mockFindDeadLoads.mockReturnValue(deadLoads);
 
       // Mock loadGridPointsMap to return a city at bot's position
-      const { loadGridPoints } = require('../../services/ai/MapTopology');
+      const { loadGridPoints } = require('../../services/MapTopology');
       (loadGridPoints as jest.Mock).mockReturnValue(new Map([
         ['10,10', { name: 'TestCity' }],
       ]));
@@ -4160,7 +4160,7 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
       mockFindDeadLoads.mockReturnValue(['Hops']);
 
       // loadGridPointsMap returns no city at bot's position
-      const { loadGridPoints } = require('../../services/ai/MapTopology');
+      const { loadGridPoints } = require('../../services/MapTopology');
       (loadGridPoints as jest.Mock).mockReturnValue(new Map());
 
       const route = {

--- a/src/server/__tests__/ai/ActionResolver.test.ts
+++ b/src/server/__tests__/ai/ActionResolver.test.ts
@@ -30,14 +30,14 @@ import {
   TurnPlanDiscardHand,
   TurnPlanPassTurn,
 } from '../../../shared/types/GameTypes';
-import type { GridPointData, GridCoord } from '../../services/ai/MapTopology';
+import type { GridPointData, GridCoord } from '../../services/MapTopology';
 import type { TrackUsageComputation, PathEdge } from '../../../shared/services/trackUsageFees';
 
 // ─── Mock modules ────────────────────────────────────────────────────────────
 
 jest.mock('../../services/ai/computeBuildSegments');
 jest.mock('../../../shared/services/trackUsageFees');
-jest.mock('../../services/ai/MapTopology');
+jest.mock('../../services/MapTopology');
 jest.mock('../../../shared/services/majorCityGroups', () => {
   const actual = jest.requireActual('../../../shared/services/majorCityGroups');
   return {
@@ -50,7 +50,7 @@ jest.mock('../../../shared/services/majorCityGroups', () => {
 
 import { computeBuildSegments } from '../../services/ai/computeBuildSegments';
 import { computeTrackUsageForMove } from '../../../shared/services/trackUsageFees';
-import { loadGridPoints, hexDistance } from '../../services/ai/MapTopology';
+import { loadGridPoints, hexDistance } from '../../services/MapTopology';
 import { getMajorCityGroups, getMajorCityLookup } from '../../../shared/services/majorCityGroups';
 
 const mockComputeBuildSegments = computeBuildSegments as jest.MockedFunction<typeof computeBuildSegments>;

--- a/src/server/__tests__/ai/ContextBuilder.coldStart.test.ts
+++ b/src/server/__tests__/ai/ContextBuilder.coldStart.test.ts
@@ -107,7 +107,7 @@ const mockHexDistance = jest.fn((r1: number, c1: number, r2: number, c2: number)
   return Math.max(Math.abs(x1 - x2), Math.abs(y1 - y2), Math.abs(z1 - z2));
 });
 
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   estimatePathCost: (r1: number, c1: number, r2: number, c2: number) => mockEstimatePathCost(r1, c1, r2, c2),
   estimateHopDistance: (r1: number, c1: number, r2: number, c2: number) => mockEstimateHopDistance(r1, c1, r2, c2),
   hexDistance: (r1: number, c1: number, r2: number, c2: number) => mockHexDistance(r1, c1, r2, c2),

--- a/src/server/__tests__/ai/ContextBuilder.ferryCrossings.test.ts
+++ b/src/server/__tests__/ai/ContextBuilder.ferryCrossings.test.ts
@@ -12,7 +12,7 @@ jest.mock('../../../shared/services/majorCityGroups', () => ({
   computeEffectivePathLength: jest.fn().mockReturnValue(0),
 }));
 
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   hexDistance: jest.fn(),
   loadGridPoints: jest.fn().mockReturnValue([]),
   estimateHopDistance: jest.fn().mockReturnValue(0),
@@ -23,7 +23,7 @@ jest.mock('../../services/ai/MapTopology', () => ({
 }));
 
 import { getFerryEdges } from '../../../shared/services/majorCityGroups';
-import { hexDistance } from '../../services/ai/MapTopology';
+import { hexDistance } from '../../services/MapTopology';
 
 const mockedGetFerryEdges = getFerryEdges as jest.MockedFunction<typeof getFerryEdges>;
 const mockedHexDistance = hexDistance as jest.MockedFunction<typeof hexDistance>;

--- a/src/server/__tests__/ai/LLMStrategyBrain.test.ts
+++ b/src/server/__tests__/ai/LLMStrategyBrain.test.ts
@@ -54,7 +54,7 @@ jest.mock('../../services/ai/RouteValidator', () => ({
 }));
 
 // Mock MapTopology
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   loadGridPoints: jest.fn(() => new Map()),
   getHexNeighbors: jest.fn(() => []),
   getTerrainCost: jest.fn(() => 1),

--- a/src/server/__tests__/ai/PlanExecutor.test.ts
+++ b/src/server/__tests__/ai/PlanExecutor.test.ts
@@ -28,7 +28,7 @@ jest.mock('../../services/ai/ActionResolver', () => ({
 }));
 
 // Mock MapTopology
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   loadGridPoints: jest.fn(() => new Map()),
   getHexNeighbors: jest.fn(() => []),
   getTerrainCost: jest.fn(() => 1),
@@ -73,7 +73,7 @@ jest.mock('../../services/ai/ContextBuilder', () => ({
 
 import { ActionResolver } from '../../services/ai/ActionResolver';
 import { getMajorCityLookup } from '../../../shared/services/majorCityGroups';
-import { loadGridPoints } from '../../services/ai/MapTopology';
+import { loadGridPoints } from '../../services/MapTopology';
 import { ContextBuilder } from '../../services/ai/ContextBuilder';
 
 const mockResolve = ActionResolver.resolve as jest.Mock;

--- a/src/server/__tests__/ai/RouteValidator.test.ts
+++ b/src/server/__tests__/ai/RouteValidator.test.ts
@@ -12,12 +12,12 @@ import {
   TerrainType,
   DemandContext,
 } from '../../../shared/types/GameTypes';
-import { GridPointData } from '../../services/ai/MapTopology';
+import { GridPointData } from '../../services/MapTopology';
 
 // Mock MapTopology — loadGridPoints and estimateHopDistance return controllable values
 const mockGridPoints = new Map<string, GridPointData>();
 const mockEstimateHopDistance = jest.fn<number, [number, number, number, number]>(() => 10);
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   loadGridPoints: jest.fn(() => mockGridPoints),
   estimateHopDistance: (r1: number, c1: number, r2: number, c2: number) => mockEstimateHopDistance(r1, c1, r2, c2),
   getHexNeighbors: jest.fn(() => []),

--- a/src/server/__tests__/ai/TurnComposer.test.ts
+++ b/src/server/__tests__/ai/TurnComposer.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../services/ai/PlanExecutor', () => ({
     findDemandBuildTarget: jest.fn(),
   },
 }));
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   loadGridPoints: jest.fn(() => new Map()),
   getHexNeighbors: jest.fn(() => []),
   getTerrainCost: jest.fn(() => 1),
@@ -35,7 +35,7 @@ jest.mock('../../../shared/services/TrackNetworkService', () => ({
 import { TurnComposer } from '../../services/ai/TurnComposer';
 import { ActionResolver } from '../../services/ai/ActionResolver';
 import { PlanExecutor } from '../../services/ai/PlanExecutor';
-import { loadGridPoints } from '../../services/ai/MapTopology';
+import { loadGridPoints } from '../../services/MapTopology';
 import * as majorCityGroups from '../../../shared/services/majorCityGroups';
 import {
   AIActionType,

--- a/src/server/__tests__/ai/WorldSnapshotService.test.ts
+++ b/src/server/__tests__/ai/WorldSnapshotService.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../db/index', () => ({
   db: { query: jest.fn() },
 }));
 
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   loadGridPoints: jest.fn(() => new Map()),
   gridToPixel: jest.fn(() => ({ x: 0, y: 0 })),
 }));
@@ -47,7 +47,7 @@ jest.mock('../../services/loadService', () => ({
 
 import { capture } from '../../services/ai/WorldSnapshotService';
 import { db } from '../../db/index';
-import { loadGridPoints } from '../../services/ai/MapTopology';
+import { loadGridPoints } from '../../services/MapTopology';
 
 const mockQuery = db.query as jest.Mock;
 const mockLoadGridPoints = loadGridPoints as jest.Mock;

--- a/src/server/__tests__/computeBuildSegments.test.ts
+++ b/src/server/__tests__/computeBuildSegments.test.ts
@@ -7,7 +7,7 @@ import {
   hexDistance,
   _resetCache,
   GridCoord,
-} from '../services/ai/MapTopology';
+} from '../services/MapTopology';
 import { getMajorCityLookup, getMajorCityGroups, getFerryEdges } from '../../shared/services/majorCityGroups';
 
 describe('computeBuildSegments', () => {

--- a/src/server/__tests__/integration/botBuildTrack.test.ts
+++ b/src/server/__tests__/integration/botBuildTrack.test.ts
@@ -26,7 +26,7 @@ jest.mock('../../services/socketService', () => ({
 }));
 
 // Mock MapTopology (loaded by ActionResolver, ContextBuilder, computeBuildSegments)
-jest.mock('../../services/ai/MapTopology', () => ({
+jest.mock('../../services/MapTopology', () => ({
   loadGridPoints: jest.fn(() => {
     const map = new Map();
     // Paris major city and surroundings for pathfinding

--- a/src/server/services/MapTopology.ts
+++ b/src/server/services/MapTopology.ts
@@ -7,10 +7,10 @@
 
 import fs from 'fs';
 import path from 'path';
-import { TerrainType, WaterCrossingType } from '../../../shared/types/GameTypes';
-import { getTerrainBuildCost } from '../../../shared/config/terrainCosts';
-import { getFerryEdges, type FerryEdge } from '../../../shared/services/majorCityGroups';
-import waterCrossingsData from '../../../../configuration/waterCrossings.json';
+import { TerrainType, WaterCrossingType } from '../../shared/types/GameTypes';
+import { getTerrainBuildCost } from '../../shared/config/terrainCosts';
+import { getFerryEdges, type FerryEdge } from '../../shared/services/majorCityGroups';
+import waterCrossingsData from '../../../configuration/waterCrossings.json';
 
 /** Parsed grid point from gridPoints.json */
 export interface GridPointData {
@@ -90,7 +90,7 @@ function mapTypeToTerrain(type: string): TerrainType {
 export function loadGridPoints(): Map<string, GridPointData> {
   if (gridPointsCache) return gridPointsCache;
 
-  const filePath = path.resolve(__dirname, '../../../../configuration/gridPoints.json');
+  const filePath = path.resolve(__dirname, '../../../configuration/gridPoints.json');
   const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Array<{
     GridX: number;
     GridY: number;

--- a/src/server/services/ai/AIStrategyEngine.ts
+++ b/src/server/services/ai/AIStrategyEngine.ts
@@ -41,7 +41,7 @@ import {
 import { db } from '../../db/index';
 import { getMajorCityGroups, getMajorCityLookup, computeEffectivePathLength } from '../../../shared/services/majorCityGroups';
 import { getTrainCapacity } from '../../../shared/services/trainProperties';
-import { gridToPixel, loadGridPoints as loadGridPointsMap } from './MapTopology';
+import { gridToPixel, loadGridPoints as loadGridPointsMap } from '../MapTopology';
 import { RouteValidator } from './RouteValidator';
 import { getMemory, updateMemory } from './BotMemory';
 import { initTurnLog, logPhase, flushTurnLog, LLMPhaseFields } from './DecisionLogger';

--- a/src/server/services/ai/ActionResolver.ts
+++ b/src/server/services/ai/ActionResolver.ts
@@ -28,7 +28,7 @@ import {
   TRACK_USAGE_FEE,
   PlayerTrackState,
 } from '../../../shared/types/GameTypes';
-import { loadGridPoints, GridCoord, GridPointData, hexDistance } from './MapTopology';
+import { loadGridPoints, GridCoord, GridPointData, hexDistance } from '../MapTopology';
 import { getMajorCityGroups, getMajorCityLookup, computeEffectivePathLength } from '../../../shared/services/majorCityGroups';
 import { computeBuildSegments } from './computeBuildSegments';
 import { computeTrackUsageForMove } from '../../../shared/services/trackUsageFees';

--- a/src/server/services/ai/ContextBuilder.ts
+++ b/src/server/services/ai/ContextBuilder.ts
@@ -25,7 +25,7 @@ import {
 } from '../../../shared/types/GameTypes';
 import { buildTrackNetwork } from '../../../shared/services/TrackNetworkService';
 import { getMajorCityGroups, getFerryEdges } from '../../../shared/services/majorCityGroups';
-import { hexDistance, estimateHopDistance, estimatePathCost, computeLandmass, computeFerryRouteInfo, makeKey, loadGridPoints } from './MapTopology';
+import { hexDistance, estimateHopDistance, estimatePathCost, computeLandmass, computeFerryRouteInfo, makeKey, loadGridPoints } from '../MapTopology';
 import { getTrainSpeed, getTrainCapacity } from '../../../shared/services/trainProperties';
 import { getCityNameAtPosition } from '../../../shared/services/cityPositionResolver';
 

--- a/src/server/services/ai/PlanExecutor.ts
+++ b/src/server/services/ai/PlanExecutor.ts
@@ -28,7 +28,7 @@ import {
   ResolvedAction,
 } from '../../../shared/types/GameTypes';
 import { ActionResolver } from './ActionResolver';
-import { loadGridPoints } from './MapTopology';
+import { loadGridPoints } from '../MapTopology';
 import { buildTrackNetwork } from '../../../shared/services/TrackNetworkService';
 import { ContextBuilder } from './ContextBuilder';
 

--- a/src/server/services/ai/RouteValidator.ts
+++ b/src/server/services/ai/RouteValidator.ts
@@ -21,7 +21,7 @@ import {
   DemandContext,
   TerrainType,
 } from '../../../shared/types/GameTypes';
-import { loadGridPoints, estimateHopDistance, GridPointData } from './MapTopology';
+import { loadGridPoints, estimateHopDistance, GridPointData } from '../MapTopology';
 
 export interface RouteValidationResult {
   valid: boolean;

--- a/src/server/services/ai/TurnComposer.ts
+++ b/src/server/services/ai/TurnComposer.ts
@@ -25,7 +25,7 @@ import {
   TrainType,
 } from '../../../shared/types/GameTypes';
 import { ActionResolver } from './ActionResolver';
-import { loadGridPoints } from './MapTopology';
+import { loadGridPoints } from '../MapTopology';
 import { computeEffectivePathLength, getMajorCityLookup } from '../../../shared/services/majorCityGroups';
 import { getTrainCapacity } from '../../../shared/services/trainProperties';
 

--- a/src/server/services/ai/TurnExecutor.ts
+++ b/src/server/services/ai/TurnExecutor.ts
@@ -18,7 +18,7 @@ import { emitToGame, emitStatePatch } from '../socketService';
 import { PlayerService } from '../playerService';
 import { LoadService } from '../loadService';
 import { DemandDeckService } from '../demandDeckService';
-import { gridToPixel, loadGridPoints } from './MapTopology';
+import { gridToPixel, loadGridPoints } from '../MapTopology';
 import { getTrainCapacity, getTrainSpeed } from '../../../shared/services/trainProperties';
 import { getCityNameAtPosition } from '../../../shared/services/cityPositionResolver';
 

--- a/src/server/services/ai/WorldSnapshotService.ts
+++ b/src/server/services/ai/WorldSnapshotService.ts
@@ -11,7 +11,7 @@ import { DemandDeckService } from '../demandDeckService';
 import { LoadService } from '../loadService';
 import { getConnectedMajorCityCount } from './connectedMajorCities';
 import { getMajorCityGroups, getFerryEdges } from '../../../shared/services/majorCityGroups';
-import { loadGridPoints, gridToPixel } from './MapTopology';
+import { loadGridPoints, gridToPixel } from '../MapTopology';
 
 /**
  * Capture a frozen snapshot of the game world for AI evaluation.

--- a/src/server/services/ai/computeBuildSegments.ts
+++ b/src/server/services/ai/computeBuildSegments.ts
@@ -17,7 +17,7 @@ import {
   computeFerryRouteInfo,
   GridCoord,
   GridPointData,
-} from './MapTopology';
+} from '../MapTopology';
 import { getMajorCityLookup, getMajorCityGroups, getFerryEdges, isIntraCityEdge } from '../../../shared/services/majorCityGroups';
 import { getWaterCrossingExtraCost } from '../../../shared/config/waterCrossings';
 

--- a/src/server/services/playerService.ts
+++ b/src/server/services/playerService.ts
@@ -9,7 +9,7 @@ import { TrackService } from "./trackService";
 import { DemandCard } from "../../shared/types/DemandCard";
 import { LoadType } from "../../shared/types/LoadTypes";
 import { computeTrackUsageForMove } from "../../shared/services/trackUsageFees";
-import { loadGridPoints } from "./ai/MapTopology";
+import { loadGridPoints } from "./MapTopology";
 import { getFerryEdges } from "../../shared/services/majorCityGroups";
 import { TrackSegment } from "../../shared/types/TrackTypes";
 


### PR DESCRIPTION
## Summary

- Moves `MapTopology.ts` from `src/server/services/ai/` to `src/server/services/MapTopology.ts`
- Updates all 24 importers (10 production files, 14 test files) to the new path
- Relocates `src/server/__tests__/ai/MapTopology.test.ts` → `src/server/__tests__/MapTopology.ai.test.ts` to coexist with the existing root-level test file

Pure mechanical refactor — no behavior changes, public API preserved exactly.

## Motivation

`MapTopology` is general-purpose hex/grid utility code (not AI-specific). Moving it out of `ai/` establishes clean module boundaries before the upcoming event card system layers new dependencies on it.

## Test plan

- [x] `npm run build` — passes with zero TypeScript errors
- [x] `npm test` — 2072 passing, 8 skipped, 100 suites (no regression)
- [x] `grep -r "ai/MapTopology" src/` — zero matches (no stale imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR relocates the MapTopology module from the ai/ subdirectory to the services/ directory and updates all import references across the codebase. The change establishes clean module boundaries since MapTopology contains general-purpose hex/grid utilities rather than AI-specific logic. This is a pure mechanical refactor with no behavioral changes.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates import paths in 24 files (10 production, 14 test) to reference the relocated MapTopology module in services/MapTopology</li>

<li>Moves MapTopology.ts from src/server/services/ai/ to src/server/services/</li>

<li>Renames test file from MapTopology.test.ts to MapTopology.ai.test.ts to coexist with existing root-level test</li>

</ul>
</details>

</div>