### PR TITLE
feat: event card types, unified deck & DB migration

### DIFF
--- a/configuration/event_cards.json
+++ b/configuration/event_cards.json
@@ -1,0 +1,222 @@
+[
+  {
+    "id": 121,
+    "type": "Strike",
+    "title": "Coastal Strike!",
+    "description": "No train may pick up or deliver any load at any city within 3 mileposts of any coast.",
+    "effectConfig": {
+      "type": "Strike",
+      "variant": "coastal",
+      "coastalRadius": 3
+    }
+  },
+  {
+    "id": 122,
+    "type": "Strike",
+    "title": "Coastal Strike!",
+    "description": "No train may pick up or deliver any load at any city within 3 mileposts of any coast.",
+    "effectConfig": {
+      "type": "Strike",
+      "variant": "coastal",
+      "coastalRadius": 3
+    }
+  },
+  {
+    "id": 123,
+    "type": "Strike",
+    "title": "Rail Strike!",
+    "description": "No train may move on the drawing player's rail lines. The drawing player may not build track during this event.",
+    "effectConfig": {
+      "type": "Strike",
+      "variant": "rail",
+      "affectsDrawingPlayerOnly": true
+    }
+  },
+  {
+    "id": 124,
+    "type": "ExcessProfitTax",
+    "title": "Excess Profit Tax!",
+    "description": "All players pay a sliding-scale tax based on their current cash holdings.",
+    "effectConfig": {
+      "type": "ExcessProfitTax",
+      "brackets": [
+        { "threshold": 200, "tax": 50 },
+        { "threshold": 150, "tax": 40 },
+        { "threshold": 100, "tax": 30 },
+        { "threshold": 50, "tax": 20 },
+        { "threshold": 0, "tax": 0 }
+      ]
+    }
+  },
+  {
+    "id": 125,
+    "type": "Derailment",
+    "title": "Derailment!",
+    "description": "All trains within 3 mileposts of Paris or Bruxelles lose 1 turn and 1 load.",
+    "effectConfig": {
+      "type": "Derailment",
+      "cities": ["Paris", "Bruxelles"],
+      "radius": 3
+    }
+  },
+  {
+    "id": 126,
+    "type": "Derailment",
+    "title": "Derailment!",
+    "description": "All trains within 3 mileposts of Frankfurt or Stuttgart lose 1 turn and 1 load.",
+    "effectConfig": {
+      "type": "Derailment",
+      "cities": ["Frankfurt", "Stuttgart"],
+      "radius": 3
+    }
+  },
+  {
+    "id": 127,
+    "type": "Derailment",
+    "title": "Derailment!",
+    "description": "All trains within 3 mileposts of Wien or Budapest lose 1 turn and 1 load.",
+    "effectConfig": {
+      "type": "Derailment",
+      "cities": ["Wien", "Budapest"],
+      "radius": 3
+    }
+  },
+  {
+    "id": 128,
+    "type": "Derailment",
+    "title": "Derailment!",
+    "description": "All trains within 3 mileposts of Milano or Torino lose 1 turn and 1 load.",
+    "effectConfig": {
+      "type": "Derailment",
+      "cities": ["Milano", "Torino"],
+      "radius": 3
+    }
+  },
+  {
+    "id": 129,
+    "type": "Derailment",
+    "title": "Derailment!",
+    "description": "All trains within 3 mileposts of Warszawa or Krakow lose 1 turn and 1 load.",
+    "effectConfig": {
+      "type": "Derailment",
+      "cities": ["Warszawa", "Krakow"],
+      "radius": 3
+    }
+  },
+  {
+    "id": 130,
+    "type": "Snow",
+    "title": "Snow!",
+    "description": "All trains within 6 mileposts of Torino move at half rate. No movement or railbuilding allowed in Alpine mileposts of the affected area.",
+    "effectConfig": {
+      "type": "Snow",
+      "centerCity": "Torino",
+      "radius": 6,
+      "blockedTerrain": [3]
+    }
+  },
+  {
+    "id": 131,
+    "type": "Snow",
+    "title": "Snow!",
+    "description": "All trains within 4 mileposts of München (Munich) move at half rate. No movement or railbuilding allowed in mountain mileposts of the affected area.",
+    "effectConfig": {
+      "type": "Snow",
+      "centerCity": "München",
+      "radius": 4,
+      "blockedTerrain": [2]
+    }
+  },
+  {
+    "id": 132,
+    "type": "Snow",
+    "title": "Snow!",
+    "description": "All trains within 4 mileposts of Praha (Prague) move at half rate. No movement or railbuilding allowed in mountain mileposts of the affected area.",
+    "effectConfig": {
+      "type": "Snow",
+      "centerCity": "Praha",
+      "radius": 4,
+      "blockedTerrain": [2]
+    }
+  },
+  {
+    "id": 133,
+    "type": "Flood",
+    "title": "Flood!",
+    "description": "Bridges crossing the Rhein are immediately erased. Track may be rebuilt after this event card is discarded.",
+    "effectConfig": {
+      "type": "Flood",
+      "river": "Rhein"
+    }
+  },
+  {
+    "id": 134,
+    "type": "Flood",
+    "title": "Flood!",
+    "description": "Bridges crossing the Donau are immediately erased. Track may be rebuilt after this event card is discarded.",
+    "effectConfig": {
+      "type": "Flood",
+      "river": "Donau"
+    }
+  },
+  {
+    "id": 135,
+    "type": "Flood",
+    "title": "Flood!",
+    "description": "Bridges crossing the Elbe are immediately erased. Track may be rebuilt after this event card is discarded.",
+    "effectConfig": {
+      "type": "Flood",
+      "river": "Elbe"
+    }
+  },
+  {
+    "id": 136,
+    "type": "Flood",
+    "title": "Flood!",
+    "description": "Bridges crossing the Po are immediately erased. Track may be rebuilt after this event card is discarded.",
+    "effectConfig": {
+      "type": "Flood",
+      "river": "Po"
+    }
+  },
+  {
+    "id": 137,
+    "type": "Flood",
+    "title": "Flood!",
+    "description": "Bridges crossing the Loire are immediately erased. Track may be rebuilt after this event card is discarded.",
+    "effectConfig": {
+      "type": "Flood",
+      "river": "Loire"
+    }
+  },
+  {
+    "id": 138,
+    "type": "Flood",
+    "title": "Flood!",
+    "description": "Bridges crossing the Siene are immediately erased. Track may be rebuilt after this event card is discarded.",
+    "effectConfig": {
+      "type": "Flood",
+      "river": "Siene"
+    }
+  },
+  {
+    "id": 139,
+    "type": "Flood",
+    "title": "Flood!",
+    "description": "Bridges crossing the Oder are immediately erased. Track may be rebuilt after this event card is discarded.",
+    "effectConfig": {
+      "type": "Flood",
+      "river": "Oder"
+    }
+  },
+  {
+    "id": 140,
+    "type": "Flood",
+    "title": "Flood!",
+    "description": "Bridges crossing the Vistula are immediately erased. Track may be rebuilt after this event card is discarded.",
+    "effectConfig": {
+      "type": "Flood",
+      "river": "Vistula"
+    }
+  }
+]

--- a/configuration/event_cards.json
+++ b/configuration/event_cards.json
@@ -122,7 +122,7 @@
     "description": "All trains within 4 mileposts of München (Munich) move at half rate. No movement or railbuilding allowed in mountain mileposts of the affected area.",
     "effectConfig": {
       "type": "Snow",
-      "centerCity": "München",
+      "centerCity": "Munchen",
       "radius": 4,
       "blockedTerrain": [2]
     }

--- a/db/migrations/036_add_games_active_event.sql
+++ b/db/migrations/036_add_games_active_event.sql
@@ -1,0 +1,14 @@
+-- Migration: Add active_event column to games table
+-- Version: 36
+-- Description: Adds a nullable JSONB column to store the currently active event card
+--              per game. At most one event can be active at a time (per rulebook rules).
+--              This column is populated by Project 3 (event effect processing).
+--              No backfill required -- existing rows default to NULL.
+--
+-- Shape (when populated by Project 3):
+--   { "cardId": 131, "drawingPlayerId": "uuid", "drawingPlayerIndex": 2, "expiresAfterTurnNumber": 17 }
+
+ALTER TABLE games ADD COLUMN active_event JSONB NULL;
+
+-- DOWN
+-- ALTER TABLE games DROP COLUMN active_event;

--- a/src/server/__tests__/ai/AIStrategyEngine.test.ts
+++ b/src/server/__tests__/ai/AIStrategyEngine.test.ts
@@ -73,7 +73,7 @@ jest.mock('../../services/demandDeckService', () => ({
   DemandDeckService: {
     getInstance: jest.fn(() => ({
       getCard: jest.fn(() => undefined),
-      drawCard: jest.fn(() => ({ id: 99, demands: [] })),
+      drawCard: jest.fn(() => ({ type: 'demand', card: { id: 99, demands: [] } })),
       discardCard: jest.fn(),
     })),
   },

--- a/src/server/__tests__/deckRoutes.events.test.ts
+++ b/src/server/__tests__/deckRoutes.events.test.ts
@@ -1,0 +1,153 @@
+/**
+ * API smoke tests for GET /api/deck/events endpoint.
+ *
+ * Verifies:
+ * - 401 Unauthorized when no JWT is provided
+ * - 401 Unauthorized when JWT is invalid
+ * - 200 OK with event card array when JWT is valid
+ * - Response contains event cards with correct structure
+ */
+
+import request from 'supertest';
+import express from 'express';
+import deckRoutes from '../routes/deckRoutes';
+import { AuthService } from '../services/authService';
+import { EventCardType } from '../../shared/types/EventCard';
+
+jest.mock('../services/authService');
+jest.mock('../services/demandDeckService', () => ({
+  demandDeckService: {
+    getAllCards: jest.fn(() => []),
+    getAllEventCards: jest.fn(() => [
+      {
+        id: 121,
+        type: EventCardType.Strike,
+        title: 'Coastal Strike!',
+        description: 'No train may pick up or deliver any load at any city within 3 mileposts of any coast.',
+        effectConfig: { type: EventCardType.Strike, variant: 'coastal', coastalRadius: 3 },
+      },
+      {
+        id: 130,
+        type: EventCardType.Snow,
+        title: 'Snow!',
+        description: 'All trains within 6 mileposts of Torino move at half rate.',
+        effectConfig: { type: EventCardType.Snow, centerCity: 'Torino', radius: 6, blockedTerrain: [3] },
+      },
+    ]),
+    getCard: jest.fn(),
+    reset: jest.fn(),
+    getDeckState: jest.fn(() => ({ totalCards: 166, drawPileSize: 166, discardPileSize: 0, dealtCardsCount: 0 })),
+  },
+}));
+
+const mockAuthService = AuthService as jest.Mocked<typeof AuthService>;
+
+const mockUser = {
+  id: 'test-user-id',
+  username: 'testuser',
+  email: 'test@example.com',
+  emailVerified: true,
+  createdAt: new Date(),
+  lastActive: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockTokenPayload = {
+  userId: 'test-user-id',
+  username: 'testuser',
+  email: 'test@example.com',
+  iat: Math.floor(Date.now() / 1000),
+  exp: Math.floor(Date.now() / 1000) + 900,
+};
+
+const app = express();
+app.use(express.json());
+app.use('/api/deck', deckRoutes);
+
+describe('GET /api/deck/events', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Authentication', () => {
+    it('should return 401 when no Authorization header is provided', async () => {
+      const response = await request(app).get('/api/deck/events');
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('UNAUTHORIZED');
+    });
+
+    it('should return 401 when token is invalid', async () => {
+      mockAuthService.verifyToken.mockReturnValue(null);
+      const response = await request(app)
+        .get('/api/deck/events')
+        .set('Authorization', 'Bearer invalid.token.here');
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('UNAUTHORIZED');
+    });
+
+    it('should return 401 when user no longer exists', async () => {
+      mockAuthService.verifyToken.mockReturnValue(mockTokenPayload);
+      mockAuthService.findUserById.mockResolvedValue(null);
+      const response = await request(app)
+        .get('/api/deck/events')
+        .set('Authorization', 'Bearer valid.token.here');
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('Happy path', () => {
+    beforeEach(() => {
+      mockAuthService.verifyToken.mockReturnValue(mockTokenPayload);
+      mockAuthService.findUserById.mockResolvedValue(mockUser);
+    });
+
+    it('should return 200 with event cards array', async () => {
+      const response = await request(app)
+        .get('/api/deck/events')
+        .set('Authorization', 'Bearer valid.token.here');
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('should return event cards with required fields (id, type, title, description, effectConfig)', async () => {
+      const response = await request(app)
+        .get('/api/deck/events')
+        .set('Authorization', 'Bearer valid.token.here');
+
+      expect(response.status).toBe(200);
+      const cards = response.body;
+      expect(cards.length).toBeGreaterThan(0);
+
+      const card = cards[0];
+      expect(card).toHaveProperty('id');
+      expect(card).toHaveProperty('type');
+      expect(card).toHaveProperty('title');
+      expect(card).toHaveProperty('description');
+      expect(card).toHaveProperty('effectConfig');
+    });
+
+    it('should return cards with valid EventCardType values', async () => {
+      const response = await request(app)
+        .get('/api/deck/events')
+        .set('Authorization', 'Bearer valid.token.here');
+
+      expect(response.status).toBe(200);
+      const validTypes = Object.values(EventCardType);
+      for (const card of response.body as any[]) {
+        expect(validTypes).toContain(card.type);
+      }
+    });
+
+    it('should include Strike and Snow card types in the response', async () => {
+      const response = await request(app)
+        .get('/api/deck/events')
+        .set('Authorization', 'Bearer valid.token.here');
+
+      expect(response.status).toBe(200);
+      const types = (response.body as any[]).map((c) => c.type);
+      expect(types).toContain(EventCardType.Strike);
+      expect(types).toContain(EventCardType.Snow);
+    });
+  });
+});

--- a/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
+++ b/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for DemandDeckService unified draw pile (demand cards + event cards).
+ *
+ * These tests verify:
+ * - The unified draw pile contains all 146 demand cards + 20 event cards = 166 total
+ * - drawCard() returns CardDrawResult with correct type discriminators
+ * - Event cards and demand cards are both present in the pool
+ * - ensureCardIsDealt, returnDealtCardToTop, returnDiscardedCardToDealt work for both card types
+ * - getAllEventCards() returns all 20 event cards
+ * - reset() restores unified pile of 166 cards
+ */
+import { DemandDeckService } from '../services/demandDeckService';
+import { EventCardType } from '../../shared/types/EventCard';
+
+// Get the singleton and reset it to a clean state for each test
+function getFreshService(): DemandDeckService {
+  const service = DemandDeckService.getInstance();
+  service.reset();
+  return service;
+}
+
+describe('DemandDeckService unified draw pile', () => {
+  let service: DemandDeckService;
+
+  beforeEach(() => {
+    service = getFreshService();
+  });
+
+  describe('deck initialization', () => {
+    it('should have 166 total cards (146 demand + 20 event)', () => {
+      const state = service.getDeckState();
+      expect(state.totalCards).toBe(166);
+    });
+
+    it('should initialize draw pile with all 166 cards', () => {
+      const state = service.getDeckState();
+      expect(state.drawPileSize).toBe(166);
+      expect(state.discardPileSize).toBe(0);
+      expect(state.dealtCardsCount).toBe(0);
+    });
+
+    it('should have 20 event cards via getAllEventCards()', () => {
+      const eventCards = service.getAllEventCards();
+      expect(eventCards).toHaveLength(20);
+    });
+
+    it('should have event card IDs 121–140', () => {
+      const eventCards = service.getAllEventCards();
+      const ids = eventCards.map((c) => c.id).sort((a, b) => a - b);
+      const expected = Array.from({ length: 20 }, (_, i) => 121 + i);
+      expect(ids).toEqual(expected);
+    });
+
+    it('should return all demand cards via getAllCards()', () => {
+      const demandCards = service.getAllCards();
+      expect(demandCards).toHaveLength(146);
+    });
+
+    it('should return specific demand card via getCard()', () => {
+      const card = service.getCard(1);
+      expect(card).toBeDefined();
+      expect(card!.id).toBe(1);
+    });
+
+    it('should return demand card for ID 121 via getCard() (demand cards include 121)', () => {
+      // Demand card IDs go 1–146, so ID 121 is a demand card
+      const card = service.getCard(121);
+      expect(card).toBeDefined();
+      expect(card!.id).toBe(121);
+    });
+  });
+
+  describe('drawCard() — CardDrawResult discriminated union', () => {
+    it('should return CardDrawResult (not null) on first draw', () => {
+      const result = service.drawCard();
+      expect(result).not.toBeNull();
+      expect(result).toHaveProperty('type');
+      expect(result).toHaveProperty('card');
+    });
+
+    it('should return type "demand" or "event" on each draw', () => {
+      // Draw enough cards to likely get both types
+      const results: string[] = [];
+      for (let i = 0; i < 50; i++) {
+        const r = service.drawCard();
+        if (r) results.push(r.type);
+      }
+      expect(results.every((t) => t === 'demand' || t === 'event')).toBe(true);
+    });
+
+    it('should include event cards in the draw pile', () => {
+      // Draw all 166 cards
+      const drawnTypes: string[] = [];
+      let result = service.drawCard();
+      while (result !== null) {
+        drawnTypes.push(result.type);
+        // Don't add back to discard so pile empties
+        result = service.drawCard();
+        if (drawnTypes.length >= 166) break;
+      }
+      const eventDraws = drawnTypes.filter((t) => t === 'event');
+      const demandDraws = drawnTypes.filter((t) => t === 'demand');
+      expect(eventDraws.length).toBe(20);
+      expect(demandDraws.length).toBe(146);
+    });
+
+    it('should mark drawn card as dealt', () => {
+      const before = service.getDeckState();
+      service.drawCard();
+      const after = service.getDeckState();
+      expect(after.drawPileSize).toBe(before.drawPileSize - 1);
+      expect(after.dealtCardsCount).toBe(before.dealtCardsCount + 1);
+    });
+
+    it('should return null when deck and discard are both empty', () => {
+      // Draw all cards without discarding
+      for (let i = 0; i < 166; i++) {
+        service.drawCard();
+      }
+      const result = service.drawCard();
+      expect(result).toBeNull();
+    });
+
+    it('should reshuffle discard pile into draw pile when draw pile is empty', () => {
+      // Draw all 166 cards then discard them all using correct discard method per type
+      const drawnResults: Array<{ type: string; id: number }> = [];
+      for (let i = 0; i < 166; i++) {
+        const r = service.drawCard();
+        if (r) drawnResults.push({ type: r.type, id: r.card.id });
+      }
+      expect(drawnResults).toHaveLength(166);
+      // Discard all drawn cards using the appropriate method for each type
+      for (const { type, id } of drawnResults) {
+        if (type === 'event') {
+          service.discardEventCard(id);
+        } else {
+          service.discardCard(id);
+        }
+      }
+      // Now draw pile should reshuffle from discard
+      const afterDiscard = service.getDeckState();
+      expect(afterDiscard.discardPileSize).toBe(166);
+      expect(afterDiscard.drawPileSize).toBe(0);
+
+      const reshuffled = service.drawCard();
+      expect(reshuffled).not.toBeNull();
+      const afterReshuffle = service.getDeckState();
+      expect(afterReshuffle.drawPileSize + afterReshuffle.dealtCardsCount + afterReshuffle.discardPileSize).toBe(166);
+    });
+  });
+
+  describe('discardCard() — both card types', () => {
+    it('should discard a demand card by ID', () => {
+      const result = service.drawCard();
+      expect(result).not.toBeNull();
+      const cardId = result!.card.id;
+
+      service.discardCard(cardId);
+      const state = service.getDeckState();
+      expect(state.discardPileSize).toBe(1);
+      expect(state.dealtCardsCount).toBe(0);
+    });
+
+    it('should discard an event card by ID via discardEventCard()', () => {
+      // Draw until we get an event card
+      let eventCardId: number | null = null;
+      const demandDrawn: number[] = [];
+      for (let i = 0; i < 166; i++) {
+        const r = service.drawCard();
+        if (!r) break;
+        if (r.type === 'event') {
+          eventCardId = r.card.id;
+          break;
+        }
+        demandDrawn.push(r.card.id);
+        // Put demand cards back so we don't exhaust the deck
+        service.discardCard(r.card.id);
+      }
+      expect(eventCardId).not.toBeNull();
+      // Event card is now dealt — discard it via discardEventCard
+      service.discardEventCard(eventCardId!);
+      const state = service.getDeckState();
+      expect(state.dealtCardsCount).toBe(0);
+    });
+
+    it('should throw for an unknown card ID', () => {
+      expect(() => service.discardCard(99999)).toThrow('Invalid card ID: 99999');
+    });
+  });
+
+  describe('ensureCardIsDealt() — both card types', () => {
+    it('should mark a demand card as dealt', () => {
+      const demandCardId = service.getAllCards()[0].id;
+      const result = service.ensureCardIsDealt(demandCardId);
+      expect(result).toBe(true);
+      const state = service.getDeckState();
+      expect(state.dealtCardsCount).toBe(1);
+    });
+
+    it('should return false for event card IDs (ensureCardIsDealt is demand-only)', () => {
+      // Event card ID 121 is NOT a demand card in the context of reconciliation
+      // (demand cards use ID range 1-146, but event card IDs overlap; ensureCardIsDealt
+      // only affects demand card entries since player hands never hold event cards)
+      // ID 121 happens to be BOTH a demand card AND an event card — ensureCardIsDealt
+      // should handle it as a demand card
+      const result = service.ensureCardIsDealt(121);
+      expect(result).toBe(true); // 121 is a demand card, so this returns true
+    });
+
+    it('should return false for unknown card ID', () => {
+      const result = service.ensureCardIsDealt(99999);
+      expect(result).toBe(false);
+    });
+
+    it('should return true if card is already dealt', () => {
+      const cardId = service.getAllCards()[0].id;
+      service.ensureCardIsDealt(cardId);
+      const result = service.ensureCardIsDealt(cardId); // second call
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('returnDealtCardToTop() — both card types', () => {
+    it('should return a dealt demand card to draw pile', () => {
+      const r = service.drawCard();
+      expect(r).not.toBeNull();
+      const cardId = r!.card.id;
+
+      const success = service.returnDealtCardToTop(cardId);
+      expect(success).toBe(true);
+      const state = service.getDeckState();
+      expect(state.dealtCardsCount).toBe(0);
+      expect(state.drawPileSize).toBe(166);
+    });
+
+    it('should return false for a card not dealt', () => {
+      const cardId = service.getAllCards()[0].id;
+      const result = service.returnDealtCardToTop(cardId);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for unknown card ID', () => {
+      const result = service.returnDealtCardToTop(99999);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('returnDiscardedCardToDealt() — both card types', () => {
+    it('should move a discarded demand card back to dealt', () => {
+      const r = service.drawCard();
+      expect(r).not.toBeNull();
+      const cardId = r!.card.id;
+      service.discardCard(cardId);
+
+      const success = service.returnDiscardedCardToDealt(cardId);
+      expect(success).toBe(true);
+      const state = service.getDeckState();
+      expect(state.discardPileSize).toBe(0);
+      expect(state.dealtCardsCount).toBe(1);
+    });
+
+    it('should return false if card is not in discard pile', () => {
+      const cardId = service.getAllCards()[0].id;
+      const result = service.returnDiscardedCardToDealt(cardId);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for unknown card ID', () => {
+      const result = service.returnDiscardedCardToDealt(99999);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('reset()', () => {
+    it('should restore to full 166-card draw pile after reset', () => {
+      // Draw some cards and discard some
+      for (let i = 0; i < 10; i++) {
+        service.drawCard();
+      }
+      service.reset();
+      const state = service.getDeckState();
+      expect(state.totalCards).toBe(166);
+      expect(state.drawPileSize).toBe(166);
+      expect(state.discardPileSize).toBe(0);
+      expect(state.dealtCardsCount).toBe(0);
+    });
+  });
+
+  describe('event card type coverage', () => {
+    it('should have event cards of each type in the pool', () => {
+      const eventCards = service.getAllEventCards();
+      const types = new Set(eventCards.map((c) => c.type));
+      expect(types.has(EventCardType.Strike)).toBe(true);
+      expect(types.has(EventCardType.Derailment)).toBe(true);
+      expect(types.has(EventCardType.Snow)).toBe(true);
+      expect(types.has(EventCardType.Flood)).toBe(true);
+      expect(types.has(EventCardType.ExcessProfitTax)).toBe(true);
+    });
+  });
+});

--- a/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
+++ b/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
@@ -151,13 +151,26 @@ describe('DemandDeckService unified draw pile', () => {
 
   describe('discardCard() — both card types', () => {
     it('should discard a demand card by ID', () => {
-      const result = service.drawCard();
-      expect(result).not.toBeNull();
-      const cardId = result!.card.id;
+      // Draw until we get a demand card (unified deck may draw event cards first)
+      let demandResult: ReturnType<typeof service.drawCard> = null;
+      const eventCardsDrawn: number[] = [];
+      for (let i = 0; i < 166; i++) {
+        const r = service.drawCard();
+        if (!r) break;
+        if (r.type === 'demand') {
+          demandResult = r;
+          break;
+        }
+        // Discard event cards so they don't stay in dealt
+        service.discardEventCard(r.card.id);
+        eventCardsDrawn.push(r.card.id);
+      }
+      expect(demandResult).not.toBeNull();
+      const cardId = demandResult!.card.id;
 
       service.discardCard(cardId);
       const state = service.getDeckState();
-      expect(state.discardPileSize).toBe(1);
+      expect(state.discardPileSize).toBe(1 + eventCardsDrawn.length);
       expect(state.dealtCardsCount).toBe(0);
     });
 

--- a/src/server/__tests__/migration036_add_games_active_event.test.ts
+++ b/src/server/__tests__/migration036_add_games_active_event.test.ts
@@ -1,0 +1,178 @@
+import { db } from '../db';
+
+/**
+ * Tests for migration 036: Add active_event JSONB column to games table.
+ *
+ * These tests verify:
+ * - The `active_event` column exists with type JSONB and is nullable
+ * - Pre-existing game rows have active_event = NULL
+ * - New game rows default to active_event = NULL
+ * - The column accepts valid JSONB values and NULL
+ *
+ * Note: The migration is applied automatically via checkDatabase() in the
+ * beforeAll setup (src/server/__tests__/setup.ts). These tests verify the
+ * post-migration schema state.
+ */
+describe('Migration 036: games.active_event column', () => {
+  let testUserId: string;
+  let preExistingGameId: string;
+
+  beforeAll(async () => {
+    // Create a test user for game creation (games require created_by)
+    const userResult = await db.query(
+      `INSERT INTO users (username, email, password_hash)
+       VALUES ($1, $2, $3)
+       RETURNING id`,
+      ['migration036_testuser', 'migration036_test@example.com', 'hashedpassword']
+    );
+    testUserId = userResult.rows[0].id;
+
+    // Insert a game row that simulates a "pre-existing" row (before migration).
+    // Since the migration is already applied, active_event will default to NULL,
+    // which is exactly what we want to verify.
+    const gameResult = await db.query(
+      `INSERT INTO games (join_code, created_by, is_public, status)
+       VALUES (generate_unique_join_code(), $1, $2, $3)
+       RETURNING id`,
+      [testUserId, false, 'setup']
+    );
+    preExistingGameId = gameResult.rows[0].id;
+  });
+
+  afterAll(async () => {
+    // Clean up in reverse dependency order
+    await db.query('DELETE FROM games WHERE id = $1', [preExistingGameId]);
+    await db.query('DELETE FROM users WHERE id = $1', [testUserId]);
+  });
+
+  describe('Schema verification', () => {
+    it('should have active_event column on games table', async () => {
+      const result = await db.query(`
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'games'
+          AND column_name = 'active_event'
+      `);
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].column_name).toBe('active_event');
+    });
+
+    it('should have active_event column with type jsonb', async () => {
+      const result = await db.query(`
+        SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'games'
+          AND column_name = 'active_event'
+      `);
+
+      expect(result.rows[0].data_type).toBe('jsonb');
+    });
+
+    it('should have active_event column as nullable', async () => {
+      const result = await db.query(`
+        SELECT is_nullable
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'games'
+          AND column_name = 'active_event'
+      `);
+
+      expect(result.rows[0].is_nullable).toBe('YES');
+    });
+  });
+
+  describe('Data integrity', () => {
+    it('should have active_event = NULL for pre-existing game rows', async () => {
+      const result = await db.query(
+        'SELECT active_event FROM games WHERE id = $1',
+        [preExistingGameId]
+      );
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].active_event).toBeNull();
+    });
+
+    it('should default active_event to NULL for new game rows', async () => {
+      const newGameResult = await db.query(
+        `INSERT INTO games (join_code, created_by, is_public, status)
+         VALUES (generate_unique_join_code(), $1, $2, $3)
+         RETURNING id, active_event`,
+        [testUserId, false, 'setup']
+      );
+
+      expect(newGameResult.rows[0].active_event).toBeNull();
+
+      // Clean up
+      await db.query('DELETE FROM games WHERE id = $1', [newGameResult.rows[0].id]);
+    });
+
+    it('should allow setting active_event to a valid JSONB object', async () => {
+      const activeEventPayload = {
+        cardId: 131,
+        drawingPlayerId: 'some-player-uuid',
+        drawingPlayerIndex: 2,
+        expiresAfterTurnNumber: 17,
+      };
+
+      await db.query(
+        'UPDATE games SET active_event = $1 WHERE id = $2',
+        [JSON.stringify(activeEventPayload), preExistingGameId]
+      );
+
+      const result = await db.query(
+        'SELECT active_event FROM games WHERE id = $1',
+        [preExistingGameId]
+      );
+
+      expect(result.rows[0].active_event).toEqual(activeEventPayload);
+
+      // Reset back to NULL to clean up
+      await db.query(
+        'UPDATE games SET active_event = NULL WHERE id = $1',
+        [preExistingGameId]
+      );
+    });
+
+    it('should allow setting active_event back to NULL after a value was set', async () => {
+      // First set a value
+      await db.query(
+        `UPDATE games SET active_event = $1 WHERE id = $2`,
+        [JSON.stringify({ cardId: 125 }), preExistingGameId]
+      );
+
+      // Then clear it
+      await db.query(
+        'UPDATE games SET active_event = NULL WHERE id = $1',
+        [preExistingGameId]
+      );
+
+      const result = await db.query(
+        'SELECT active_event FROM games WHERE id = $1',
+        [preExistingGameId]
+      );
+
+      expect(result.rows[0].active_event).toBeNull();
+    });
+  });
+
+  describe('Rollback verification', () => {
+    // The project migration framework (checkDatabase in src/server/db/index.ts)
+    // applies migrations forward-only via schema_migrations version tracking.
+    // Down-migrations (DROP COLUMN) are not automatically executed by the framework.
+    // The rollback SQL is documented in the migration file comment as:
+    //   -- ALTER TABLE games DROP COLUMN active_event;
+    // This can be run manually if a rollback is needed, but is not tested here
+    // because there is no automated down-migration runner in this project.
+    it('should document that rollback SQL is included in migration file comments', async () => {
+      // Verify migration 036 is tracked in schema_migrations
+      const result = await db.query(
+        'SELECT version FROM schema_migrations WHERE version = 36'
+      );
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].version).toBe(36);
+    });
+  });
+});

--- a/src/server/__tests__/mocks/demandDeck.mock.ts
+++ b/src/server/__tests__/mocks/demandDeck.mock.ts
@@ -1,6 +1,7 @@
 /**
  * Mock for DemandDeckService.
  * Provides configurable getCard/drawCard/discardCard for test scenarios.
+ * drawCard() returns CardDrawResult format: { type: 'demand', card: DemandCard }
  */
 
 export interface MockDemandCard {
@@ -10,6 +11,10 @@ export interface MockDemandCard {
 
 const cards = new Map<number, MockDemandCard>();
 let nextCardId = 200;
+
+function makeDemandResult(card: MockDemandCard) {
+  return { type: 'demand' as const, card };
+}
 
 const mockInstance = {
   getCard: jest.fn((id: number) => cards.get(id) ?? undefined),
@@ -24,7 +29,7 @@ const mockInstance = {
       ],
     };
     cards.set(id, card);
-    return card;
+    return makeDemandResult(card);
   }),
   discardCard: jest.fn(),
 };
@@ -66,7 +71,7 @@ export function resetDemandDeckMock(): void {
       ],
     };
     cards.set(id, card);
-    return card;
+    return makeDemandResult(card);
   });
   mockInstance.discardCard.mockReset();
   mockDemandDeckService.getInstance.mockReset().mockReturnValue(mockInstance);

--- a/src/server/__tests__/playerService.discardHand.test.ts
+++ b/src/server/__tests__/playerService.discardHand.test.ts
@@ -37,6 +37,11 @@ const { __mockClient: mockClient } = jest.requireMock('../db/index') as {
   __mockClient: { query: jest.Mock; release: jest.Mock };
 };
 
+/** Helper to create a demand CardDrawResult mock value */
+function demandResult(id: number) {
+  return { type: 'demand' as const, card: { id, demands: [] } };
+}
+
 describe('PlayerService.discardHandForPlayer', () => {
   const gameId = 'game-123';
   const playerId = 'player-456';
@@ -59,9 +64,9 @@ describe('PlayerService.discardHandForPlayer', () => {
   describe('happy path', () => {
     it('should discard hand and draw 3 new cards', async () => {
       (demandDeckService.drawCard as jest.Mock)
-        .mockReturnValueOnce({ id: 10, city: 'Berlin', demands: [] })
-        .mockReturnValueOnce({ id: 20, city: 'Paris', demands: [] })
-        .mockReturnValueOnce({ id: 30, city: 'Roma', demands: [] });
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
 
       mockClient.query.mockImplementation((sql: string) => {
         if (sql === 'BEGIN' || sql === 'COMMIT') return Promise.resolve();
@@ -86,9 +91,9 @@ describe('PlayerService.discardHandForPlayer', () => {
 
     it('should discard each old card via demandDeckService', async () => {
       (demandDeckService.drawCard as jest.Mock)
-        .mockReturnValueOnce({ id: 10 })
-        .mockReturnValueOnce({ id: 20 })
-        .mockReturnValueOnce({ id: 30 });
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
 
       mockClient.query.mockImplementation((sql: string) => {
         if (sql === 'BEGIN' || sql === 'COMMIT') return Promise.resolve();
@@ -111,9 +116,9 @@ describe('PlayerService.discardHandForPlayer', () => {
 
     it('should use FOR UPDATE row locking', async () => {
       (demandDeckService.drawCard as jest.Mock)
-        .mockReturnValueOnce({ id: 10 })
-        .mockReturnValueOnce({ id: 20 })
-        .mockReturnValueOnce({ id: 30 });
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
 
       mockClient.query.mockImplementation((sql: string) => {
         if (sql === 'BEGIN' || sql === 'COMMIT') return Promise.resolve();
@@ -136,9 +141,9 @@ describe('PlayerService.discardHandForPlayer', () => {
 
     it('should NOT advance the game turn', async () => {
       (demandDeckService.drawCard as jest.Mock)
-        .mockReturnValueOnce({ id: 10 })
-        .mockReturnValueOnce({ id: 20 })
-        .mockReturnValueOnce({ id: 30 });
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
 
       mockClient.query.mockImplementation((sql: string) => {
         if (sql === 'BEGIN' || sql === 'COMMIT') return Promise.resolve();
@@ -165,9 +170,9 @@ describe('PlayerService.discardHandForPlayer', () => {
 
     it('should handle null hand gracefully', async () => {
       (demandDeckService.drawCard as jest.Mock)
-        .mockReturnValueOnce({ id: 10 })
-        .mockReturnValueOnce({ id: 20 })
-        .mockReturnValueOnce({ id: 30 });
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
 
       mockClient.query.mockImplementation((sql: string) => {
         if (sql === 'BEGIN' || sql === 'COMMIT') return Promise.resolve();
@@ -207,7 +212,7 @@ describe('PlayerService.discardHandForPlayer', () => {
   describe('draw failure', () => {
     it('should throw when deck is empty', async () => {
       (demandDeckService.drawCard as jest.Mock)
-        .mockReturnValueOnce({ id: 10 })
+        .mockReturnValueOnce(demandResult(10))
         .mockReturnValueOnce(null); // deck exhausted
 
       mockClient.query.mockImplementation((sql: string) => {
@@ -227,9 +232,9 @@ describe('PlayerService.discardHandForPlayer', () => {
   describe('transaction rollback on DB failure', () => {
     it('should rollback when hand UPDATE fails', async () => {
       (demandDeckService.drawCard as jest.Mock)
-        .mockReturnValueOnce({ id: 10 })
-        .mockReturnValueOnce({ id: 20 })
-        .mockReturnValueOnce({ id: 30 });
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
 
       mockClient.query.mockImplementation((sql: string) => {
         if (sql === 'BEGIN' || sql === 'ROLLBACK') return Promise.resolve();
@@ -290,11 +295,10 @@ describe('PlayerService.discardHandForUser — regression', () => {
   });
 
   function setupHappyPath(): void {
-    let queryCount = 0;
     (demandDeckService.drawCard as jest.Mock)
-      .mockReturnValueOnce({ id: 10 })
-      .mockReturnValueOnce({ id: 20 })
-      .mockReturnValueOnce({ id: 30 });
+      .mockReturnValueOnce(demandResult(10))
+      .mockReturnValueOnce(demandResult(20))
+      .mockReturnValueOnce(demandResult(30));
 
     mockClient.query.mockImplementation((sql: string, params?: any[]) => {
       if (sql === 'BEGIN' || sql === 'COMMIT') return Promise.resolve();

--- a/src/server/__tests__/playerService.discardHand.test.ts
+++ b/src/server/__tests__/playerService.discardHand.test.ts
@@ -27,6 +27,7 @@ jest.mock('../db/index', () => {
 jest.mock('../services/demandDeckService', () => ({
   demandDeckService: {
     discardCard: jest.fn(),
+    discardEventCard: jest.fn(),
     drawCard: jest.fn(),
     returnDealtCardToTop: jest.fn(),
     returnDiscardedCardToDealt: jest.fn(),
@@ -226,6 +227,95 @@ describe('PlayerService.discardHandForPlayer', () => {
       await expect(
         PlayerService.discardHandForPlayer(gameId, playerId),
       ).rejects.toThrow('Failed to draw new demand card');
+    });
+  });
+
+  describe('event card stub behavior', () => {
+    function eventResult(id: number) {
+      return {
+        type: 'event' as const,
+        card: {
+          id,
+          type: 1, // EventCardType.Strike (numeric)
+          title: 'Strike!',
+          description: 'Test event',
+          effectConfig: { effectType: 'strike', variant: 'coastal', coastalRadius: 3 },
+        },
+      };
+    }
+
+    beforeEach(() => {
+      mockClient.query.mockImplementation((sql: string) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT') return Promise.resolve();
+        if (sql.includes('SELECT hand')) {
+          return Promise.resolve({ rows: [{ hand: [1, 2, 3] }] });
+        }
+        if (sql.includes('UPDATE players')) {
+          return Promise.resolve({ rows: [] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+    });
+
+    it('should discard event cards and draw again until 3 demand cards are collected', async () => {
+      // First draw: event card, then 3 demand cards
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(eventResult(121))
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
+
+      const result = await PlayerService.discardHandForPlayer(gameId, playerId);
+
+      expect(result.newHandIds).toEqual([10, 20, 30]);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledTimes(1);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledWith(121);
+      // drawCard is called 4 times: 1 event + 3 demand
+      expect(demandDeckService.drawCard).toHaveBeenCalledTimes(4);
+    });
+
+    it('should discard multiple consecutive event cards and keep drawing', async () => {
+      // Two event cards before 3 demand cards
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(eventResult(121))
+        .mockReturnValueOnce(eventResult(122))
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
+
+      const result = await PlayerService.discardHandForPlayer(gameId, playerId);
+
+      expect(result.newHandIds).toEqual([10, 20, 30]);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledTimes(2);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledWith(121);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledWith(122);
+    });
+
+    it('should log a warning when an event card is drawn', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(eventResult(125))
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
+
+      await PlayerService.discardHandForPlayer(gameId, playerId);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnMessage = warnSpy.mock.calls[0][0] as string;
+      expect(warnMessage).toContain('125');
+    });
+
+    it('should not call discardEventCard when only demand cards are drawn', async () => {
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(demandResult(10))
+        .mockReturnValueOnce(demandResult(20))
+        .mockReturnValueOnce(demandResult(30));
+
+      await PlayerService.discardHandForPlayer(gameId, playerId);
+
+      expect(demandDeckService.discardEventCard).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/__tests__/playerService.discardHand.test.ts
+++ b/src/server/__tests__/playerService.discardHand.test.ts
@@ -236,10 +236,10 @@ describe('PlayerService.discardHandForPlayer', () => {
         type: 'event' as const,
         card: {
           id,
-          type: 1, // EventCardType.Strike (numeric)
+          type: 'Strike' as const, // EventCardType.Strike
           title: 'Strike!',
           description: 'Test event',
-          effectConfig: { effectType: 'strike', variant: 'coastal', coastalRadius: 3 },
+          effectConfig: { type: 'Strike' as const, variant: 'coastal' as const, coastalRadius: 3 },
         },
       };
     }

--- a/src/server/__tests__/playerService.fulfillDemand.test.ts
+++ b/src/server/__tests__/playerService.fulfillDemand.test.ts
@@ -1,0 +1,251 @@
+import { db } from '../db/index';
+import { PlayerService } from '../services/playerService';
+import { demandDeckService } from '../services/demandDeckService';
+
+// Mock socketService to prevent real socket emissions
+jest.mock('../services/socketService', () => ({
+  emitTurnChange: jest.fn(),
+  emitStatePatch: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Mock the database module
+jest.mock('../db/index', () => {
+  const mockClient = {
+    query: jest.fn(),
+    release: jest.fn(),
+  };
+  return {
+    db: {
+      connect: jest.fn().mockResolvedValue(mockClient),
+      query: jest.fn(),
+    },
+    __mockClient: mockClient,
+  };
+});
+
+// Mock DemandDeckService
+jest.mock('../services/demandDeckService', () => ({
+  demandDeckService: {
+    discardCard: jest.fn(),
+    discardEventCard: jest.fn(),
+    drawCard: jest.fn(),
+    returnDealtCardToTop: jest.fn(),
+    returnDiscardedCardToDealt: jest.fn(),
+  },
+}));
+
+const { __mockClient: mockClient } = jest.requireMock('../db/index') as {
+  __mockClient: { query: jest.Mock; release: jest.Mock };
+};
+
+/** Helper to create a demand CardDrawResult mock value */
+function demandResult(id: number) {
+  return { type: 'demand' as const, card: { id, demands: [] } };
+}
+
+/** Helper to create an event CardDrawResult mock value */
+function eventResult(id: number) {
+  return {
+    type: 'event' as const,
+    card: {
+      id,
+      type: 1, // EventCardType.Strike (numeric)
+      title: 'Strike!',
+      description: 'Test event card',
+      effectConfig: { effectType: 'strike', variant: 'coastal', coastalRadius: 3 },
+    },
+  };
+}
+
+describe('PlayerService.fulfillDemand', () => {
+  const gameId = 'game-123';
+  const playerId = 'player-456';
+  const city = 'Paris';
+  const loadType = 'Coal';
+  const cardId = 5;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function setupPlayerDb(hand: number[] = [cardId, 2, 3]): void {
+    mockClient.query.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT') return Promise.resolve();
+      if (sql.includes('SELECT hand, loads')) {
+        return Promise.resolve({ rows: [{ hand, loads: ['Coal'] }] });
+      }
+      if (sql.includes('UPDATE players')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  }
+
+  describe('demand card flow (happy path)', () => {
+    it('should return the new demand card after fulfilling a demand', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock).mockReturnValueOnce(demandResult(99));
+
+      const result = await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      expect(result.newCard).toBeDefined();
+      expect(result.newCard.id).toBe(99);
+    });
+
+    it('should draw exactly one card when first draw is a demand card', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock).mockReturnValueOnce(demandResult(99));
+
+      await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      expect(demandDeckService.drawCard).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update the player hand in the database', async () => {
+      setupPlayerDb([cardId, 2, 3]);
+      (demandDeckService.drawCard as jest.Mock).mockReturnValueOnce(demandResult(99));
+
+      await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      const updateCall = mockClient.query.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('UPDATE players'),
+      );
+      expect(updateCall).toBeDefined();
+      // New hand replaces cardId with new card id 99
+      expect(updateCall![1][0]).toEqual([99, 2, 3]);
+    });
+
+    it('should commit the transaction on success', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock).mockReturnValueOnce(demandResult(99));
+
+      await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+
+  describe('event card stub behavior', () => {
+    it('should discard event cards and return next demand card', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(eventResult(121))
+        .mockReturnValueOnce(demandResult(99));
+
+      const result = await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      expect(result.newCard.id).toBe(99);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledTimes(1);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledWith(121);
+    });
+
+    it('should discard multiple consecutive event cards before returning a demand card', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(eventResult(121))
+        .mockReturnValueOnce(eventResult(130))
+        .mockReturnValueOnce(demandResult(99));
+
+      const result = await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      expect(result.newCard.id).toBe(99);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledTimes(2);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledWith(121);
+      expect(demandDeckService.discardEventCard).toHaveBeenCalledWith(130);
+    });
+
+    it('should log a warning when an event card is drawn', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(eventResult(125))
+        .mockReturnValueOnce(demandResult(99));
+
+      await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnMessage = warnSpy.mock.calls[0][0] as string;
+      expect(warnMessage).toContain('125');
+    });
+
+    it('should not call discardEventCard when only demand cards are drawn', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock).mockReturnValueOnce(demandResult(99));
+
+      await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      expect(demandDeckService.discardEventCard).not.toHaveBeenCalled();
+    });
+
+    it('should draw again after event card until demand card found', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(eventResult(121))
+        .mockReturnValueOnce(demandResult(50));
+
+      await PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId);
+
+      // drawCard called twice: event card + demand card
+      expect(demandDeckService.drawCard).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw when player is not found', async () => {
+      mockClient.query.mockImplementation((sql: string) => {
+        if (sql === 'BEGIN' || sql === 'ROLLBACK') return Promise.resolve();
+        if (sql.includes('SELECT hand, loads')) {
+          return Promise.resolve({ rows: [] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      await expect(
+        PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId),
+      ).rejects.toThrow('Player not found');
+    });
+
+    it('should throw when deck is exhausted (all cards are null)', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock).mockReturnValue(null);
+
+      await expect(
+        PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId),
+      ).rejects.toThrow('Failed to draw new card');
+    });
+
+    it('should throw when deck is exhausted after event cards', async () => {
+      setupPlayerDb();
+      (demandDeckService.drawCard as jest.Mock)
+        .mockReturnValueOnce(eventResult(121))
+        .mockReturnValueOnce(null);
+
+      await expect(
+        PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId),
+      ).rejects.toThrow('Failed to draw new card');
+    });
+
+    it('should rollback transaction on DB error', async () => {
+      mockClient.query.mockImplementation((sql: string) => {
+        if (sql === 'BEGIN' || sql === 'ROLLBACK') return Promise.resolve();
+        if (sql.includes('SELECT hand, loads')) {
+          return Promise.reject(new Error('DB read error'));
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      await expect(
+        PlayerService.fulfillDemand(gameId, playerId, city, loadType, cardId),
+      ).rejects.toThrow('DB read error');
+
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/__tests__/playerService.fulfillDemand.test.ts
+++ b/src/server/__tests__/playerService.fulfillDemand.test.ts
@@ -49,10 +49,10 @@ function eventResult(id: number) {
     type: 'event' as const,
     card: {
       id,
-      type: 1, // EventCardType.Strike (numeric)
+      type: 'Strike' as const, // EventCardType.Strike
       title: 'Strike!',
       description: 'Test event card',
-      effectConfig: { effectType: 'strike', variant: 'coastal', coastalRadius: 3 },
+      effectConfig: { type: 'Strike' as const, variant: 'coastal' as const, coastalRadius: 3 },
     },
   };
 }

--- a/src/server/__tests__/playerService.test.ts
+++ b/src/server/__tests__/playerService.test.ts
@@ -1003,7 +1003,9 @@ describe('PlayerService Integration Tests', () => {
             expect(result.currentPlayerIndex).toBe(1);
 
             const afterDeck = demandDeckService.getDeckState();
-            expect(afterDeck.discardPileSize).toBe(beforeDeck.discardPileSize + 3);
+            // At least 3 cards discarded (old hand); may be more if event cards were drawn and discarded
+            expect(afterDeck.discardPileSize).toBeGreaterThanOrEqual(beforeDeck.discardPileSize + 3);
+            // All dealt cards should be accounted for (3 new hand cards dealt, same net count)
             expect(afterDeck.dealtCardsCount).toBe(beforeDeck.dealtCardsCount);
 
             const afterPlayerRow = await db.query('SELECT hand, current_turn_number FROM players WHERE id = $1', [playerId1]);

--- a/src/server/routes/deckRoutes.ts
+++ b/src/server/routes/deckRoutes.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { demandDeckService } from '../services/demandDeckService';
+import { authenticateToken } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
@@ -70,6 +71,20 @@ router.post('/reset', (req, res) => {
   } catch (error: any) {
     console.error('Error resetting deck:', error);
     return res.status(500).json({ 
+      error: 'Server error',
+      details: error.message || 'An unexpected error occurred'
+    });
+  }
+});
+
+// Get all event card definitions
+router.get('/events', authenticateToken, (req, res) => {
+  try {
+    const cards = demandDeckService.getAllEventCards();
+    return res.status(200).json(cards);
+  } catch (error: any) {
+    console.error('Error fetching event cards:', error);
+    return res.status(500).json({
       error: 'Server error',
       details: error.message || 'An unexpected error occurred'
     });

--- a/src/server/services/demandDeckService.ts
+++ b/src/server/services/demandDeckService.ts
@@ -1,16 +1,47 @@
 import fs from 'fs';
 import path from 'path';
 import { DemandCard, RawDemandCard } from '../../shared/types/DemandCard';
+import { EventCard, RawEventCard } from '../../shared/types/EventCard';
+import { CardDrawResult } from '../../shared/types/CardDrawResult';
+
+/**
+ * Internal draw-pile key encoding:
+ *   - Demand cards:  positive ID  (1 – 146)
+ *   - Event cards:   negative ID  (-(121) to -(140))
+ *
+ * This avoids collisions since demand cards 121-140 and event cards 121-140
+ * share the same numeric range in the original specification.
+ * Public APIs always use the real (positive) card IDs.
+ */
+function eventDrawKey(eventCardId: number): number {
+  return -eventCardId;
+}
 
 export class DemandDeckService {
   private static instance: DemandDeckService;
-  private cards: DemandCard[] = [];
-  private drawPile: number[] = [];  // Array of card IDs in the draw pile
-  private discardPile: number[] = [];  // Array of card IDs in the discard pile
-  private dealtCards: Set<number> = new Set();  // Set of card IDs currently dealt to players
-  
+  private demandCards: DemandCard[] = [];
+  private eventCards: EventCard[] = [];
+  /** Lookup by real (positive) ID for demand cards */
+  private demandCardMap: Map<number, DemandCard> = new Map();
+  /** Lookup by real (positive) ID for event cards */
+  private eventCardMap: Map<number, EventCard> = new Map();
+  /** Draw pile entries: positive = demand card ID, negative = -(event card ID) */
+  private drawPile: number[] = [];
+  /** Discard pile entries: same encoding as drawPile */
+  private discardPile: number[] = [];
+  /** Dealt entries: same encoding as drawPile (negative for event cards) */
+  private dealtCards: Set<number> = new Set();
+
   private constructor() {
     this.loadCards();
+  }
+
+  /**
+   * For testing only: destroy the singleton so the next getInstance() creates a fresh one.
+   * Do NOT call this in production code.
+   */
+  public static destroyInstanceForTesting(): void {
+    DemandDeckService.instance = undefined as unknown as DemandDeckService;
   }
 
   public static getInstance(): DemandDeckService {
@@ -22,13 +53,12 @@ export class DemandDeckService {
 
   private loadCards(): void {
     try {
-      // Read the JSON file
-      const configPath = path.resolve(__dirname, '../../../configuration/demand_cards.json');
-      const rawData = fs.readFileSync(configPath, 'utf8');
-      const jsonData = JSON.parse(rawData);
-      
-      // Transform raw cards into our internal format
-      this.cards = jsonData.DemandCards.map((card: RawDemandCard): DemandCard => ({
+      // Load demand cards
+      const demandConfigPath = path.resolve(__dirname, '../../../configuration/demand_cards.json');
+      const demandRawData = fs.readFileSync(demandConfigPath, 'utf8');
+      const demandJsonData = JSON.parse(demandRawData);
+
+      this.demandCards = demandJsonData.DemandCards.map((card: RawDemandCard): DemandCard => ({
         id: card.id,
         demands: card.demands.map(demand => ({
           city: demand.city,
@@ -37,17 +67,37 @@ export class DemandDeckService {
         }))
       }));
 
-      // Validate that each card has exactly 3 demands
-      const invalidCards = this.cards.filter(card => card.demands.length !== 3);
+      // Validate that each demand card has exactly 3 demands
+      const invalidCards = this.demandCards.filter(card => card.demands.length !== 3);
       if (invalidCards.length > 0) {
         throw new Error(`Found cards with incorrect number of demands: ${invalidCards.map(c => c.id).join(', ')}`);
       }
 
-      // Initialize draw pile with all card IDs
-      this.drawPile = this.cards.map(card => card.id);
+      // Load event cards
+      const eventConfigPath = path.resolve(__dirname, '../../../configuration/event_cards.json');
+      const eventRawData = fs.readFileSync(eventConfigPath, 'utf8');
+      const rawEventCards: RawEventCard[] = JSON.parse(eventRawData);
+
+      this.eventCards = rawEventCards.map((card: RawEventCard): EventCard => ({
+        id: card.id,
+        type: card.type,
+        title: card.title,
+        description: card.description,
+        effectConfig: card.effectConfig,
+      }));
+
+      // Build lookup maps (separate, no ID collision)
+      this.demandCardMap = new Map(this.demandCards.map(c => [c.id, c]));
+      this.eventCardMap = new Map(this.eventCards.map(c => [c.id, c]));
+
+      // Initialize unified draw pile: positive IDs for demand, negative for event
+      this.drawPile = [
+        ...this.demandCards.map(c => c.id),
+        ...this.eventCards.map(c => eventDrawKey(c.id)),
+      ];
       this.shuffleDrawPile();
     } catch (error) {
-      console.error('Failed to load demand cards:', error);
+      console.error('Failed to load cards:', error);
       throw error;
     }
   }
@@ -60,7 +110,19 @@ export class DemandDeckService {
     }
   }
 
-  public drawCard(): DemandCard | null {
+  /** Convert an internal draw-pile key to a CardDrawResult, or null if not found. */
+  private resolveDrawKey(drawKey: number): CardDrawResult | null {
+    if (drawKey > 0) {
+      const card = this.demandCardMap.get(drawKey);
+      return card ? { type: 'demand', card } : null;
+    } else {
+      const realId = -drawKey;
+      const card = this.eventCardMap.get(realId);
+      return card ? { type: 'event', card } : null;
+    }
+  }
+
+  public drawCard(): CardDrawResult | null {
     // If draw pile is empty, shuffle discard pile into draw pile
     if (this.drawPile.length === 0) {
       if (this.discardPile.length === 0) {
@@ -71,9 +133,9 @@ export class DemandDeckService {
       this.shuffleDrawPile();
     }
 
-    const cardId = this.drawPile.pop()!;
-    this.dealtCards.add(cardId);  // Mark card as dealt
-    return this.cards.find(card => card.id === cardId) || null;
+    const drawKey = this.drawPile.pop()!;
+    this.dealtCards.add(drawKey);
+    return this.resolveDrawKey(drawKey);
   }
 
   /**
@@ -85,91 +147,138 @@ export class DemandDeckService {
    * If the card is found in the draw pile or discard pile, it is removed from that pile to
    * prevent duplicates, then added to dealtCards.
    */
+  /**
+   * Ensure a demand card is marked as dealt in the in-memory deck state.
+   *
+   * This is used to reconcile deck state after a server restart: players' hands are persisted
+   * in Postgres, but the deck's dealtCards/drawPile/discardPile are currently in-memory only.
+   *
+   * Only applicable to demand cards (player hands never contain event cards).
+   */
   public ensureCardIsDealt(cardId: number): boolean {
-    if (!this.cards.find(card => card.id === cardId)) {
+    if (!this.demandCardMap.has(cardId)) {
       return false;
     }
-    if (this.dealtCards.has(cardId)) {
+    const drawKey = cardId; // Demand cards: drawKey === cardId (positive)
+    if (this.dealtCards.has(drawKey)) {
       return true;
     }
-    const drawIdx = this.drawPile.lastIndexOf(cardId);
+    const drawIdx = this.drawPile.lastIndexOf(drawKey);
     if (drawIdx !== -1) {
       this.drawPile.splice(drawIdx, 1);
     }
-    const discardIdx = this.discardPile.lastIndexOf(cardId);
+    const discardIdx = this.discardPile.lastIndexOf(drawKey);
     if (discardIdx !== -1) {
       this.discardPile.splice(discardIdx, 1);
     }
-    this.dealtCards.add(cardId);
+    this.dealtCards.add(drawKey);
     return true;
   }
 
+  /**
+   * Discard a demand card by its real ID.
+   * Called when a player's demand card is fulfilled or their hand is discarded.
+   * Do NOT call this for event cards — use discardEventCard() instead.
+   */
   public discardCard(cardId: number): void {
-    if (!this.cards.find(card => card.id === cardId)) {
+    const drawKey = cardId; // Demand cards use positive IDs as draw keys
+    if (!this.demandCardMap.has(cardId)) {
       throw new Error(`Invalid card ID: ${cardId}`);
     }
-    if (!this.dealtCards.has(cardId)) {
+    if (!this.dealtCards.has(drawKey)) {
       // Attempt to reconcile after restart: the card may be in a persisted player hand
       // but not in dealtCards. Ensure it's treated as dealt and removed from draw/discard.
-      const ok = this.ensureCardIsDealt(cardId);
-      if (!ok || !this.dealtCards.has(cardId)) {
+      this.ensureCardIsDealt(cardId);
+      if (!this.dealtCards.has(drawKey)) {
         throw new Error(`Card ${cardId} is not currently dealt to any player`);
       }
     }
-    this.dealtCards.delete(cardId);  // Remove from dealt cards
-    this.discardPile.push(cardId);
+    this.dealtCards.delete(drawKey);
+    this.discardPile.push(drawKey);
   }
 
   /**
-   * Return a currently-dealt card back to the top of the draw pile.
+   * Discard a drawn event card back to the discard pile.
+   * Called immediately after drawing an event card (event cards are never held in player hands).
+   */
+  public discardEventCard(eventCardId: number): void {
+    const drawKey = eventDrawKey(eventCardId);
+    if (!this.eventCardMap.has(eventCardId)) {
+      throw new Error(`Invalid event card ID: ${eventCardId}`);
+    }
+    if (!this.dealtCards.has(drawKey)) {
+      throw new Error(`Event card ${eventCardId} is not currently drawn`);
+    }
+    this.dealtCards.delete(drawKey);
+    this.discardPile.push(drawKey);
+  }
+
+  /**
+   * Return a currently-dealt demand card back to the top of the draw pile.
    * Used for server-authoritative undo of a delivery draw.
+   * Only applicable to demand cards.
    */
   public returnDealtCardToTop(cardId: number): boolean {
-    if (!this.cards.find(card => card.id === cardId)) {
+    if (!this.demandCardMap.has(cardId)) {
       return false;
     }
-    if (!this.dealtCards.has(cardId)) {
+    const drawKey = cardId; // demand card: positive key
+    if (!this.dealtCards.has(drawKey)) {
       return false;
     }
-    this.dealtCards.delete(cardId);
-    this.drawPile.push(cardId);
+    this.dealtCards.delete(drawKey);
+    this.drawPile.push(drawKey);
     return true;
   }
 
   /**
-   * Reverse a discard by moving a card from discard pile back into dealtCards.
+   * Reverse a discard by moving a demand card from discard pile back into dealtCards.
    * Used for server-authoritative undo of a delivery (restoring the discarded demand card to hand).
+   * Only applicable to demand cards.
    */
   public returnDiscardedCardToDealt(cardId: number): boolean {
-    if (!this.cards.find(card => card.id === cardId)) {
+    if (!this.demandCardMap.has(cardId)) {
       return false;
     }
-    const idx = this.discardPile.lastIndexOf(cardId);
+    const drawKey = cardId; // demand card: positive key
+    const idx = this.discardPile.lastIndexOf(drawKey);
     if (idx === -1) {
       return false;
     }
     this.discardPile.splice(idx, 1);
-    this.dealtCards.add(cardId);
+    this.dealtCards.add(drawKey);
     return true;
   }
 
+  /** Returns all demand cards (legacy accessor). */
   public getAllCards(): DemandCard[] {
-    return [...this.cards];
+    return [...this.demandCards];
   }
 
+  /** Returns a demand card by ID, or undefined if not found. */
   public getCard(cardId: number): DemandCard | undefined {
-    return this.cards.find(card => card.id === cardId);
+    return this.demandCardMap.get(cardId);
+  }
+
+  /** Returns all event card definitions. */
+  public getAllEventCards(): EventCard[] {
+    return [...this.eventCards];
+  }
+
+  /** Total number of unique cards in the unified pool (demand + event). */
+  get totalCardCount(): number {
+    return this.demandCards.length + this.eventCards.length;
   }
 
   // For debugging/testing purposes
-  public getDeckState(): { 
-    totalCards: number, 
-    drawPileSize: number, 
+  public getDeckState(): {
+    totalCards: number,
+    drawPileSize: number,
     discardPileSize: number,
     dealtCardsCount: number
   } {
     return {
-      totalCards: this.cards.length,
+      totalCards: this.demandCards.length + this.eventCards.length,
       drawPileSize: this.drawPile.length,
       discardPileSize: this.discardPile.length,
       dealtCardsCount: this.dealtCards.size
@@ -184,8 +293,11 @@ export class DemandDeckService {
     this.loadCards(); // Reload cards from JSON configuration to ensure fresh state
     this.dealtCards.clear();
     this.discardPile = [];
-    // Reinitialize draw pile with all card IDs
-    this.drawPile = this.cards.map(card => card.id);
+    // Reinitialize draw pile with all card IDs (demand + event)
+    this.drawPile = [
+      ...this.demandCards.map(c => c.id),
+      ...this.eventCards.map(c => eventDrawKey(c.id)),
+    ];
     this.shuffleDrawPile();
   }
 }

--- a/src/server/services/demandDeckService.ts
+++ b/src/server/services/demandDeckService.ts
@@ -250,6 +250,24 @@ export class DemandDeckService {
     return true;
   }
 
+  /**
+   * Return a discarded event card back to the top of the draw pile.
+   * Used for rollback compensation when a transaction fails after event cards were discarded.
+   */
+  public returnDiscardedEventCardToDrawPile(eventCardId: number): boolean {
+    if (!this.eventCardMap.has(eventCardId)) {
+      return false;
+    }
+    const drawKey = eventDrawKey(eventCardId);
+    const idx = this.discardPile.lastIndexOf(drawKey);
+    if (idx === -1) {
+      return false;
+    }
+    this.discardPile.splice(idx, 1);
+    this.drawPile.push(drawKey);
+    return true;
+  }
+
   /** Returns all demand cards (legacy accessor). */
   public getAllCards(): DemandCard[] {
     return [...this.demandCards];

--- a/src/server/services/playerService.ts
+++ b/src/server/services/playerService.ts
@@ -814,6 +814,7 @@ export class PlayerService {
     const client = await db.connect();
     let drewCardId: number | null = null;
     let discardedCardId: number | null = null;
+    const discardedEventCardIds: number[] = [];
     try {
       await client.query("BEGIN");
 
@@ -900,6 +901,7 @@ export class PlayerService {
       while (newDrawResult !== null && newDrawResult.type === 'event') {
         console.warn(`[deliverLoad] Drew event card ${newDrawResult.card.id} during hand replacement — discarding`);
         demandDeckService.discardEventCard(newDrawResult.card.id);
+        discardedEventCardIds.push(newDrawResult.card.id);
         newDrawResult = demandDeckService.drawCard();
       }
       if (!newDrawResult) {
@@ -965,6 +967,14 @@ export class PlayerService {
       if (typeof discardedCardId === "number") {
         try {
           demandDeckService.returnDiscardedCardToDealt(discardedCardId);
+        } catch {
+          // ignore
+        }
+      }
+      // Return any event cards that were discarded during the draw loop back to the draw pile.
+      for (const eventId of discardedEventCardIds) {
+        try {
+          demandDeckService.returnDiscardedEventCardToDrawPile(eventId);
         } catch {
           // ignore
         }
@@ -1634,7 +1644,8 @@ export class PlayerService {
     handIds: number[],
     client: import("pg").PoolClient,
     discardedIds: number[],
-    drawnIds: number[]
+    drawnIds: number[],
+    discardedEventIds: number[] = []
   ): Promise<{ newHandIds: number[] }> {
     // Discard old hand (must be currently dealt).
     for (const id of handIds) {
@@ -1654,6 +1665,7 @@ export class PlayerService {
         // Event cards drawn during hand replacement are discarded immediately
         console.warn(`[discardHandCore] Drew event card ${result.card.id} during hand replacement — discarding`);
         demandDeckService.discardEventCard(result.card.id);
+        discardedEventIds.push(result.card.id);
         continue;
       }
       newCards.push(result.card);
@@ -1683,6 +1695,7 @@ export class PlayerService {
     const client = await db.connect();
     const discardedIds: number[] = [];
     const drawnIds: number[] = [];
+    const discardedEventIds: number[] = [];
     try {
       await client.query("BEGIN");
 
@@ -1704,7 +1717,7 @@ export class PlayerService {
         ? currentHand.map((v) => Number(v)).filter((v) => Number.isFinite(v))
         : [];
 
-      const coreResult = await PlayerService.discardHandCore(gameId, playerId, handIds, client, discardedIds, drawnIds);
+      const coreResult = await PlayerService.discardHandCore(gameId, playerId, handIds, client, discardedIds, drawnIds, discardedEventIds);
 
       await client.query("COMMIT");
       return { newHandIds: coreResult.newHandIds };
@@ -1720,6 +1733,9 @@ export class PlayerService {
       }
       for (const id of discardedIds) {
         try { demandDeckService.returnDiscardedCardToDealt(id); } catch { /* best-effort */ }
+      }
+      for (const id of discardedEventIds) {
+        try { demandDeckService.returnDiscardedEventCardToDrawPile(id); } catch { /* best-effort */ }
       }
       throw err;
     } finally {
@@ -1754,6 +1770,7 @@ export class PlayerService {
     const client = await db.connect();
     const discardedIds: number[] = [];
     const drawnIds: number[] = [];
+    const discardedEventIds: number[] = [];
     try {
       await client.query("BEGIN");
 
@@ -1839,7 +1856,7 @@ export class PlayerService {
       // - no server-tracked turn_actions this turn
 
       // Core card logic: discard old hand, draw 3 new cards, persist.
-      const coreResult = await PlayerService.discardHandCore(gameId, playerId, handIds, client, discardedIds, drawnIds);
+      const coreResult = await PlayerService.discardHandCore(gameId, playerId, handIds, client, discardedIds, drawnIds, discardedEventIds);
 
       // Increment per-player turn count at END of the active player's turn.
       await client.query(
@@ -1904,6 +1921,13 @@ export class PlayerService {
       for (const id of discardedIds) {
         try {
           demandDeckService.returnDiscardedCardToDealt(id);
+        } catch {
+          // ignore
+        }
+      }
+      for (const id of discardedEventIds) {
+        try {
+          demandDeckService.returnDiscardedEventCardToDrawPile(id);
         } catch {
           // ignore
         }

--- a/src/server/services/playerService.ts
+++ b/src/server/services/playerService.ts
@@ -162,13 +162,19 @@ export class PlayerService {
 
     // ALWAYS draw 3 initial cards server-side (ignore any client-provided cards)
     // Cards must be drawn server-side to ensure proper deck management and prevent duplicates
+    // Event cards drawn during initial deal are discarded and replaced per game rules
     const handCardIds: number[] = [];
-    for (let i = 0; i < 3; i++) {
-      const card = demandDeckService.drawCard();
-      if (!card) {
-        throw new Error(`Failed to draw initial card ${i + 1} for player ${player.id}`);
+    while (handCardIds.length < 3) {
+      const drawResult = demandDeckService.drawCard();
+      if (!drawResult) {
+        throw new Error(`Failed to draw initial card ${handCardIds.length + 1} for player ${player.id}`);
       }
-      handCardIds.push(card.id);
+      if (drawResult.type === 'event') {
+        console.warn(`[addPlayer] Drew event card ${drawResult.card.id} during initial deal — discarding`);
+        demandDeckService.discardEventCard(drawResult.card.id);
+        continue;
+      }
+      handCardIds.push(drawResult.card.id);
     }
 
     const query = `
@@ -752,14 +758,22 @@ export class PlayerService {
 
       const player = playerResult.rows[0];
       
-      // Draw a new card from the deck first
-      const newCard = await demandDeckService.drawCard();
-      if (!newCard) {
+      // Draw a new demand card from the deck (discard any event cards drawn first)
+      let newCard: import('../../shared/types/DemandCard').DemandCard | null = null;
+      let drawResult = demandDeckService.drawCard();
+      while (drawResult !== null && drawResult.type === 'event') {
+        // Event cards drawn during hand-replacement are discarded immediately
+        console.warn(`[fulfillDemand] Drew event card ${drawResult.card.id} during hand replacement — discarding`);
+        demandDeckService.discardEventCard(drawResult.card.id);
+        drawResult = demandDeckService.drawCard();
+      }
+      if (drawResult === null) {
         throw new Error('Failed to draw new card');
       }
-      
+      newCard = drawResult.card;
+
       // Create the new hand by replacing the fulfilled card with the new card
-      const newHand = player.hand.map(id => id === cardId ? newCard.id : id);
+      const newHand = player.hand.map(id => id === cardId ? newCard!.id : id);
 
       // Update player's hand in database
       const updateQuery = `
@@ -881,10 +895,17 @@ export class PlayerService {
         throw new Error("Invalid payment");
       }
 
-      const newCard = demandDeckService.drawCard();
-      if (!newCard) {
+      // Draw a new demand card (discard any event cards encountered)
+      let newDrawResult = demandDeckService.drawCard();
+      while (newDrawResult !== null && newDrawResult.type === 'event') {
+        console.warn(`[deliverLoad] Drew event card ${newDrawResult.card.id} during hand replacement — discarding`);
+        demandDeckService.discardEventCard(newDrawResult.card.id);
+        newDrawResult = demandDeckService.drawCard();
+      }
+      if (!newDrawResult) {
         throw new Error("Failed to draw new card");
       }
+      const newCard = newDrawResult.card;
       drewCardId = newCard.id;
 
       const updatedHandIds = handIds.map((id) => (id === cardId ? newCard.id : id));
@@ -1622,14 +1643,21 @@ export class PlayerService {
     }
 
     // Draw replacement hand (future-proof loop structure).
+    // Event cards drawn during this process are discarded and replaced.
     const newCards: DemandCard[] = [];
     while (newCards.length < 3) {
-      const card = demandDeckService.drawCard();
-      if (!card) {
+      const result = demandDeckService.drawCard();
+      if (!result) {
         throw new Error("Failed to draw new demand card");
       }
-      newCards.push(card);
-      drawnIds.push(card.id);
+      if (result.type === 'event') {
+        // Event cards drawn during hand replacement are discarded immediately
+        console.warn(`[discardHandCore] Drew event card ${result.card.id} during hand replacement — discarding`);
+        demandDeckService.discardEventCard(result.card.id);
+        continue;
+      }
+      newCards.push(result.card);
+      drawnIds.push(result.card.id);
     }
     const newHandIds = newCards.map((c) => c.id);
 
@@ -1990,15 +2018,20 @@ export class PlayerService {
         discardedIds.push(id);
       }
 
-      // Draw replacement hand.
+      // Draw replacement hand (event cards discarded and replaced per game rules).
       const newCards: DemandCard[] = [];
       while (newCards.length < 3) {
-        const card = demandDeckService.drawCard();
-        if (!card) {
+        const result = demandDeckService.drawCard();
+        if (!result) {
           throw new Error("Failed to draw new demand card");
         }
-        newCards.push(card);
-        drawnIds.push(card.id);
+        if (result.type === 'event') {
+          console.warn(`[restartPlayer] Drew event card ${result.card.id} during restart hand — discarding`);
+          demandDeckService.discardEventCard(result.card.id);
+          continue;
+        }
+        newCards.push(result.card);
+        drawnIds.push(result.card.id);
       }
       const newHandIds = newCards.map((c) => c.id);
 

--- a/src/shared/types/CardDrawResult.ts
+++ b/src/shared/types/CardDrawResult.ts
@@ -1,0 +1,18 @@
+import { DemandCard } from './DemandCard';
+import { EventCard } from './EventCard';
+
+/**
+ * Discriminated union returned by DemandDeckService.drawCard().
+ *
+ * Callers must check `result.type` to determine which card was drawn:
+ *
+ * ```ts
+ * const result = deckService.drawCard();
+ * if (result === null) { // deck exhausted }
+ * else if (result.type === 'demand') { // result.card is DemandCard }
+ * else { // result.type === 'event', result.card is EventCard }
+ * ```
+ */
+export type CardDrawResult =
+  | { readonly type: 'demand'; readonly card: DemandCard }
+  | { readonly type: 'event'; readonly card: EventCard };

--- a/src/shared/types/EventCard.ts
+++ b/src/shared/types/EventCard.ts
@@ -1,0 +1,115 @@
+import { TerrainType } from './GameTypes';
+
+/**
+ * Enum representing the five event card types in Eurorails.
+ * Uses string values to match the existing codebase enum style (e.g. TrainType, AIActionType).
+ */
+export enum EventCardType {
+  Strike = 'Strike',
+  Derailment = 'Derailment',
+  Snow = 'Snow',
+  Flood = 'Flood',
+  ExcessProfitTax = 'ExcessProfitTax',
+}
+
+// ─── Per-type effect config interfaces ──────────────────────────────────────
+
+/**
+ * Strike event — two variants:
+ * - 'coastal': no pickup/delivery within coastalRadius mileposts of any coast
+ * - 'rail': the drawing player cannot move on their own track
+ */
+export interface StrikeEffect {
+  readonly type: EventCardType.Strike;
+  /** 'coastal' = near-coast restriction; 'rail' = drawing player's own rail */
+  readonly variant: 'coastal' | 'rail';
+  /** Radius in mileposts from any coast (coastal variant only) */
+  readonly coastalRadius?: number;
+  /** True if only the drawing player is affected (rail variant) */
+  readonly affectsDrawingPlayerOnly?: boolean;
+}
+
+/**
+ * Derailment event — all trains within `radius` mileposts of any listed city
+ * lose 1 turn and 1 load.
+ */
+export interface DerailmentEffect {
+  readonly type: EventCardType.Derailment;
+  /** Cities that are the epicentre of the derailment */
+  readonly cities: string[];
+  /** Radius in mileposts around each city */
+  readonly radius: number;
+}
+
+/**
+ * Snow event — trains within `radius` mileposts of `centerCity` move at half
+ * rate; no movement or rail-building allowed on `blockedTerrain` mileposts in
+ * the affected area.
+ */
+export interface SnowEffect {
+  readonly type: EventCardType.Snow;
+  readonly centerCity: string;
+  readonly radius: number;
+  /** Terrain types that are blocked for movement and building in the area */
+  readonly blockedTerrain: TerrainType[];
+}
+
+/**
+ * Flood event — bridges crossing the named river are immediately erased.
+ * The river name must match an entry in configuration/rivers.json.
+ */
+export interface FloodEffect {
+  readonly type: EventCardType.Flood;
+  readonly river: string;
+}
+
+/**
+ * Tax bracket used by the ExcessProfitTax event.
+ * Players with money >= `threshold` pay `tax` million ECU.
+ */
+export interface TaxBracket {
+  readonly threshold: number;
+  readonly tax: number;
+}
+
+/**
+ * Excess Profit Tax event — all players pay a sliding-scale tax based on
+ * their current cash holdings.
+ */
+export interface ExcessProfitTaxEffect {
+  readonly type: EventCardType.ExcessProfitTax;
+  /** Ordered tax brackets (highest threshold first) */
+  readonly brackets: TaxBracket[];
+}
+
+/** Discriminated union of all event effect configurations */
+export type EventEffectConfig =
+  | StrikeEffect
+  | DerailmentEffect
+  | SnowEffect
+  | FloodEffect
+  | ExcessProfitTaxEffect;
+
+// ─── EventCard interface ─────────────────────────────────────────────────────
+
+/** An event card loaded from configuration/event_cards.json */
+export interface EventCard {
+  /** Unique card ID — rulebook IDs 121–140 */
+  readonly id: number;
+  readonly type: EventCardType;
+  readonly title: string;
+  readonly description: string;
+  readonly effectConfig: EventEffectConfig;
+}
+
+/**
+ * Raw JSON shape for an event card as stored in configuration/event_cards.json.
+ * Mirrors EventCard but allows mutable fields for JSON.parse() results.
+ */
+export interface RawEventCard {
+  id: number;
+  type: EventCardType;
+  title: string;
+  description: string;
+  effectConfig: EventEffectConfig;
+}

--- a/src/shared/types/__tests__/EventCard.test.ts
+++ b/src/shared/types/__tests__/EventCard.test.ts
@@ -73,7 +73,7 @@ describe('EventCard types', () => {
     it('should narrow to SnowEffect on Snow type', () => {
       const effect: EventEffectConfig = {
         type: EventCardType.Snow,
-        centerCity: 'München',
+        centerCity: 'Munchen',
         radius: 4,
         blockedTerrain: [TerrainType.Mountain],
       };
@@ -81,7 +81,7 @@ describe('EventCard types', () => {
       switch (effect.type) {
         case EventCardType.Snow: {
           const snow: SnowEffect = effect;
-          expect(snow.centerCity).toBe('München');
+          expect(snow.centerCity).toBe('Munchen');
           expect(snow.radius).toBe(4);
           expect(snow.blockedTerrain).toContain(TerrainType.Mountain);
           break;
@@ -175,7 +175,7 @@ describe('EventCard types', () => {
         description: 'Test',
         effectConfig: {
           type: EventCardType.Snow,
-          centerCity: 'München',
+          centerCity: 'Munchen',
           radius: 4,
           blockedTerrain: [TerrainType.Mountain],
         },
@@ -258,7 +258,7 @@ describe('event_cards.json configuration', () => {
     });
     expect(card131.effectConfig).toMatchObject({
       type: EventCardType.Snow,
-      centerCity: 'München',
+      centerCity: 'Munchen',
       radius: 4,
       blockedTerrain: [TerrainType.Mountain],
     });

--- a/src/shared/types/__tests__/EventCard.test.ts
+++ b/src/shared/types/__tests__/EventCard.test.ts
@@ -1,0 +1,346 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  EventCard,
+  EventCardType,
+  EventEffectConfig,
+  RawEventCard,
+  StrikeEffect,
+  DerailmentEffect,
+  SnowEffect,
+  FloodEffect,
+  ExcessProfitTaxEffect,
+} from '../EventCard';
+import { TerrainType } from '../GameTypes';
+import { CardDrawResult } from '../CardDrawResult';
+
+describe('EventCard types', () => {
+  describe('EventCardType enum', () => {
+    it('should have exactly 5 values', () => {
+      const values = Object.values(EventCardType);
+      expect(values).toHaveLength(5);
+    });
+
+    it('should have expected string values', () => {
+      expect(EventCardType.Strike).toBe('Strike');
+      expect(EventCardType.Derailment).toBe('Derailment');
+      expect(EventCardType.Snow).toBe('Snow');
+      expect(EventCardType.Flood).toBe('Flood');
+      expect(EventCardType.ExcessProfitTax).toBe('ExcessProfitTax');
+    });
+  });
+
+  describe('EventEffectConfig discriminated union narrowing', () => {
+    it('should narrow to StrikeEffect on Strike type', () => {
+      const effect: EventEffectConfig = {
+        type: EventCardType.Strike,
+        variant: 'coastal',
+        coastalRadius: 3,
+      };
+
+      // TypeScript type narrowing via switch
+      switch (effect.type) {
+        case EventCardType.Strike: {
+          const strike: StrikeEffect = effect; // must narrow correctly
+          expect(strike.variant).toBe('coastal');
+          expect(strike.coastalRadius).toBe(3);
+          break;
+        }
+        default:
+          fail('Should have narrowed to Strike');
+      }
+    });
+
+    it('should narrow to DerailmentEffect on Derailment type', () => {
+      const effect: EventEffectConfig = {
+        type: EventCardType.Derailment,
+        cities: ['Paris', 'Berlin'],
+        radius: 3,
+      };
+
+      switch (effect.type) {
+        case EventCardType.Derailment: {
+          const derail: DerailmentEffect = effect;
+          expect(derail.cities).toEqual(['Paris', 'Berlin']);
+          expect(derail.radius).toBe(3);
+          break;
+        }
+        default:
+          fail('Should have narrowed to Derailment');
+      }
+    });
+
+    it('should narrow to SnowEffect on Snow type', () => {
+      const effect: EventEffectConfig = {
+        type: EventCardType.Snow,
+        centerCity: 'München',
+        radius: 4,
+        blockedTerrain: [TerrainType.Mountain],
+      };
+
+      switch (effect.type) {
+        case EventCardType.Snow: {
+          const snow: SnowEffect = effect;
+          expect(snow.centerCity).toBe('München');
+          expect(snow.radius).toBe(4);
+          expect(snow.blockedTerrain).toContain(TerrainType.Mountain);
+          break;
+        }
+        default:
+          fail('Should have narrowed to Snow');
+      }
+    });
+
+    it('should narrow to FloodEffect on Flood type', () => {
+      const effect: EventEffectConfig = {
+        type: EventCardType.Flood,
+        river: 'Rhein',
+      };
+
+      switch (effect.type) {
+        case EventCardType.Flood: {
+          const flood: FloodEffect = effect;
+          expect(flood.river).toBe('Rhein');
+          break;
+        }
+        default:
+          fail('Should have narrowed to Flood');
+      }
+    });
+
+    it('should narrow to ExcessProfitTaxEffect on ExcessProfitTax type', () => {
+      const effect: EventEffectConfig = {
+        type: EventCardType.ExcessProfitTax,
+        brackets: [
+          { threshold: 200, tax: 50 },
+          { threshold: 0, tax: 0 },
+        ],
+      };
+
+      switch (effect.type) {
+        case EventCardType.ExcessProfitTax: {
+          const tax: ExcessProfitTaxEffect = effect;
+          expect(tax.brackets).toHaveLength(2);
+          expect(tax.brackets[0].threshold).toBe(200);
+          break;
+        }
+        default:
+          fail('Should have narrowed to ExcessProfitTax');
+      }
+    });
+
+    it('should be exhaustive — switch covers all 5 types', () => {
+      const effects: EventEffectConfig[] = [
+        { type: EventCardType.Strike, variant: 'rail' },
+        { type: EventCardType.Derailment, cities: ['Paris'], radius: 3 },
+        { type: EventCardType.Snow, centerCity: 'Torino', radius: 6, blockedTerrain: [TerrainType.Alpine] },
+        { type: EventCardType.Flood, river: 'Elbe' },
+        { type: EventCardType.ExcessProfitTax, brackets: [] },
+      ];
+
+      let covered = 0;
+      for (const effect of effects) {
+        switch (effect.type) {
+          case EventCardType.Strike:
+          case EventCardType.Derailment:
+          case EventCardType.Snow:
+          case EventCardType.Flood:
+          case EventCardType.ExcessProfitTax:
+            covered++;
+            break;
+        }
+      }
+      expect(covered).toBe(5);
+    });
+  });
+
+  describe('CardDrawResult discriminated union', () => {
+    it('should narrow to DemandCard on demand type', () => {
+      const result: CardDrawResult = {
+        type: 'demand',
+        card: { id: 1, demands: [{ city: 'Berlin', resource: 'Cattle' as any, payment: 17 }, { city: 'Paris', resource: 'Beer' as any, payment: 23 }, { city: 'London', resource: 'Coal' as any, payment: 15 }] },
+      };
+
+      expect(result.type).toBe('demand');
+      if (result.type === 'demand') {
+        expect(result.card.id).toBe(1);
+      }
+    });
+
+    it('should narrow to EventCard on event type', () => {
+      const eventCard: EventCard = {
+        id: 131,
+        type: EventCardType.Snow,
+        title: 'Snow!',
+        description: 'Test',
+        effectConfig: {
+          type: EventCardType.Snow,
+          centerCity: 'München',
+          radius: 4,
+          blockedTerrain: [TerrainType.Mountain],
+        },
+      };
+
+      const result: CardDrawResult = { type: 'event', card: eventCard };
+      expect(result.type).toBe('event');
+      if (result.type === 'event') {
+        expect(result.card.id).toBe(131);
+        expect(result.card.type).toBe(EventCardType.Snow);
+      }
+    });
+  });
+});
+
+describe('event_cards.json configuration', () => {
+  const EVENT_CARDS_PATH = path.join(process.cwd(), 'configuration', 'event_cards.json');
+
+  let rawCards: RawEventCard[];
+
+  beforeAll(() => {
+    const jsonContent = fs.readFileSync(EVENT_CARDS_PATH, 'utf-8');
+    rawCards = JSON.parse(jsonContent) as RawEventCard[];
+  });
+
+  it('should load exactly 20 event cards', () => {
+    expect(rawCards).toHaveLength(20);
+  });
+
+  it('should have sequential IDs from 121 to 140', () => {
+    const ids = rawCards.map((c) => c.id).sort((a, b) => a - b);
+    const expected = Array.from({ length: 20 }, (_, i) => 121 + i);
+    expect(ids).toEqual(expected);
+  });
+
+  it('should have 3 Strike cards (#121, #122, #123)', () => {
+    const strikes = rawCards.filter((c) => c.type === EventCardType.Strike);
+    expect(strikes).toHaveLength(3);
+    const strikeIds = strikes.map((c) => c.id).sort((a, b) => a - b);
+    expect(strikeIds).toEqual([121, 122, 123]);
+  });
+
+  it('should have 1 ExcessProfitTax card (#124)', () => {
+    const taxCards = rawCards.filter((c) => c.type === EventCardType.ExcessProfitTax);
+    expect(taxCards).toHaveLength(1);
+    expect(taxCards[0].id).toBe(124);
+  });
+
+  it('should have 5 Derailment cards (#125-#129)', () => {
+    const derailments = rawCards.filter((c) => c.type === EventCardType.Derailment);
+    expect(derailments).toHaveLength(5);
+    const ids = derailments.map((c) => c.id).sort((a, b) => a - b);
+    expect(ids).toEqual([125, 126, 127, 128, 129]);
+  });
+
+  it('should have 3 Snow cards (#130-#132)', () => {
+    const snowCards = rawCards.filter((c) => c.type === EventCardType.Snow);
+    expect(snowCards).toHaveLength(3);
+    const ids = snowCards.map((c) => c.id).sort((a, b) => a - b);
+    expect(ids).toEqual([130, 131, 132]);
+  });
+
+  it('should have 8 Flood cards (#133-#140)', () => {
+    const floodCards = rawCards.filter((c) => c.type === EventCardType.Flood);
+    expect(floodCards).toHaveLength(8);
+    const ids = floodCards.map((c) => c.id).sort((a, b) => a - b);
+    expect(ids).toEqual([133, 134, 135, 136, 137, 138, 139, 140]);
+  });
+
+  it('should have correct Snow card configurations per rulebook', () => {
+    const card130 = rawCards.find((c) => c.id === 130)!;
+    const card131 = rawCards.find((c) => c.id === 131)!;
+    const card132 = rawCards.find((c) => c.id === 132)!;
+
+    expect(card130.effectConfig).toMatchObject({
+      type: EventCardType.Snow,
+      centerCity: 'Torino',
+      radius: 6,
+      blockedTerrain: [TerrainType.Alpine],
+    });
+    expect(card131.effectConfig).toMatchObject({
+      type: EventCardType.Snow,
+      centerCity: 'München',
+      radius: 4,
+      blockedTerrain: [TerrainType.Mountain],
+    });
+    expect(card132.effectConfig).toMatchObject({
+      type: EventCardType.Snow,
+      centerCity: 'Praha',
+      radius: 4,
+      blockedTerrain: [TerrainType.Mountain],
+    });
+  });
+
+  it('should have correct coastal Strike configurations with radius 3 for #121 and #122', () => {
+    const card121 = rawCards.find((c) => c.id === 121)!;
+    const card122 = rawCards.find((c) => c.id === 122)!;
+
+    expect(card121.effectConfig).toMatchObject({
+      type: EventCardType.Strike,
+      variant: 'coastal',
+      coastalRadius: 3,
+    });
+    expect(card122.effectConfig).toMatchObject({
+      type: EventCardType.Strike,
+      variant: 'coastal',
+      coastalRadius: 3,
+    });
+  });
+
+  it('should have correct rail Strike configuration for #123', () => {
+    const card123 = rawCards.find((c) => c.id === 123)!;
+
+    expect(card123.effectConfig).toMatchObject({
+      type: EventCardType.Strike,
+      variant: 'rail',
+      affectsDrawingPlayerOnly: true,
+    });
+  });
+
+  it('should have valid Flood card river names matching rivers.json', () => {
+    // Load rivers.json to validate names
+    const riversPath = path.join(process.cwd(), 'configuration', 'rivers.json');
+    const rivers: Array<{ Name: string }> = JSON.parse(fs.readFileSync(riversPath, 'utf-8'));
+    const validRiverNames = new Set(rivers.map((r) => r.Name));
+
+    const floodCards = rawCards.filter((c) => c.type === EventCardType.Flood);
+    for (const card of floodCards) {
+      const effect = card.effectConfig as FloodEffect;
+      expect(validRiverNames.has(effect.river)).toBe(true);
+    }
+  });
+
+  it('should have 8 distinct rivers in Flood cards', () => {
+    const floodCards = rawCards.filter((c) => c.type === EventCardType.Flood);
+    const rivers = new Set(floodCards.map((c) => (c.effectConfig as FloodEffect).river));
+    expect(rivers.size).toBe(8);
+  });
+
+  it('should have all cards with non-empty title and description', () => {
+    for (const card of rawCards) {
+      expect(card.title).toBeTruthy();
+      expect(card.description).toBeTruthy();
+    }
+  });
+
+  it('should have ExcessProfitTax card with tax brackets', () => {
+    const taxCard = rawCards.find((c) => c.type === EventCardType.ExcessProfitTax)!;
+    const effect = taxCard.effectConfig as ExcessProfitTaxEffect;
+    expect(effect.brackets).toBeDefined();
+    expect(effect.brackets.length).toBeGreaterThan(0);
+    // Verify bracket structure
+    for (const bracket of effect.brackets) {
+      expect(typeof bracket.threshold).toBe('number');
+      expect(typeof bracket.tax).toBe('number');
+    }
+  });
+
+  it('should have all Derailment cards with cities array and radius 3', () => {
+    const derailments = rawCards.filter((c) => c.type === EventCardType.Derailment);
+    for (const card of derailments) {
+      const effect = card.effectConfig as DerailmentEffect;
+      expect(effect.cities).toBeDefined();
+      expect(effect.cities.length).toBeGreaterThan(0);
+      expect(effect.radius).toBe(3);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `games.active_event` nullable JSONB column via migration `036_add_games_active_event.sql`
- Defines `EventCardType` enum, `EventCard` interface, and `CardDrawResult` union type in `src/shared/types/`
- Creates `configuration/event_cards.json` with all 20 event cards (#121–#140), including flood river assignments
- Unifies `DemandDeckService` to shuffle both 146 demand cards and 20 event cards into a single draw pile
- Adds `GET /api/deck/events` endpoint returning all event card definitions
- Stubs event card handling in `playerService` (`fulfillDemand`, `discardHandCore`) — event cards are logged + discarded, draw continues until a demand card is found

## Test plan

- [x] `npm run build` — compiles without errors
- [x] `npm test` — 2172 passing (100+ new tests added)
- [x] Migration test validates column addition, nullable default, rollback
- [x] EventCard type tests validate all 20 cards match rulebook
- [x] Unified deck draw tests verify mixed demand/event shuffling
- [x] API smoke tests for `GET /api/deck/events`
- [x] PlayerService stub tests verify event cards are discarded with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request implements a comprehensive event card system for the Eurorails AI game, extending the existing demand card mechanics to include 20 new event cards with various game effects. The changes introduce database schema extensions, new type definitions, unified deck management, API endpoints, and stub implementations for event card handling in player operations, while maintaining full backward compatibility with existing demand card functionality.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces nullable JSONB active_event column to games table in migration036_add_games_active_event.sql to track currently active event card effects per game instance.</li>

<li>Creates comprehensive event card type system with EventCardType enum, EventCard interface, and CardDrawResult discriminated union in src/shared/types/ to support type-safe event card definitions and draw operations.</li>

<li>Unifies DemandDeckService in src/server/services/demandDeckService.ts to manage combined pool of 166 cards (146 demand + 20 event) using internal key encoding to prevent ID collisions between card types.</li>

<li>Adds authenticated GET /api/deck/events endpoint in src/server/routes/deckRoutes.ts to provide access to all 20 event card definitions with proper security validation.</li>

<li>Implements stub event card handling in playerService.ts where drawn event cards are logged with warnings, immediately discarded, and drawing continues until demand cards are obtained for player hands.</li>

</ul>
</details>

</div>