### PR TITLE
feat: ActiveEffectManager core service for persistent event effects

### DIFF
--- a/docs/ActiveEffectManager.md
+++ b/docs/ActiveEffectManager.md
@@ -1,0 +1,251 @@
+# ActiveEffectManager API Reference
+
+## Overview
+
+`ActiveEffectManager` is a stateless service that manages persistent event card effects for the Eurorails game. It reads and writes the `games.active_event` JSONB array column to track effects that span multiple turns (e.g., Strike, Snow, Flood, Derailment). Every call reads from the database — there is no in-memory cache, guaranteeing correctness after server restarts.
+
+**File:** `src/server/services/ActiveEffectManager.ts`
+
+All write methods accept a `PoolClient` and require the caller to manage the transaction. Writes use `SELECT ... FOR UPDATE` to prevent concurrent modifications.
+
+---
+
+## Key Types
+
+Defined in `src/shared/types/EventCard.ts`:
+
+| Type | Description |
+|------|-------------|
+| `ActiveEffectRecord` | Persisted shape stored in `games.active_event` JSONB array |
+| `ActiveEffect` | Runtime shape returned by `getActiveEffects`; `affectedZone` is a `Set<string>` |
+| `MovementRestriction` | Restriction on train movement (`half_rate`, `blocked_terrain`, `no_movement_on_player_rail`) |
+| `BuildRestriction` | Restriction on track building (`blocked_terrain`, `no_build_for_player`) |
+| `PickupDeliveryRestriction` | Restriction on pickup/delivery in a zone (`no_pickup_delivery_in_zone`) |
+
+`games.active_event` stores a `ActiveEffectRecord[]` JSON array (or `null` when no effects are active).
+
+---
+
+## Class Definition
+
+```typescript
+class ActiveEffectManager {
+  async getActiveEffects(gameId: string): Promise<ActiveEffect[]>;
+
+  async addActiveEffect(
+    gameId: string,
+    descriptor: ActiveEffectDescriptor,
+    cardType: EventCardType,
+    perPlayerEffects: PerPlayerEffect[],
+    client: PoolClient,
+    riverName?: string,
+  ): Promise<void>;
+
+  async cleanupExpiredEffects(
+    gameId: string,
+    completedPlayerIndex: number,
+    completedTurnNumber: number,
+    client: PoolClient,
+  ): Promise<{ expiredCardIds: number[] }>;
+
+  async getMovementRestrictions(gameId: string): Promise<MovementRestriction[]>;
+  async getBuildRestrictions(gameId: string): Promise<BuildRestriction[]>;
+  async getPickupDeliveryRestrictions(gameId: string): Promise<PickupDeliveryRestriction[]>;
+
+  async consumeLostTurn(
+    gameId: string,
+    playerId: string,
+    client: PoolClient,
+  ): Promise<boolean>;
+}
+
+export const activeEffectManager = new ActiveEffectManager();
+```
+
+---
+
+## Methods
+
+### `getActiveEffects(gameId)`
+
+Reads all currently active effects from the database.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+
+**Returns:** `Promise<ActiveEffect[]>` — All active effects. Returns `[]` if `active_event` is null or empty.
+
+**Behavior:**
+- Reads `games.active_event` without locking (read-only).
+- Deserializes each `ActiveEffectRecord` into `ActiveEffect`, converting `affectedZone: string[]` to `affectedZone: Set<string>` for O(1) membership checks.
+
+**Example:**
+```typescript
+const effects = await activeEffectManager.getActiveEffects(gameId);
+for (const effect of effects) {
+  if (effect.affectedZone.has(playerMilepostKey)) {
+    // player is in the affected zone
+  }
+}
+```
+
+---
+
+### `addActiveEffect(gameId, descriptor, cardType, perPlayerEffects, client, riverName?)`
+
+Persists a new active effect by appending it to the `games.active_event` array inside the caller's transaction.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+- `descriptor: ActiveEffectDescriptor` — From `EventCardResult.persistentEffectDescriptor` (returned by `EventCardService.processEventCard`).
+- `cardType: EventCardType` — From the drawn event card's `.type` field.
+- `perPlayerEffects: PerPlayerEffect[]` — From `EventCardResult.perPlayerEffects`. Used to extract `pendingLostTurns` for Derailment cards.
+- `client: PoolClient` — Caller-owned database client (must already be in a transaction).
+- `riverName?: string` — **Flood only.** The river name from `effectConfig.river` (e.g., `"Rhine"`). Stored as `floodedRiver` for rebuild-blocking logic in SP-2.
+
+**Returns:** `Promise<void>`
+
+**Behavior:**
+- Uses `SELECT active_event FROM games WHERE id = $1 FOR UPDATE` to lock the game row.
+- Builds restriction arrays from `cardType` and `affectedZone`:
+  - **Strike (coastal, zone non-empty):** `PickupDeliveryRestriction` with `no_pickup_delivery_in_zone`
+  - **Strike (rail, zone empty):** `MovementRestriction` with `no_movement_on_player_rail` + `BuildRestriction` with `no_build_for_player`, both targeting `drawingPlayerId`
+  - **Snow:** `MovementRestriction` with `half_rate` + `blocked_terrain`, and `BuildRestriction` with `blocked_terrain`
+  - **Flood:** No restrictions (bridge removal handled in P2; rebuild blocking via `floodedRiver`)
+  - **Derailment:** No movement/build restrictions; extracts `pendingLostTurns` from `perPlayerEffects`
+- Appends the new `ActiveEffectRecord` to the existing array (or creates `[record]` if `active_event` is null).
+
+**Example:**
+```typescript
+await activeEffectManager.addActiveEffect(
+  gameId,
+  result.persistentEffectDescriptor!,
+  card.type,
+  result.perPlayerEffects,
+  client,
+  card.type === EventCardType.Flood
+    ? (card.effectConfig as FloodEffect).river
+    : undefined,
+);
+```
+
+---
+
+### `cleanupExpiredEffects(gameId, completedPlayerIndex, completedTurnNumber, client)`
+
+Removes all effects that have expired after the specified player's turn completion. Returns the card IDs of expired effects for socket broadcast.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+- `completedPlayerIndex: number` — Zero-based index of the player who just completed their turn.
+- `completedTurnNumber: number` — The turn number that just completed.
+- `client: PoolClient` — Caller-owned database client (must be in a transaction).
+
+**Returns:** `Promise<{ expiredCardIds: number[] }>` — Card IDs of effects that were removed. Empty array if none expired.
+
+**Behavior:**
+- Uses `SELECT ... FOR UPDATE` to lock the game row.
+- An effect expires when **both** conditions are true:
+  - `record.drawingPlayerIndex === completedPlayerIndex`
+  - `record.expiresAfterTurnNumber <= completedTurnNumber`
+- Writes the remaining (non-expired) effects back to `games.active_event`. Sets to `null` if all effects expired.
+- Per rulebook: effects expire "at the end of the drawing player's next turn."
+
+**Example:**
+```typescript
+const { expiredCardIds } = await activeEffectManager.cleanupExpiredEffects(
+  gameId,
+  currentPlayerIndex,
+  currentTurnNumber,
+  client,
+);
+// Broadcast expiredCardIds via socket
+```
+
+---
+
+### `getMovementRestrictions(gameId)`
+
+Aggregates movement restrictions across all active effects.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+
+**Returns:** `Promise<MovementRestriction[]>` — Union of all active effects' movement restrictions. Empty array if no effects are active.
+
+**Behavior:**
+- Calls `getActiveEffects` internally (read-only, no locking).
+- Concatenates `restrictions.movement` from all effects into a single array.
+- Callers apply all restrictions to determine whether a move is valid.
+
+---
+
+### `getBuildRestrictions(gameId)`
+
+Aggregates build restrictions across all active effects.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+
+**Returns:** `Promise<BuildRestriction[]>` — Union of all active effects' build restrictions. Empty array if no effects are active.
+
+---
+
+### `getPickupDeliveryRestrictions(gameId)`
+
+Aggregates pickup/delivery restrictions across all active effects.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+
+**Returns:** `Promise<PickupDeliveryRestriction[]>` — Union of all active effects' pickup/delivery restrictions. Empty array if no effects are active.
+
+---
+
+### `consumeLostTurn(gameId, playerId, client)`
+
+Removes a player's pending lost turn from the first matching active effect. A player loses **at most one turn** regardless of how many Derailment cards hit them simultaneously.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+- `playerId: string` — The player whose lost turn is being consumed.
+- `client: PoolClient` — Caller-owned database client (must be in a transaction).
+
+**Returns:** `Promise<boolean>` — `true` if the player had a pending lost turn that was consumed, `false` otherwise.
+
+**Behavior:**
+- Uses `SELECT ... FOR UPDATE` to lock the game row.
+- Scans all active effects' `pendingLostTurns` arrays for the player.
+- Removes the player from the **first** matching effect only (prevents double-consumption).
+- Writes the modified array back to `games.active_event`.
+
+**Example:**
+```typescript
+const hadLostTurn = await activeEffectManager.consumeLostTurn(gameId, playerId, client);
+if (hadLostTurn) {
+  // Skip player's turn — their turn has been consumed
+  return;
+}
+```
+
+---
+
+## Singleton Export
+
+A singleton instance is exported for use across the server:
+
+```typescript
+import { activeEffectManager } from '../services/ActiveEffectManager';
+```
+
+---
+
+## Dependency Notes
+
+This service is the foundation for P3 sub-projects:
+
+| Consumer | Usage |
+|----------|-------|
+| SP-2 (PlayerService) | Calls restriction query methods before validating moves/builds |
+| SP-3 (Turn lifecycle) | Calls `cleanupExpiredEffects` at turn end; `consumeLostTurn` at turn start |
+| SP-4 (SocketService) | Broadcasts `expiredCardIds` from `cleanupExpiredEffects` |

--- a/src/server/__tests__/ActiveEffectManager.test.ts
+++ b/src/server/__tests__/ActiveEffectManager.test.ts
@@ -180,7 +180,11 @@ describe('ActiveEffectManager', () => {
 
     it('should persist a Snow Alpine effect with half_rate and blocked_terrain', async () => {
       const client = makeMockClient([{ active_event: null }]);
-      const descriptor = makeDescriptor({ cardId: 130, affectedZone: ['mp-alpine-1'] });
+      const descriptor = makeDescriptor({
+        cardId: 130,
+        affectedZone: ['mp-alpine-1', 'mp-clear-2', 'mp-clear-3'],
+        blockedTerrainZone: ['mp-alpine-1'],
+      });
 
       await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Snow, [], client);
 
@@ -190,10 +194,18 @@ describe('ActiveEffectManager', () => {
       const jsonArg = JSON.parse((updateCall as any[])[1][0]);
       expect(jsonArg[0].cardType).toBe(EventCardType.Snow);
       const movRestrictions = jsonArg[0].restrictions.movement;
-      expect(movRestrictions.some((r: any) => r.type === 'half_rate')).toBe(true);
-      expect(movRestrictions.some((r: any) => r.type === 'blocked_terrain')).toBe(true);
+      // half_rate uses the full affectedZone
+      const halfRate = movRestrictions.find((r: any) => r.type === 'half_rate');
+      expect(halfRate).toBeDefined();
+      expect(halfRate.zone).toEqual(['mp-alpine-1', 'mp-clear-2', 'mp-clear-3']);
+      // blocked_terrain uses the narrower blockedTerrainZone
+      const blockedMov = movRestrictions.find((r: any) => r.type === 'blocked_terrain');
+      expect(blockedMov).toBeDefined();
+      expect(blockedMov.zone).toEqual(['mp-alpine-1']);
       const buildRestrictions = jsonArg[0].restrictions.build;
-      expect(buildRestrictions.some((r: any) => r.type === 'blocked_terrain')).toBe(true);
+      const blockedBuild = buildRestrictions.find((r: any) => r.type === 'blocked_terrain');
+      expect(blockedBuild).toBeDefined();
+      expect(blockedBuild.zone).toEqual(['mp-alpine-1']);
     });
 
     it('should persist a Derailment effect with pendingLostTurns', async () => {

--- a/src/server/__tests__/ActiveEffectManager.test.ts
+++ b/src/server/__tests__/ActiveEffectManager.test.ts
@@ -1,0 +1,648 @@
+/**
+ * Unit tests for ActiveEffectManager.
+ *
+ * Mocks the DB pool and PoolClient to control JSONB content.
+ * Tests all methods and edge cases as specified in the testing strategy.
+ */
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// ── Mock DB ──────────────────────────────────────────────────────────────────
+jest.mock('../db/index', () => ({
+  db: {
+    query: jest.fn<() => Promise<any>>(),
+  },
+}));
+
+import { ActiveEffectManager } from '../services/ActiveEffectManager';
+import { db } from '../db/index';
+import {
+  ActiveEffectDescriptor,
+  ActiveEffectRecord,
+  EventCardType,
+  PerPlayerEffect,
+} from '../../shared/types/EventCard';
+import { PoolClient } from 'pg';
+
+const mockDb = db as unknown as { query: jest.Mock<() => Promise<any>> };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeMockClient(activeEventRows: any[] = []): jest.Mocked<PoolClient> {
+  const client = {
+    query: jest.fn<() => Promise<any>>().mockResolvedValue({ rows: activeEventRows }),
+  } as unknown as jest.Mocked<PoolClient>;
+  return client;
+}
+
+function makeDescriptor(overrides: Partial<ActiveEffectDescriptor> = {}): ActiveEffectDescriptor {
+  return {
+    cardId: 121,
+    drawingPlayerId: 'player-1',
+    drawingPlayerIndex: 0,
+    expiresAfterTurnNumber: 2,
+    affectedZone: ['mp-1-1', 'mp-1-2'],
+    ...overrides,
+  };
+}
+
+function makeActiveEffectRecord(overrides: Partial<ActiveEffectRecord> = {}): ActiveEffectRecord {
+  return {
+    cardId: 121,
+    cardType: 'Strike',
+    drawingPlayerId: 'player-1',
+    drawingPlayerIndex: 0,
+    drawingPlayerTurnNumber: 1,
+    expiresAfterTurnNumber: 2,
+    affectedZone: ['mp-1-1', 'mp-1-2'],
+    restrictions: {
+      movement: [],
+      build: [],
+      pickupDelivery: [{ type: 'no_pickup_delivery_in_zone', zone: ['mp-1-1', 'mp-1-2'] }],
+    },
+    pendingLostTurns: [],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const GAME_ID = 'game-uuid-1';
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ActiveEffectManager', () => {
+  let manager: ActiveEffectManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    manager = new ActiveEffectManager();
+  });
+
+  // ── getActiveEffects ──────────────────────────────────────────────────────
+
+  describe('getActiveEffects', () => {
+    it('should return empty array when active_event is null', async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: null }] });
+
+      const effects = await manager.getActiveEffects(GAME_ID);
+      expect(effects).toEqual([]);
+    });
+
+    it('should return empty array when active_event is empty array', async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: [] }] });
+
+      const effects = await manager.getActiveEffects(GAME_ID);
+      expect(effects).toEqual([]);
+    });
+
+    it('should return empty array when game row not found', async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [] });
+
+      const effects = await manager.getActiveEffects(GAME_ID);
+      expect(effects).toEqual([]);
+    });
+
+    it('should deserialize JSONB and rehydrate affectedZone as Set<string>', async () => {
+      const record = makeActiveEffectRecord();
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: [record] }] });
+
+      const effects = await manager.getActiveEffects(GAME_ID);
+
+      expect(effects).toHaveLength(1);
+      expect(effects[0].affectedZone).toBeInstanceOf(Set);
+      expect(effects[0].affectedZone).toEqual(new Set(['mp-1-1', 'mp-1-2']));
+      expect(effects[0].cardId).toBe(121);
+      expect(effects[0].cardType).toBe(EventCardType.Strike);
+    });
+
+    it('should return multiple effects when array has multiple entries', async () => {
+      const record1 = makeActiveEffectRecord({ cardId: 121 });
+      const record2 = makeActiveEffectRecord({ cardId: 130, cardType: 'Snow' });
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: [record1, record2] }] });
+
+      const effects = await manager.getActiveEffects(GAME_ID);
+      expect(effects).toHaveLength(2);
+      expect(effects[0].cardId).toBe(121);
+      expect(effects[1].cardId).toBe(130);
+    });
+
+    it('should preserve floodedRiver field when present', async () => {
+      const record = makeActiveEffectRecord({ cardType: 'Flood', floodedRiver: 'Rhine' });
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: [record] }] });
+
+      const effects = await manager.getActiveEffects(GAME_ID);
+      expect(effects[0].floodedRiver).toBe('Rhine');
+    });
+  });
+
+  // ── addActiveEffect ───────────────────────────────────────────────────────
+
+  describe('addActiveEffect', () => {
+    it('should persist a Strike coastal effect with correct restrictions', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor({ cardId: 121, affectedZone: ['mp-coast-1', 'mp-coast-2'] });
+
+      await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Strike, [], client);
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      expect(updateCall).toBeDefined();
+
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg).toHaveLength(1);
+      expect(jsonArg[0].cardId).toBe(121);
+      expect(jsonArg[0].cardType).toBe(EventCardType.Strike);
+      expect(jsonArg[0].restrictions.pickupDelivery).toHaveLength(1);
+      expect(jsonArg[0].restrictions.pickupDelivery[0].type).toBe('no_pickup_delivery_in_zone');
+      expect(jsonArg[0].restrictions.movement).toHaveLength(0);
+      expect(jsonArg[0].restrictions.build).toHaveLength(0);
+    });
+
+    it('should persist a Strike rail effect with movement and build restrictions', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      // Rail strike has empty affectedZone
+      const descriptor = makeDescriptor({ cardId: 123, affectedZone: [] });
+
+      await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Strike, [], client);
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg[0].restrictions.movement).toHaveLength(1);
+      expect(jsonArg[0].restrictions.movement[0].type).toBe('no_movement_on_player_rail');
+      expect(jsonArg[0].restrictions.movement[0].targetPlayerId).toBe('player-1');
+      expect(jsonArg[0].restrictions.build).toHaveLength(1);
+      expect(jsonArg[0].restrictions.build[0].type).toBe('no_build_for_player');
+      expect(jsonArg[0].restrictions.build[0].targetPlayerId).toBe('player-1');
+      expect(jsonArg[0].restrictions.pickupDelivery).toHaveLength(0);
+    });
+
+    it('should persist a Snow Alpine effect with half_rate and blocked_terrain', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor({ cardId: 130, affectedZone: ['mp-alpine-1'] });
+
+      await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Snow, [], client);
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg[0].cardType).toBe(EventCardType.Snow);
+      const movRestrictions = jsonArg[0].restrictions.movement;
+      expect(movRestrictions.some((r: any) => r.type === 'half_rate')).toBe(true);
+      expect(movRestrictions.some((r: any) => r.type === 'blocked_terrain')).toBe(true);
+      const buildRestrictions = jsonArg[0].restrictions.build;
+      expect(buildRestrictions.some((r: any) => r.type === 'blocked_terrain')).toBe(true);
+    });
+
+    it('should persist a Derailment effect with pendingLostTurns', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor({ cardId: 125, affectedZone: ['mp-d-1'] });
+      const perPlayerEffects: PerPlayerEffect[] = [
+        { playerId: 'player-2', effectType: 'turn_lost', details: 'Derailment' },
+        { playerId: 'player-2', effectType: 'load_lost', details: 'Derailment', amount: 1 },
+        { playerId: 'player-3', effectType: 'turn_lost', details: 'Derailment' },
+      ];
+
+      await manager.addActiveEffect(
+        GAME_ID, descriptor, EventCardType.Derailment, perPlayerEffects, client,
+      );
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg[0].pendingLostTurns).toHaveLength(2);
+      expect(jsonArg[0].pendingLostTurns[0].playerId).toBe('player-2');
+      expect(jsonArg[0].pendingLostTurns[1].playerId).toBe('player-3');
+    });
+
+    it('should deduplicate pendingLostTurns (player in zone by multiple Derailments)', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor({ cardId: 125, affectedZone: [] });
+      // Player 2 appears twice with turn_lost (should appear once)
+      const perPlayerEffects: PerPlayerEffect[] = [
+        { playerId: 'player-2', effectType: 'turn_lost', details: 'Derailment' },
+        { playerId: 'player-2', effectType: 'turn_lost', details: 'Derailment' },
+      ];
+
+      await manager.addActiveEffect(
+        GAME_ID, descriptor, EventCardType.Derailment, perPlayerEffects, client,
+      );
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg[0].pendingLostTurns).toHaveLength(1);
+    });
+
+    it('should append to existing effects array (multi-effect)', async () => {
+      const existing = makeActiveEffectRecord({ cardId: 121 });
+      const client = makeMockClient([{ active_event: [existing] }]);
+      const descriptor = makeDescriptor({ cardId: 130 });
+
+      await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Snow, [], client);
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg).toHaveLength(2);
+      expect(jsonArg[0].cardId).toBe(121);
+      expect(jsonArg[1].cardId).toBe(130);
+    });
+
+    it('should create array from null active_event', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor();
+
+      await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Strike, [], client);
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg).toHaveLength(1);
+    });
+
+    it('should store floodedRiver for Flood events', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor({ cardId: 135, affectedZone: [] });
+
+      await manager.addActiveEffect(
+        GAME_ID, descriptor, EventCardType.Flood, [], client, 'Rhine',
+      );
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg[0].floodedRiver).toBe('Rhine');
+    });
+
+    it('should not set floodedRiver when riverName is not provided', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor();
+
+      await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Strike, [], client);
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg[0].floodedRiver).toBeUndefined();
+    });
+
+    it('should use SELECT FOR UPDATE to lock game row', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor();
+
+      await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Strike, [], client);
+
+      const lockCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('FOR UPDATE'),
+      );
+      expect(lockCall).toBeDefined();
+    });
+
+    it('should set drawingPlayerTurnNumber to expiresAfterTurnNumber - 1', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+      const descriptor = makeDescriptor({ expiresAfterTurnNumber: 5 });
+
+      await manager.addActiveEffect(GAME_ID, descriptor, EventCardType.Strike, [], client);
+
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg[0].drawingPlayerTurnNumber).toBe(4);
+    });
+  });
+
+  // ── cleanupExpiredEffects ─────────────────────────────────────────────────
+
+  describe('cleanupExpiredEffects', () => {
+    it('should return empty when no effects active', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+
+      const result = await manager.cleanupExpiredEffects(GAME_ID, 0, 2, client);
+      expect(result.expiredCardIds).toEqual([]);
+    });
+
+    it('should return empty when active_event is empty array', async () => {
+      const client = makeMockClient([{ active_event: [] }]);
+
+      const result = await manager.cleanupExpiredEffects(GAME_ID, 0, 2, client);
+      expect(result.expiredCardIds).toEqual([]);
+    });
+
+    it('should remove expired effect at correct turn boundary', async () => {
+      const record = makeActiveEffectRecord({
+        cardId: 121,
+        drawingPlayerIndex: 0,
+        expiresAfterTurnNumber: 2,
+      });
+      const client = makeMockClient([{ active_event: [record] }]);
+
+      const result = await manager.cleanupExpiredEffects(GAME_ID, 0, 2, client);
+
+      expect(result.expiredCardIds).toEqual([121]);
+      // Should write null or empty array
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      expect(updateCall).toBeDefined();
+    });
+
+    it('should keep non-expired effects', async () => {
+      const expired = makeActiveEffectRecord({
+        cardId: 121,
+        drawingPlayerIndex: 0,
+        expiresAfterTurnNumber: 2,
+      });
+      const notExpired = makeActiveEffectRecord({
+        cardId: 130,
+        drawingPlayerIndex: 1,
+        expiresAfterTurnNumber: 3,
+      });
+      const client = makeMockClient([{ active_event: [expired, notExpired] }]);
+
+      const result = await manager.cleanupExpiredEffects(GAME_ID, 0, 2, client);
+
+      expect(result.expiredCardIds).toEqual([121]);
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg).toHaveLength(1);
+      expect(jsonArg[0].cardId).toBe(130);
+    });
+
+    it('should handle multiple effects with different expiry times', async () => {
+      const records = [
+        makeActiveEffectRecord({ cardId: 121, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2 }),
+        makeActiveEffectRecord({ cardId: 122, drawingPlayerIndex: 0, expiresAfterTurnNumber: 3 }),
+        makeActiveEffectRecord({ cardId: 130, drawingPlayerIndex: 1, expiresAfterTurnNumber: 2 }),
+      ];
+      const client = makeMockClient([{ active_event: records }]);
+
+      // Player 0 completes turn 2
+      const result = await manager.cleanupExpiredEffects(GAME_ID, 0, 2, client);
+
+      // Only card 121 expires: playerIndex=0, expiresAfterTurn=2
+      expect(result.expiredCardIds).toEqual([121]);
+    });
+
+    it('should not expire effects for a different player completing their turn', async () => {
+      const record = makeActiveEffectRecord({
+        cardId: 121,
+        drawingPlayerIndex: 0,
+        expiresAfterTurnNumber: 2,
+      });
+      const client = makeMockClient([{ active_event: [record] }]);
+
+      // Player 1 completes turn 2, not player 0
+      const result = await manager.cleanupExpiredEffects(GAME_ID, 1, 2, client);
+
+      expect(result.expiredCardIds).toEqual([]);
+    });
+
+    it('should use SELECT FOR UPDATE to lock game row', async () => {
+      const client = makeMockClient([{ active_event: [] }]);
+
+      await manager.cleanupExpiredEffects(GAME_ID, 0, 2, client);
+
+      const lockCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('FOR UPDATE'),
+      );
+      expect(lockCall).toBeDefined();
+    });
+  });
+
+  // ── getMovementRestrictions ───────────────────────────────────────────────
+
+  describe('getMovementRestrictions', () => {
+    it('should return empty array when no active effects', async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: null }] });
+
+      const restrictions = await manager.getMovementRestrictions(GAME_ID);
+      expect(restrictions).toEqual([]);
+    });
+
+    it('should aggregate movement restrictions across multiple active effects', async () => {
+      const record1 = makeActiveEffectRecord({
+        cardId: 130,
+        cardType: 'Snow',
+        restrictions: {
+          movement: [{ type: 'half_rate', zone: ['mp-1'] }],
+          build: [],
+          pickupDelivery: [],
+        },
+      });
+      const record2 = makeActiveEffectRecord({
+        cardId: 131,
+        cardType: 'Snow',
+        restrictions: {
+          movement: [{ type: 'blocked_terrain', zone: ['mp-2'] }],
+          build: [],
+          pickupDelivery: [],
+        },
+      });
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: [record1, record2] }] });
+
+      const restrictions = await manager.getMovementRestrictions(GAME_ID);
+      expect(restrictions).toHaveLength(2);
+      expect(restrictions[0].type).toBe('half_rate');
+      expect(restrictions[1].type).toBe('blocked_terrain');
+    });
+  });
+
+  // ── getBuildRestrictions ──────────────────────────────────────────────────
+
+  describe('getBuildRestrictions', () => {
+    it('should return empty array when no active effects', async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: null }] });
+
+      const restrictions = await manager.getBuildRestrictions(GAME_ID);
+      expect(restrictions).toEqual([]);
+    });
+
+    it('should aggregate build restrictions across multiple active effects', async () => {
+      const record1 = makeActiveEffectRecord({
+        cardId: 123,
+        cardType: 'Strike',
+        restrictions: {
+          movement: [],
+          build: [{ type: 'no_build_for_player', targetPlayerId: 'player-1' }],
+          pickupDelivery: [],
+        },
+      });
+      const record2 = makeActiveEffectRecord({
+        cardId: 130,
+        cardType: 'Snow',
+        restrictions: {
+          movement: [],
+          build: [{ type: 'blocked_terrain', zone: ['mp-alpine-1'] }],
+          pickupDelivery: [],
+        },
+      });
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: [record1, record2] }] });
+
+      const restrictions = await manager.getBuildRestrictions(GAME_ID);
+      expect(restrictions).toHaveLength(2);
+    });
+  });
+
+  // ── getPickupDeliveryRestrictions ─────────────────────────────────────────
+
+  describe('getPickupDeliveryRestrictions', () => {
+    it('should return empty array when no active effects', async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: null }] });
+
+      const restrictions = await manager.getPickupDeliveryRestrictions(GAME_ID);
+      expect(restrictions).toEqual([]);
+    });
+
+    it('should aggregate pickup/delivery restrictions across multiple active effects', async () => {
+      const record1 = makeActiveEffectRecord({
+        cardId: 121,
+        restrictions: {
+          movement: [],
+          build: [],
+          pickupDelivery: [{ type: 'no_pickup_delivery_in_zone', zone: ['mp-coast-1'] }],
+        },
+      });
+      const record2 = makeActiveEffectRecord({
+        cardId: 122,
+        restrictions: {
+          movement: [],
+          build: [],
+          pickupDelivery: [{ type: 'no_pickup_delivery_in_zone', zone: ['mp-coast-2'] }],
+        },
+      });
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: [record1, record2] }] });
+
+      const restrictions = await manager.getPickupDeliveryRestrictions(GAME_ID);
+      expect(restrictions).toHaveLength(2);
+      expect(restrictions[0].zone).toEqual(['mp-coast-1']);
+      expect(restrictions[1].zone).toEqual(['mp-coast-2']);
+    });
+  });
+
+  // ── consumeLostTurn ───────────────────────────────────────────────────────
+
+  describe('consumeLostTurn', () => {
+    it('should return false when no active effects', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+
+      const result = await manager.consumeLostTurn(GAME_ID, 'player-2', client);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when player has no pending lost turn', async () => {
+      const record = makeActiveEffectRecord({
+        pendingLostTurns: [{ playerId: 'player-3' }],
+      });
+      const client = makeMockClient([{ active_event: [record] }]);
+
+      const result = await manager.consumeLostTurn(GAME_ID, 'player-2', client);
+      expect(result).toBe(false);
+    });
+
+    it('should remove player from pendingLostTurns and return true', async () => {
+      const record = makeActiveEffectRecord({
+        cardId: 125,
+        pendingLostTurns: [{ playerId: 'player-2' }, { playerId: 'player-3' }],
+      });
+      const client = makeMockClient([{ active_event: [record] }]);
+
+      const result = await manager.consumeLostTurn(GAME_ID, 'player-2', client);
+
+      expect(result).toBe(true);
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      expect(jsonArg[0].pendingLostTurns).toHaveLength(1);
+      expect(jsonArg[0].pendingLostTurns[0].playerId).toBe('player-3');
+    });
+
+    it('should only remove from first matching effect (one turn max)', async () => {
+      const record1 = makeActiveEffectRecord({
+        cardId: 125,
+        pendingLostTurns: [{ playerId: 'player-2' }],
+      });
+      const record2 = makeActiveEffectRecord({
+        cardId: 126,
+        pendingLostTurns: [{ playerId: 'player-2' }],
+      });
+      const client = makeMockClient([{ active_event: [record1, record2] }]);
+
+      const result = await manager.consumeLostTurn(GAME_ID, 'player-2', client);
+
+      expect(result).toBe(true);
+      const updateCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('UPDATE games'),
+      );
+      const jsonArg = JSON.parse((updateCall as any[])[1][0]);
+      // First effect should have player-2 removed
+      expect(jsonArg[0].pendingLostTurns).toHaveLength(0);
+      // Second effect should still have player-2 (not double-consumed)
+      expect(jsonArg[1].pendingLostTurns).toHaveLength(1);
+      expect(jsonArg[1].pendingLostTurns[0].playerId).toBe('player-2');
+    });
+
+    it('should use SELECT FOR UPDATE to lock game row', async () => {
+      const client = makeMockClient([{ active_event: null }]);
+
+      await manager.consumeLostTurn(GAME_ID, 'player-2', client);
+
+      const lockCall = (client.query as jest.Mock).mock.calls.find(
+        (c: any[]) => (c[0] as string).includes('FOR UPDATE'),
+      );
+      expect(lockCall).toBeDefined();
+    });
+  });
+
+  // ── Restart hydration (stateless design) ─────────────────────────────────
+
+  describe('Restart hydration (stateless design)', () => {
+    it('should correctly read back written ActiveEffectRecord from DB', async () => {
+      // Simulate: write an ActiveEffectRecord, then read back via getActiveEffects
+      const record: ActiveEffectRecord = {
+        cardId: 130,
+        cardType: 'Snow',
+        drawingPlayerId: 'player-1',
+        drawingPlayerIndex: 0,
+        drawingPlayerTurnNumber: 3,
+        expiresAfterTurnNumber: 4,
+        affectedZone: ['mp-alpine-1', 'mp-alpine-2'],
+        restrictions: {
+          movement: [{ type: 'half_rate', zone: ['mp-alpine-1', 'mp-alpine-2'] }],
+          build: [{ type: 'blocked_terrain', zone: ['mp-alpine-1', 'mp-alpine-2'] }],
+          pickupDelivery: [],
+        },
+        pendingLostTurns: [],
+        createdAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      // Simulate a fresh manager reading from DB (stateless)
+      mockDb.query.mockResolvedValueOnce({ rows: [{ active_event: [record] }] });
+
+      const freshManager = new ActiveEffectManager();
+      const effects = await freshManager.getActiveEffects(GAME_ID);
+
+      expect(effects).toHaveLength(1);
+      expect(effects[0].cardId).toBe(130);
+      expect(effects[0].cardType).toBe(EventCardType.Snow);
+      expect(effects[0].affectedZone).toBeInstanceOf(Set);
+      expect(effects[0].affectedZone.has('mp-alpine-1')).toBe(true);
+      expect(effects[0].affectedZone.has('mp-alpine-2')).toBe(true);
+      expect(effects[0].restrictions.movement[0].type).toBe('half_rate');
+      expect(effects[0].restrictions.build[0].type).toBe('blocked_terrain');
+      expect(effects[0].pendingLostTurns).toEqual([]);
+    });
+  });
+});

--- a/src/server/services/ActiveEffectManager.ts
+++ b/src/server/services/ActiveEffectManager.ts
@@ -72,7 +72,7 @@ export class ActiveEffectManager {
 
     const existing: ActiveEffectRecord[] = lockResult.rows[0]?.active_event ?? [];
 
-    const restrictions = this.buildRestrictions(cardType, descriptor.affectedZone, descriptor.drawingPlayerId);
+    const restrictions = this.buildRestrictions(cardType, descriptor.affectedZone, descriptor.drawingPlayerId, descriptor.blockedTerrainZone);
 
     const pendingLostTurns = this.extractPendingLostTurns(cardType, perPlayerEffects);
 
@@ -259,6 +259,7 @@ export class ActiveEffectManager {
     cardType: EventCardType,
     affectedZone: string[],
     drawingPlayerId: string,
+    blockedTerrainZone?: string[],
   ): ActiveEffectRecord['restrictions'] {
     const movement: MovementRestriction[] = [];
     const build: BuildRestriction[] = [];
@@ -280,23 +281,13 @@ export class ActiveEffectManager {
         break;
 
       case EventCardType.Snow:
-        // Snow cards produce half_rate movement restriction + blocked terrain for movement and build.
-        // Alpine (#130) blocks Alpine terrain; Mountain (#131, #132) blocks Mountain terrain.
-        // We check affectedZone presence to determine applicability; terrain type is
-        // determined by the card's effectConfig but we don't have it here.
-        // Per spec: Snow #130 (Alpine) → blocked_terrain: [Alpine]; Snow #131/#132 → [Mountain]
-        // Since we don't have the card config, we store both in the same structure.
-        // The caller (addActiveEffect) passes the full effectConfig-derived zone.
-        // We use a helper to determine which terrain was blocked from the card's effectConfig.
-        // Since we can't know at this level, we store restrictions without blockedTerrain
-        // and rely on the affectedZone for enforcement. For strict spec compliance, the
-        // terrain types will be set by the calling code if needed.
-        // For now, we use generic Snow restrictions with zone only.
+        // Half-rate applies to the full affected zone
         movement.push({ type: 'half_rate', zone: affectedZone });
-        // Blocked terrain movement restriction — terrain type per spec
-        // (Alpine for card 130, Mountain for 131/132). Store zone-based restriction.
-        movement.push({ type: 'blocked_terrain', zone: affectedZone });
-        build.push({ type: 'blocked_terrain', zone: affectedZone });
+        // Blocked terrain restrictions use the narrower blockedTerrainZone
+        // (mileposts filtered to only mountain/alpine terrain by EventCardService.processSnow).
+        // This prevents incorrectly banning movement/building on clear mileposts in the radius.
+        movement.push({ type: 'blocked_terrain', zone: blockedTerrainZone ?? affectedZone });
+        build.push({ type: 'blocked_terrain', zone: blockedTerrainZone ?? affectedZone });
         break;
 
       case EventCardType.Flood:

--- a/src/server/services/ActiveEffectManager.ts
+++ b/src/server/services/ActiveEffectManager.ts
@@ -1,0 +1,345 @@
+/**
+ * ActiveEffectManager — Stateless service for managing persistent event card effects.
+ *
+ * Reads and writes `games.active_event` JSONB array to manage persistent effects,
+ * compute restrictions, and handle Derailment turn-loss tracking.
+ *
+ * Design: Stateless singleton — no in-memory cache. Every call reads from DB.
+ * All write operations accept PoolClient to participate in caller's transaction
+ * with SELECT ... FOR UPDATE concurrency locking.
+ */
+
+import { PoolClient } from 'pg';
+import { db } from '../db/index';
+import {
+  ActiveEffect,
+  ActiveEffectDescriptor,
+  ActiveEffectRecord,
+  BuildRestriction,
+  EventCardType,
+  MovementRestriction,
+  PerPlayerEffect,
+  PickupDeliveryRestriction,
+} from '../../shared/types/EventCard';
+import { TerrainType } from '../../shared/types/GameTypes';
+
+export class ActiveEffectManager {
+  /**
+   * Read all currently active effects from DB.
+   * Deserializes JSONB array and rehydrates affectedZone as Set<string>.
+   */
+  async getActiveEffects(gameId: string): Promise<ActiveEffect[]> {
+    const result = await db.query(
+      `SELECT active_event FROM games WHERE id = $1`,
+      [gameId],
+    );
+
+    if (result.rows.length === 0) {
+      return [];
+    }
+
+    const records: ActiveEffectRecord[] | null = result.rows[0].active_event;
+    if (!records || records.length === 0) {
+      return [];
+    }
+
+    return records.map(record => this.rehydrateRecord(record));
+  }
+
+  /**
+   * Add a new active effect (appends to the array) inside caller's transaction.
+   *
+   * @param gameId           The game being affected
+   * @param descriptor       From EventCardResult.persistentEffectDescriptor
+   * @param cardType         From the drawn EventCard.type
+   * @param perPlayerEffects From EventCardResult.perPlayerEffects (for Derailment pendingLostTurns)
+   * @param client           Caller-owned PoolClient (must be in a transaction)
+   * @param riverName        Flood only — from effectConfig.river
+   */
+  async addActiveEffect(
+    gameId: string,
+    descriptor: ActiveEffectDescriptor,
+    cardType: EventCardType,
+    perPlayerEffects: PerPlayerEffect[],
+    client: PoolClient,
+    riverName?: string,
+  ): Promise<void> {
+    // Lock the game row to prevent concurrent modifications
+    const lockResult = await client.query(
+      `SELECT active_event FROM games WHERE id = $1 FOR UPDATE`,
+      [gameId],
+    );
+
+    const existing: ActiveEffectRecord[] = lockResult.rows[0]?.active_event ?? [];
+
+    const restrictions = this.buildRestrictions(cardType, descriptor.affectedZone, descriptor.drawingPlayerId);
+
+    const pendingLostTurns = this.extractPendingLostTurns(cardType, perPlayerEffects);
+
+    const newRecord: ActiveEffectRecord = {
+      cardId: descriptor.cardId,
+      cardType,
+      drawingPlayerId: descriptor.drawingPlayerId,
+      drawingPlayerIndex: descriptor.drawingPlayerIndex,
+      drawingPlayerTurnNumber: descriptor.expiresAfterTurnNumber - 1,
+      expiresAfterTurnNumber: descriptor.expiresAfterTurnNumber,
+      affectedZone: descriptor.affectedZone,
+      restrictions,
+      pendingLostTurns,
+      createdAt: new Date().toISOString(),
+    };
+
+    if (riverName !== undefined) {
+      newRecord.floodedRiver = riverName;
+    }
+
+    const updated = [...existing, newRecord];
+
+    await client.query(
+      `UPDATE games SET active_event = $1 WHERE id = $2`,
+      [JSON.stringify(updated), gameId],
+    );
+
+    console.info(
+      `[ActiveEffectManager] Persisted active effect: cardId=${descriptor.cardId} cardType=${cardType} gameId=${gameId}`,
+    );
+  }
+
+  /**
+   * Remove all expired effects after turn completion.
+   * Returns list of expired card IDs for socket notification.
+   *
+   * An effect expires when:
+   *   expiresAfterTurnNumber <= completedTurnNumber
+   *   AND drawingPlayerIndex === completedPlayerIndex
+   */
+  async cleanupExpiredEffects(
+    gameId: string,
+    completedPlayerIndex: number,
+    completedTurnNumber: number,
+    client: PoolClient,
+  ): Promise<{ expiredCardIds: number[] }> {
+    const lockResult = await client.query(
+      `SELECT active_event FROM games WHERE id = $1 FOR UPDATE`,
+      [gameId],
+    );
+
+    const records: ActiveEffectRecord[] | null = lockResult.rows[0]?.active_event;
+    if (!records || records.length === 0) {
+      return { expiredCardIds: [] };
+    }
+
+    const expiredCardIds: number[] = [];
+    const remaining: ActiveEffectRecord[] = [];
+
+    for (const record of records) {
+      const isExpired =
+        record.drawingPlayerIndex === completedPlayerIndex &&
+        record.expiresAfterTurnNumber <= completedTurnNumber;
+
+      if (isExpired) {
+        expiredCardIds.push(record.cardId);
+      } else {
+        remaining.push(record);
+      }
+    }
+
+    const updatedValue = remaining.length > 0 ? JSON.stringify(remaining) : null;
+    await client.query(
+      `UPDATE games SET active_event = $1 WHERE id = $2`,
+      [updatedValue, gameId],
+    );
+
+    if (expiredCardIds.length > 0) {
+      console.info(
+        `[ActiveEffectManager] Cleaned up expired effects: cardIds=${expiredCardIds.join(',')} gameId=${gameId}`,
+      );
+    }
+
+    return { expiredCardIds };
+  }
+
+  /**
+   * Aggregate movement restrictions across all active effects (read-only).
+   */
+  async getMovementRestrictions(gameId: string): Promise<MovementRestriction[]> {
+    const effects = await this.getActiveEffects(gameId);
+    return effects.flatMap(e => e.restrictions.movement);
+  }
+
+  /**
+   * Aggregate build restrictions across all active effects (read-only).
+   */
+  async getBuildRestrictions(gameId: string): Promise<BuildRestriction[]> {
+    const effects = await this.getActiveEffects(gameId);
+    return effects.flatMap(e => e.restrictions.build);
+  }
+
+  /**
+   * Aggregate pickup/delivery restrictions across all active effects (read-only).
+   */
+  async getPickupDeliveryRestrictions(gameId: string): Promise<PickupDeliveryRestriction[]> {
+    const effects = await this.getActiveEffects(gameId);
+    return effects.flatMap(e => e.restrictions.pickupDelivery);
+  }
+
+  /**
+   * Remove a player's pending lost turn from the first matching active effect.
+   * A player loses at most one turn total regardless of how many Derailments hit them.
+   *
+   * @returns true if player was found and removed, false otherwise
+   */
+  async consumeLostTurn(
+    gameId: string,
+    playerId: string,
+    client: PoolClient,
+  ): Promise<boolean> {
+    const lockResult = await client.query(
+      `SELECT active_event FROM games WHERE id = $1 FOR UPDATE`,
+      [gameId],
+    );
+
+    const records: ActiveEffectRecord[] | null = lockResult.rows[0]?.active_event;
+    if (!records || records.length === 0) {
+      return false;
+    }
+
+    let consumed = false;
+    const updated = records.map(record => {
+      if (consumed) return record;
+
+      const idx = record.pendingLostTurns.findIndex(p => p.playerId === playerId);
+      if (idx === -1) return record;
+
+      consumed = true;
+      const newPendingLostTurns = [
+        ...record.pendingLostTurns.slice(0, idx),
+        ...record.pendingLostTurns.slice(idx + 1),
+      ];
+      return { ...record, pendingLostTurns: newPendingLostTurns };
+    });
+
+    if (!consumed) {
+      return false;
+    }
+
+    await client.query(
+      `UPDATE games SET active_event = $1 WHERE id = $2`,
+      [JSON.stringify(updated), gameId],
+    );
+
+    console.info(
+      `[ActiveEffectManager] Consumed lost turn for player=${playerId} gameId=${gameId}`,
+    );
+
+    return true;
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────────
+
+  private rehydrateRecord(record: ActiveEffectRecord): ActiveEffect {
+    return {
+      cardId: record.cardId,
+      cardType: record.cardType as EventCardType,
+      drawingPlayerId: record.drawingPlayerId,
+      drawingPlayerIndex: record.drawingPlayerIndex,
+      expiresAfterTurnNumber: record.expiresAfterTurnNumber,
+      affectedZone: new Set(record.affectedZone),
+      restrictions: record.restrictions,
+      pendingLostTurns: record.pendingLostTurns,
+      floodedRiver: record.floodedRiver,
+    };
+  }
+
+  /**
+   * Build restriction arrays from cardType + affectedZone + drawingPlayerId.
+   * Maps event type to restriction shape per the spec.
+   */
+  private buildRestrictions(
+    cardType: EventCardType,
+    affectedZone: string[],
+    drawingPlayerId: string,
+  ): ActiveEffectRecord['restrictions'] {
+    const movement: MovementRestriction[] = [];
+    const build: BuildRestriction[] = [];
+    const pickupDelivery: PickupDeliveryRestriction[] = [];
+
+    switch (cardType) {
+      case EventCardType.Strike:
+        // Coastal strike (#121, #122): no pickup/delivery in zone
+        // Rail strike (#123): no movement on player's rail + no build for player
+        // We distinguish via affectedZone: coastal has a zone, rail has empty zone
+        if (affectedZone.length > 0) {
+          // Coastal variant
+          pickupDelivery.push({ type: 'no_pickup_delivery_in_zone', zone: affectedZone });
+        } else {
+          // Rail variant — targeting drawing player only
+          movement.push({ type: 'no_movement_on_player_rail', targetPlayerId: drawingPlayerId });
+          build.push({ type: 'no_build_for_player', targetPlayerId: drawingPlayerId });
+        }
+        break;
+
+      case EventCardType.Snow:
+        // Snow cards produce half_rate movement restriction + blocked terrain for movement and build.
+        // Alpine (#130) blocks Alpine terrain; Mountain (#131, #132) blocks Mountain terrain.
+        // We check affectedZone presence to determine applicability; terrain type is
+        // determined by the card's effectConfig but we don't have it here.
+        // Per spec: Snow #130 (Alpine) → blocked_terrain: [Alpine]; Snow #131/#132 → [Mountain]
+        // Since we don't have the card config, we store both in the same structure.
+        // The caller (addActiveEffect) passes the full effectConfig-derived zone.
+        // We use a helper to determine which terrain was blocked from the card's effectConfig.
+        // Since we can't know at this level, we store restrictions without blockedTerrain
+        // and rely on the affectedZone for enforcement. For strict spec compliance, the
+        // terrain types will be set by the calling code if needed.
+        // For now, we use generic Snow restrictions with zone only.
+        movement.push({ type: 'half_rate', zone: affectedZone });
+        // Blocked terrain movement restriction — terrain type per spec
+        // (Alpine for card 130, Mountain for 131/132). Store zone-based restriction.
+        movement.push({ type: 'blocked_terrain', zone: affectedZone });
+        build.push({ type: 'blocked_terrain', zone: affectedZone });
+        break;
+
+      case EventCardType.Flood:
+        // No movement/build restrictions stored — bridge removal handled in P2.
+        // Rebuild blocking handled via floodedRiver field.
+        break;
+
+      case EventCardType.Derailment:
+        // No movement/build restrictions — only pendingLostTurns tracked.
+        break;
+
+      case EventCardType.ExcessProfitTax:
+        // Immediate effect only — not persisted.
+        break;
+    }
+
+    return { movement, build, pickupDelivery };
+  }
+
+  /**
+   * Extract pendingLostTurns for Derailment cards from perPlayerEffects.
+   * Only players with turn_lost effects are included.
+   */
+  private extractPendingLostTurns(
+    cardType: EventCardType,
+    perPlayerEffects: PerPlayerEffect[],
+  ): { playerId: string }[] {
+    if (cardType !== EventCardType.Derailment) {
+      return [];
+    }
+
+    const seen = new Set<string>();
+    const result: { playerId: string }[] = [];
+
+    for (const effect of perPlayerEffects) {
+      if (effect.effectType === 'turn_lost' && !seen.has(effect.playerId)) {
+        seen.add(effect.playerId);
+        result.push({ playerId: effect.playerId });
+      }
+    }
+
+    return result;
+  }
+}
+
+export const activeEffectManager = new ActiveEffectManager();

--- a/src/server/services/EventCardService.ts
+++ b/src/server/services/EventCardService.ts
@@ -351,6 +351,7 @@ export class EventCardService {
     const descriptor: ActiveEffectDescriptor = await buildDescriptor(
       card, drawingPlayerId, gameId, client, Array.from(halfRateZone),
     );
+    descriptor.blockedTerrainZone = Array.from(blockedTerrainZone);
 
     return {
       cardId: card.id,

--- a/src/server/services/docs/ActiveEffectManager.md
+++ b/src/server/services/docs/ActiveEffectManager.md
@@ -1,0 +1,251 @@
+# ActiveEffectManager API Reference
+
+## Overview
+
+`ActiveEffectManager` is a stateless service that manages persistent event card effects for the Eurorails game. It reads and writes the `games.active_event` JSONB array column to track effects that span multiple turns (e.g., Strike, Snow, Flood, Derailment). Every call reads from the database — there is no in-memory cache, guaranteeing correctness after server restarts.
+
+**File:** `src/server/services/ActiveEffectManager.ts`
+
+All write methods accept a `PoolClient` and require the caller to manage the transaction. Writes use `SELECT ... FOR UPDATE` to prevent concurrent modifications.
+
+---
+
+## Key Types
+
+Defined in `src/shared/types/EventCard.ts`:
+
+| Type | Description |
+|------|-------------|
+| `ActiveEffectRecord` | Persisted shape stored in `games.active_event` JSONB array |
+| `ActiveEffect` | Runtime shape returned by `getActiveEffects`; `affectedZone` is a `Set<string>` |
+| `MovementRestriction` | Restriction on train movement (`half_rate`, `blocked_terrain`, `no_movement_on_player_rail`) |
+| `BuildRestriction` | Restriction on track building (`blocked_terrain`, `no_build_for_player`) |
+| `PickupDeliveryRestriction` | Restriction on pickup/delivery in a zone (`no_pickup_delivery_in_zone`) |
+
+`games.active_event` stores a `ActiveEffectRecord[]` JSON array (or `null` when no effects are active).
+
+---
+
+## Class Definition
+
+```typescript
+class ActiveEffectManager {
+  async getActiveEffects(gameId: string): Promise<ActiveEffect[]>;
+
+  async addActiveEffect(
+    gameId: string,
+    descriptor: ActiveEffectDescriptor,
+    cardType: EventCardType,
+    perPlayerEffects: PerPlayerEffect[],
+    client: PoolClient,
+    riverName?: string,
+  ): Promise<void>;
+
+  async cleanupExpiredEffects(
+    gameId: string,
+    completedPlayerIndex: number,
+    completedTurnNumber: number,
+    client: PoolClient,
+  ): Promise<{ expiredCardIds: number[] }>;
+
+  async getMovementRestrictions(gameId: string): Promise<MovementRestriction[]>;
+  async getBuildRestrictions(gameId: string): Promise<BuildRestriction[]>;
+  async getPickupDeliveryRestrictions(gameId: string): Promise<PickupDeliveryRestriction[]>;
+
+  async consumeLostTurn(
+    gameId: string,
+    playerId: string,
+    client: PoolClient,
+  ): Promise<boolean>;
+}
+
+export const activeEffectManager = new ActiveEffectManager();
+```
+
+---
+
+## Methods
+
+### `getActiveEffects(gameId)`
+
+Reads all currently active effects from the database.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+
+**Returns:** `Promise<ActiveEffect[]>` — All active effects. Returns `[]` if `active_event` is null or empty.
+
+**Behavior:**
+- Reads `games.active_event` without locking (read-only).
+- Deserializes each `ActiveEffectRecord` into `ActiveEffect`, converting `affectedZone: string[]` to `affectedZone: Set<string>` for O(1) membership checks.
+
+**Example:**
+```typescript
+const effects = await activeEffectManager.getActiveEffects(gameId);
+for (const effect of effects) {
+  if (effect.affectedZone.has(playerMilepostKey)) {
+    // player is in the affected zone
+  }
+}
+```
+
+---
+
+### `addActiveEffect(gameId, descriptor, cardType, perPlayerEffects, client, riverName?)`
+
+Persists a new active effect by appending it to the `games.active_event` array inside the caller's transaction.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+- `descriptor: ActiveEffectDescriptor` — From `EventCardResult.persistentEffectDescriptor` (returned by `EventCardService.processEventCard`).
+- `cardType: EventCardType` — From the drawn event card's `.type` field.
+- `perPlayerEffects: PerPlayerEffect[]` — From `EventCardResult.perPlayerEffects`. Used to extract `pendingLostTurns` for Derailment cards.
+- `client: PoolClient` — Caller-owned database client (must already be in a transaction).
+- `riverName?: string` — **Flood only.** The river name from `effectConfig.river` (e.g., `"Rhine"`). Stored as `floodedRiver` for rebuild-blocking logic in SP-2.
+
+**Returns:** `Promise<void>`
+
+**Behavior:**
+- Uses `SELECT active_event FROM games WHERE id = $1 FOR UPDATE` to lock the game row.
+- Builds restriction arrays from `cardType` and `affectedZone`:
+  - **Strike (coastal, zone non-empty):** `PickupDeliveryRestriction` with `no_pickup_delivery_in_zone`
+  - **Strike (rail, zone empty):** `MovementRestriction` with `no_movement_on_player_rail` + `BuildRestriction` with `no_build_for_player`, both targeting `drawingPlayerId`
+  - **Snow:** `MovementRestriction` with `half_rate` + `blocked_terrain`, and `BuildRestriction` with `blocked_terrain`
+  - **Flood:** No restrictions (bridge removal handled in P2; rebuild blocking via `floodedRiver`)
+  - **Derailment:** No movement/build restrictions; extracts `pendingLostTurns` from `perPlayerEffects`
+- Appends the new `ActiveEffectRecord` to the existing array (or creates `[record]` if `active_event` is null).
+
+**Example:**
+```typescript
+await activeEffectManager.addActiveEffect(
+  gameId,
+  result.persistentEffectDescriptor!,
+  card.type,
+  result.perPlayerEffects,
+  client,
+  card.type === EventCardType.Flood
+    ? (card.effectConfig as FloodEffect).river
+    : undefined,
+);
+```
+
+---
+
+### `cleanupExpiredEffects(gameId, completedPlayerIndex, completedTurnNumber, client)`
+
+Removes all effects that have expired after the specified player's turn completion. Returns the card IDs of expired effects for socket broadcast.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+- `completedPlayerIndex: number` — Zero-based index of the player who just completed their turn.
+- `completedTurnNumber: number` — The turn number that just completed.
+- `client: PoolClient` — Caller-owned database client (must be in a transaction).
+
+**Returns:** `Promise<{ expiredCardIds: number[] }>` — Card IDs of effects that were removed. Empty array if none expired.
+
+**Behavior:**
+- Uses `SELECT ... FOR UPDATE` to lock the game row.
+- An effect expires when **both** conditions are true:
+  - `record.drawingPlayerIndex === completedPlayerIndex`
+  - `record.expiresAfterTurnNumber <= completedTurnNumber`
+- Writes the remaining (non-expired) effects back to `games.active_event`. Sets to `null` if all effects expired.
+- Per rulebook: effects expire "at the end of the drawing player's next turn."
+
+**Example:**
+```typescript
+const { expiredCardIds } = await activeEffectManager.cleanupExpiredEffects(
+  gameId,
+  currentPlayerIndex,
+  currentTurnNumber,
+  client,
+);
+// Broadcast expiredCardIds via socket
+```
+
+---
+
+### `getMovementRestrictions(gameId)`
+
+Aggregates movement restrictions across all active effects.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+
+**Returns:** `Promise<MovementRestriction[]>` — Union of all active effects' movement restrictions. Empty array if no effects are active.
+
+**Behavior:**
+- Calls `getActiveEffects` internally (read-only, no locking).
+- Concatenates `restrictions.movement` from all effects into a single array.
+- Callers apply all restrictions to determine whether a move is valid.
+
+---
+
+### `getBuildRestrictions(gameId)`
+
+Aggregates build restrictions across all active effects.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+
+**Returns:** `Promise<BuildRestriction[]>` — Union of all active effects' build restrictions. Empty array if no effects are active.
+
+---
+
+### `getPickupDeliveryRestrictions(gameId)`
+
+Aggregates pickup/delivery restrictions across all active effects.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+
+**Returns:** `Promise<PickupDeliveryRestriction[]>` — Union of all active effects' pickup/delivery restrictions. Empty array if no effects are active.
+
+---
+
+### `consumeLostTurn(gameId, playerId, client)`
+
+Removes a player's pending lost turn from the first matching active effect. A player loses **at most one turn** regardless of how many Derailment cards hit them simultaneously.
+
+**Parameters:**
+- `gameId: string` — The game UUID.
+- `playerId: string` — The player whose lost turn is being consumed.
+- `client: PoolClient` — Caller-owned database client (must be in a transaction).
+
+**Returns:** `Promise<boolean>` — `true` if the player had a pending lost turn that was consumed, `false` otherwise.
+
+**Behavior:**
+- Uses `SELECT ... FOR UPDATE` to lock the game row.
+- Scans all active effects' `pendingLostTurns` arrays for the player.
+- Removes the player from the **first** matching effect only (prevents double-consumption).
+- Writes the modified array back to `games.active_event`.
+
+**Example:**
+```typescript
+const hadLostTurn = await activeEffectManager.consumeLostTurn(gameId, playerId, client);
+if (hadLostTurn) {
+  // Skip player's turn — their turn has been consumed
+  return;
+}
+```
+
+---
+
+## Singleton Export
+
+A singleton instance is exported for use across the server:
+
+```typescript
+import { activeEffectManager } from '../services/ActiveEffectManager';
+```
+
+---
+
+## Dependency Notes
+
+This service is the foundation for P3 sub-projects:
+
+| Consumer | Usage |
+|----------|-------|
+| SP-2 (PlayerService) | Calls restriction query methods before validating moves/builds |
+| SP-3 (Turn lifecycle) | Calls `cleanupExpiredEffects` at turn end; `consumeLostTurn` at turn start |
+| SP-4 (SocketService) | Broadcasts `expiredCardIds` from `cleanupExpiredEffects` |

--- a/src/shared/types/EventCard.ts
+++ b/src/shared/types/EventCard.ts
@@ -149,6 +149,8 @@ export interface ActiveEffectDescriptor {
   expiresAfterTurnNumber: number;
   /** Serialized milepost keys; rehydrated to Set<string> on read */
   affectedZone: string[];
+  /** Snow only — narrower subset of affectedZone filtered to blocked terrain types */
+  blockedTerrainZone?: string[];
 }
 
 // ─── ActiveEffectManager types (P3-SP1) ─────────────────────────────────────

--- a/src/shared/types/EventCard.ts
+++ b/src/shared/types/EventCard.ts
@@ -151,6 +151,82 @@ export interface ActiveEffectDescriptor {
   affectedZone: string[];
 }
 
+// ─── ActiveEffectManager types (P3-SP1) ─────────────────────────────────────
+
+/**
+ * Restriction on train movement — half rate, blocked terrain, or player-rail movement ban.
+ */
+export interface MovementRestriction {
+  type: 'half_rate' | 'blocked_terrain' | 'no_movement_on_player_rail';
+  zone?: string[];
+  blockedTerrain?: TerrainType[];
+  targetPlayerId?: string;
+}
+
+/**
+ * Restriction on track building — blocked terrain or build ban for a specific player.
+ */
+export interface BuildRestriction {
+  type: 'blocked_terrain' | 'no_build_for_player';
+  zone?: string[];
+  blockedTerrain?: TerrainType[];
+  targetPlayerId?: string;
+}
+
+/**
+ * Restriction on pickup and delivery in a zone.
+ */
+export interface PickupDeliveryRestriction {
+  type: 'no_pickup_delivery_in_zone';
+  zone: string[];
+}
+
+/**
+ * Persisted to games.active_event JSONB array.
+ * games.active_event = ActiveEffectRecord[] (JSON array)
+ */
+export interface ActiveEffectRecord {
+  cardId: number;
+  /** 'Strike' | 'Snow' | 'Flood' | 'Derailment' */
+  cardType: string;
+  drawingPlayerId: string;
+  drawingPlayerIndex: number;
+  drawingPlayerTurnNumber: number;
+  expiresAfterTurnNumber: number;
+  affectedZone: string[];
+  restrictions: {
+    movement: MovementRestriction[];
+    build: BuildRestriction[];
+    pickupDelivery: PickupDeliveryRestriction[];
+  };
+  pendingLostTurns: { playerId: string }[];
+  /** Flood only — river name (e.g., "Rhine") for rebuild blocking */
+  floodedRiver?: string;
+  createdAt: string;
+}
+
+/**
+ * Runtime representation of an active effect (rehydrated from ActiveEffectRecord).
+ * affectedZone is a Set<string> for efficient lookup.
+ */
+export interface ActiveEffect {
+  cardId: number;
+  cardType: EventCardType;
+  drawingPlayerId: string;
+  drawingPlayerIndex: number;
+  expiresAfterTurnNumber: number;
+  /** Rehydrated from string[] */
+  affectedZone: Set<string>;
+  restrictions: {
+    movement: MovementRestriction[];
+    build: BuildRestriction[];
+    pickupDelivery: PickupDeliveryRestriction[];
+  };
+  pendingLostTurns: { playerId: string }[];
+  /** Flood only */
+  floodedRiver?: string;
+}
+
 /**
  * Structured result returned by `EventCardService.processEventCard`.
  * Describes every state change made (and every persistent descriptor to


### PR DESCRIPTION
## Summary
- Implements `ActiveEffectManager` stateless service with 7 methods for managing persistent event card effects (movement/build/pickup-delivery restrictions, lost turn consumption, cleanup)
- Adds 5 new shared types to `EventCard.ts`: `MovementRestriction`, `BuildRestriction`, `PickupDeliveryRestriction`, `ActiveEffectRecord`, `ActiveEffect`
- Includes 36 unit tests covering all methods and edge cases
- Adds API reference documentation

## Test plan
- [x] All 36 ActiveEffectManager unit tests pass
- [x] All 50 server tests pass (including existing EventCardService tests)
- [x] TypeScript compilation clean (`npm run build`)
- [ ] Review type definitions in `src/shared/types/EventCard.ts`
- [ ] Review service methods in `src/server/services/ActiveEffectManager.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request implements the ActiveEffectManager, a core stateless service for managing persistent event card effects in the Eurorails game. The service handles effects that span multiple turns including movement restrictions, build limitations, pickup-delivery bans, and lost turn tracking for Strike, Snow, Flood, and Derailment cards. It introduces 5 new shared types for effect modeling and includes comprehensive test coverage with 36 unit tests.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces ActiveEffectManager service with database persistence using JSONB arrays in games.active_event column</li>

<li>Adds 5 new TypeScript interfaces (MovementRestriction, BuildRestriction, PickupDeliveryRestriction, ActiveEffectRecord, ActiveEffect) for effect modeling</li>

<li>Implements concurrency-safe operations using SELECT FOR UPDATE database locking for thread-safe effect management</li>

<li>Provides read-only restriction aggregation methods for game logic to query movement, build, and pickup-delivery restrictions</li>

<li>Includes comprehensive test suite with 36 unit tests covering all service methods and edge cases</li>

</ul>
</details>

</div>