### PR TITLE
feat: turn lifecycle & draw loop integration (P3-SP3)

### DIFF
--- a/src/server/__tests__/playerService.drawLoop.test.ts
+++ b/src/server/__tests__/playerService.drawLoop.test.ts
@@ -103,6 +103,33 @@ function persistentResult(cardId: number, descriptor = { cardId, drawingPlayerId
   };
 }
 
+/** EventCardResult for Flood with floodedRiver */
+function floodPersistentResult(cardId: number, riverName: string, descriptor = { cardId, drawingPlayerId: 'p1', drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] as string[] }) {
+  return {
+    cardId,
+    cardType: EventCardType.Flood,
+    drawingPlayerId: 'p1',
+    affectedZone: [] as string[],
+    perPlayerEffects: [],
+    floodSegmentsRemoved: [],
+    persistentEffectDescriptor: descriptor,
+    floodedRiver: riverName,
+  };
+}
+
+function floodEventCardResult(id: number) {
+  return {
+    type: 'event' as const,
+    card: {
+      id,
+      type: EventCardType.Flood,
+      title: 'Flood!',
+      description: 'Test flood event',
+      effectConfig: { type: EventCardType.Flood, river: 'Rhine' },
+    },
+  };
+}
+
 /** EventCardResult WITHOUT persistentEffectDescriptor (e.g. ExcessProfitTax) */
 function nonPersistentResult(cardId: number) {
   return {
@@ -150,6 +177,7 @@ describe('PlayerService.fulfillDemand — draw loop addActiveEffect', () => {
       EventCardType.Strike,
       [],
       expect.anything(), // client
+      undefined, // floodedRiver
     );
   });
 
@@ -178,6 +206,26 @@ describe('PlayerService.fulfillDemand — draw loop addActiveEffect', () => {
     await PlayerService.fulfillDemand(gameId, playerId, 'Paris', 'Coal', cardId);
 
     expect(mockAddActiveEffect).toHaveBeenCalledTimes(2);
+  });
+
+  it('should pass floodedRiver to addActiveEffect for Flood events', async () => {
+    const descriptor = { cardId: 133, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] as string[] };
+    mockProcessEventCard.mockResolvedValue(floodPersistentResult(133, 'Rhine', descriptor));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(floodEventCardResult(133))
+      .mockReturnValueOnce(demandResult(99));
+
+    await PlayerService.fulfillDemand(gameId, playerId, 'Paris', 'Coal', cardId);
+
+    expect(mockAddActiveEffect).toHaveBeenCalledTimes(1);
+    expect(mockAddActiveEffect).toHaveBeenCalledWith(
+      gameId,
+      descriptor,
+      EventCardType.Flood,
+      [],
+      expect.anything(), // client
+      'Rhine',
+    );
   });
 
   it('should still draw until demand card after persisting effects', async () => {
@@ -230,6 +278,7 @@ describe('PlayerService.discardHandForPlayer — draw loop addActiveEffect', () 
       EventCardType.Strike,
       [],
       expect.anything(),
+      undefined, // floodedRiver
     );
   });
 
@@ -262,5 +311,104 @@ describe('PlayerService.discardHandForPlayer — draw loop addActiveEffect', () 
     await PlayerService.discardHandForPlayer(gameId, playerId);
 
     expect(mockAddActiveEffect).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── deliverLoadForUser draw loop ────────────────────────────────────────────
+
+describe('PlayerService.deliverLoadForUser — draw loop addActiveEffect', () => {
+  const gameId = 'game-1';
+  const userId = 'user-1';
+  const playerId = 'player-1';
+  const cardId = 5;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.query.mockImplementation((sql: string, params?: any[]) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return Promise.resolve();
+      // Player SELECT FOR UPDATE
+      if (sql.includes('SELECT id, money') && sql.includes('user_id')) {
+        return Promise.resolve({
+          rows: [{
+            id: playerId,
+            money: 100,
+            debtOwed: 0,
+            hand: [cardId, 2, 3],
+            loads: ['Coal'],
+            turnNumber: 1,
+          }],
+        });
+      }
+      // Game current_player_index
+      if (sql.includes('current_player_index') && sql.includes('games')) {
+        return Promise.resolve({ rows: [{ current_player_index: 0 }] });
+      }
+      // Active player lookup
+      if (sql.includes('ORDER BY created_at ASC LIMIT 1 OFFSET')) {
+        return Promise.resolve({ rows: [{ id: playerId }] });
+      }
+      if (sql.includes('UPDATE players')) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    // Mock getCard to return a valid demand card
+    (demandDeckService.getCard as jest.Mock).mockReturnValue({
+      id: cardId,
+      demands: [{ city: 'Berlin', resource: 'Coal', payment: 10 }],
+    });
+
+    // Mock getPickupDeliveryRestrictions to return empty
+    (activeEffectManager.getPickupDeliveryRestrictions as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('should call addActiveEffect when processEventCard returns persistentEffectDescriptor', async () => {
+    const descriptor = { cardId: 121, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] };
+    mockProcessEventCard.mockResolvedValue(persistentResult(121, descriptor));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(121))
+      .mockReturnValueOnce(demandResult(99));
+
+    await PlayerService.deliverLoadForUser(gameId, userId, 'Berlin', 'Coal' as any, cardId);
+
+    expect(mockAddActiveEffect).toHaveBeenCalledTimes(1);
+    expect(mockAddActiveEffect).toHaveBeenCalledWith(
+      gameId,
+      descriptor,
+      EventCardType.Strike,
+      [],
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it('should NOT call addActiveEffect when persistentEffectDescriptor is absent', async () => {
+    mockProcessEventCard.mockResolvedValue(nonPersistentResult(124));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(124))
+      .mockReturnValueOnce(demandResult(99));
+
+    await PlayerService.deliverLoadForUser(gameId, userId, 'Berlin', 'Coal' as any, cardId);
+
+    expect(mockAddActiveEffect).not.toHaveBeenCalled();
+  });
+
+  it('should pass floodedRiver to addActiveEffect for Flood events', async () => {
+    const descriptor = { cardId: 133, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] as string[] };
+    mockProcessEventCard.mockResolvedValue(floodPersistentResult(133, 'Danube', descriptor));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(floodEventCardResult(133))
+      .mockReturnValueOnce(demandResult(99));
+
+    await PlayerService.deliverLoadForUser(gameId, userId, 'Berlin', 'Coal' as any, cardId);
+
+    expect(mockAddActiveEffect).toHaveBeenCalledTimes(1);
+    expect(mockAddActiveEffect).toHaveBeenCalledWith(
+      gameId,
+      descriptor,
+      EventCardType.Flood,
+      [],
+      expect.anything(),
+      'Danube',
+    );
   });
 });

--- a/src/server/__tests__/playerService.drawLoop.test.ts
+++ b/src/server/__tests__/playerService.drawLoop.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for addActiveEffect wiring in the draw loops of:
+ * - PlayerService.fulfillDemand
+ * - PlayerService.deliverLoadForUser
+ * - PlayerService.discardHandForPlayer (via discardHandCore)
+ */
+
+import { PlayerService } from '../services/playerService';
+import { demandDeckService } from '../services/demandDeckService';
+import { EventCardService } from '../services/EventCardService';
+import { activeEffectManager } from '../services/ActiveEffectManager';
+import { EventCardType } from '../../shared/types/EventCard';
+
+// Mock socketService
+jest.mock('../services/socketService', () => ({
+  emitTurnChange: jest.fn(),
+  emitStatePatch: jest.fn().mockResolvedValue(undefined),
+  getSocketIO: jest.fn().mockReturnValue(null),
+}));
+
+// Mock the database module
+jest.mock('../db/index', () => {
+  const mockClient = {
+    query: jest.fn(),
+    release: jest.fn(),
+  };
+  return {
+    db: {
+      connect: jest.fn().mockResolvedValue(mockClient),
+      query: jest.fn(),
+    },
+    __mockClient: mockClient,
+  };
+});
+
+// Mock DemandDeckService
+jest.mock('../services/demandDeckService', () => ({
+  demandDeckService: {
+    discardCard: jest.fn(),
+    discardEventCard: jest.fn(),
+    drawCard: jest.fn(),
+    returnDealtCardToTop: jest.fn(),
+    returnDiscardedCardToDealt: jest.fn(),
+    getCard: jest.fn(),
+  },
+}));
+
+// Mock EventCardService
+jest.mock('../services/EventCardService', () => ({
+  EventCardService: {
+    processEventCard: jest.fn(),
+  },
+}));
+
+// Mock ActiveEffectManager
+jest.mock('../services/ActiveEffectManager', () => ({
+  activeEffectManager: {
+    addActiveEffect: jest.fn().mockResolvedValue(undefined),
+    cleanupExpiredEffects: jest.fn().mockResolvedValue({ expiredCardIds: [] }),
+    consumeLostTurn: jest.fn().mockResolvedValue(false),
+    getMovementRestrictions: jest.fn().mockResolvedValue([]),
+    getBuildRestrictions: jest.fn().mockResolvedValue([]),
+    getPickupDeliveryRestrictions: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+const { __mockClient: mockClient } = jest.requireMock('../db/index') as {
+  __mockClient: { query: jest.Mock; release: jest.Mock };
+};
+
+const mockAddActiveEffect = activeEffectManager.addActiveEffect as jest.Mock;
+const mockProcessEventCard = EventCardService.processEventCard as jest.Mock;
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+function demandResult(id: number) {
+  return { type: 'demand' as const, card: { id, demands: [] } };
+}
+
+function eventCardResult(id: number) {
+  return {
+    type: 'event' as const,
+    card: {
+      id,
+      type: EventCardType.Strike,
+      title: 'Strike!',
+      description: 'Test event',
+      effectConfig: { type: EventCardType.Strike, variant: 'coastal' as const, coastalRadius: 3 },
+    },
+  };
+}
+
+/** EventCardResult with persistentEffectDescriptor */
+function persistentResult(cardId: number, descriptor = { cardId, drawingPlayerId: 'p1', drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] }) {
+  return {
+    cardId,
+    cardType: EventCardType.Strike,
+    drawingPlayerId: 'p1',
+    affectedZone: [],
+    perPlayerEffects: [],
+    floodSegmentsRemoved: [],
+    persistentEffectDescriptor: descriptor,
+  };
+}
+
+/** EventCardResult WITHOUT persistentEffectDescriptor (e.g. ExcessProfitTax) */
+function nonPersistentResult(cardId: number) {
+  return {
+    cardId,
+    cardType: EventCardType.ExcessProfitTax,
+    drawingPlayerId: 'p1',
+    affectedZone: [],
+    perPlayerEffects: [],
+    floodSegmentsRemoved: [],
+  };
+}
+
+// ── fulfillDemand draw loop ───────────────────────────────────────────────────
+
+describe('PlayerService.fulfillDemand — draw loop addActiveEffect', () => {
+  const gameId = 'game-1';
+  const playerId = 'player-1';
+  const cardId = 5;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.query.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return Promise.resolve();
+      if (sql.includes('SELECT hand, loads')) {
+        return Promise.resolve({ rows: [{ hand: [cardId, 2, 3], loads: [] }] });
+      }
+      if (sql.includes('UPDATE players')) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+  });
+
+  it('should call addActiveEffect when processEventCard returns persistentEffectDescriptor', async () => {
+    const descriptor = { cardId: 121, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] };
+    mockProcessEventCard.mockResolvedValue(persistentResult(121, descriptor));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(121))
+      .mockReturnValueOnce(demandResult(99));
+
+    await PlayerService.fulfillDemand(gameId, playerId, 'Paris', 'Coal', cardId);
+
+    expect(mockAddActiveEffect).toHaveBeenCalledTimes(1);
+    expect(mockAddActiveEffect).toHaveBeenCalledWith(
+      gameId,
+      descriptor,
+      EventCardType.Strike,
+      [],
+      expect.anything(), // client
+    );
+  });
+
+  it('should NOT call addActiveEffect when persistentEffectDescriptor is absent', async () => {
+    mockProcessEventCard.mockResolvedValue(nonPersistentResult(124));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(124))
+      .mockReturnValueOnce(demandResult(99));
+
+    await PlayerService.fulfillDemand(gameId, playerId, 'Paris', 'Coal', cardId);
+
+    expect(mockAddActiveEffect).not.toHaveBeenCalled();
+  });
+
+  it('should call addActiveEffect for each persistent event card in sequence', async () => {
+    const desc1 = { cardId: 121, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] };
+    const desc2 = { cardId: 130, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] };
+    mockProcessEventCard
+      .mockResolvedValueOnce(persistentResult(121, desc1))
+      .mockResolvedValueOnce(persistentResult(130, desc2));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(121))
+      .mockReturnValueOnce(eventCardResult(130))
+      .mockReturnValueOnce(demandResult(99));
+
+    await PlayerService.fulfillDemand(gameId, playerId, 'Paris', 'Coal', cardId);
+
+    expect(mockAddActiveEffect).toHaveBeenCalledTimes(2);
+  });
+
+  it('should still draw until demand card after persisting effects', async () => {
+    mockProcessEventCard.mockResolvedValue(persistentResult(121));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(121))
+      .mockReturnValueOnce(demandResult(99));
+
+    const result = await PlayerService.fulfillDemand(gameId, playerId, 'Paris', 'Coal', cardId);
+
+    expect(result.newCard.id).toBe(99);
+    expect(demandDeckService.drawCard).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── discardHandForPlayer draw loop ────────────────────────────────────────────
+
+describe('PlayerService.discardHandForPlayer — draw loop addActiveEffect', () => {
+  const gameId = 'game-1';
+  const playerId = 'player-1';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.query.mockImplementation((sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return Promise.resolve();
+      if (sql.includes('SELECT hand') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({ rows: [{ hand: [1, 2, 3] }] });
+      }
+      if (sql.includes('UPDATE players')) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+  });
+
+  it('should call addActiveEffect when drawing persistent event card in discard loop', async () => {
+    const descriptor = { cardId: 130, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 3, affectedZone: [] };
+    mockProcessEventCard.mockResolvedValue(persistentResult(130, descriptor));
+    // need to draw 3 demand cards; first slot has an event card
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(130))
+      .mockReturnValueOnce(demandResult(10))
+      .mockReturnValueOnce(demandResult(11))
+      .mockReturnValueOnce(demandResult(12));
+
+    await PlayerService.discardHandForPlayer(gameId, playerId);
+
+    expect(mockAddActiveEffect).toHaveBeenCalledTimes(1);
+    expect(mockAddActiveEffect).toHaveBeenCalledWith(
+      gameId,
+      descriptor,
+      EventCardType.Strike,
+      [],
+      expect.anything(),
+    );
+  });
+
+  it('should NOT call addActiveEffect for non-persistent event cards in discard loop', async () => {
+    mockProcessEventCard.mockResolvedValue(nonPersistentResult(124));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(124))
+      .mockReturnValueOnce(demandResult(10))
+      .mockReturnValueOnce(demandResult(11))
+      .mockReturnValueOnce(demandResult(12));
+
+    await PlayerService.discardHandForPlayer(gameId, playerId);
+
+    expect(mockAddActiveEffect).not.toHaveBeenCalled();
+  });
+
+  it('should call addActiveEffect multiple times for multiple persistent events in discard loop', async () => {
+    const desc1 = { cardId: 121, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] };
+    const desc2 = { cardId: 130, drawingPlayerId: playerId, drawingPlayerIndex: 0, expiresAfterTurnNumber: 2, affectedZone: [] };
+    mockProcessEventCard
+      .mockResolvedValueOnce(persistentResult(121, desc1))
+      .mockResolvedValueOnce(persistentResult(130, desc2));
+    (demandDeckService.drawCard as jest.Mock)
+      .mockReturnValueOnce(eventCardResult(121))
+      .mockReturnValueOnce(eventCardResult(130))
+      .mockReturnValueOnce(demandResult(10))
+      .mockReturnValueOnce(demandResult(11))
+      .mockReturnValueOnce(demandResult(12));
+
+    await PlayerService.discardHandForPlayer(gameId, playerId);
+
+    expect(mockAddActiveEffect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/__tests__/playerService.turnSkip.test.ts
+++ b/src/server/__tests__/playerService.turnSkip.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for PlayerService.updateCurrentPlayerIndex turn lifecycle:
+ * - Effect expiry via cleanupExpiredEffects
+ * - Derailment turn-skip via consumeLostTurn
+ * - Recursive advancement with infinite loop guard
+ * - Backward compatibility (no client → no checks)
+ */
+
+import { PlayerService } from '../services/playerService';
+import { activeEffectManager } from '../services/ActiveEffectManager';
+
+// Mock socketService
+jest.mock('../services/socketService', () => ({
+  emitTurnChange: jest.fn(),
+  getSocketIO: jest.fn().mockReturnValue(null),
+}));
+
+// Mock the database module
+jest.mock('../db/index', () => {
+  const mockClient = {
+    query: jest.fn(),
+    release: jest.fn(),
+  };
+  return {
+    db: {
+      connect: jest.fn().mockResolvedValue(mockClient),
+      query: jest.fn(),
+    },
+    __mockClient: mockClient,
+  };
+});
+
+// Mock ActiveEffectManager
+jest.mock('../services/ActiveEffectManager', () => ({
+  activeEffectManager: {
+    cleanupExpiredEffects: jest.fn(),
+    consumeLostTurn: jest.fn(),
+    addActiveEffect: jest.fn(),
+    getMovementRestrictions: jest.fn().mockResolvedValue([]),
+    getBuildRestrictions: jest.fn().mockResolvedValue([]),
+    getPickupDeliveryRestrictions: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+const { db, __mockClient: mockClient } = jest.requireMock('../db/index') as {
+  db: { connect: jest.Mock; query: jest.Mock };
+  __mockClient: { query: jest.Mock; release: jest.Mock };
+};
+
+const mockCleanupExpiredEffects = activeEffectManager.cleanupExpiredEffects as jest.Mock;
+const mockConsumeLostTurn = activeEffectManager.consumeLostTurn as jest.Mock;
+
+describe('PlayerService.updateCurrentPlayerIndex', () => {
+  const gameId = 'game-abc';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: no expired effects, no lost turns
+    mockCleanupExpiredEffects.mockResolvedValue({ expiredCardIds: [] });
+    mockConsumeLostTurn.mockResolvedValue(false);
+  });
+
+  // ── Helper: mock a client that returns a player at offset N ─────────────────
+  function setupClientWithPlayers(playerList: Array<{ id: string; current_turn_number: number }>) {
+    mockClient.query.mockImplementation((sql: string, params?: unknown[]) => {
+      if (typeof sql === 'string' && sql.includes('SELECT id, current_turn_number')) {
+        const offset = params ? Number(params[1]) : 0;
+        const row = playerList[offset];
+        return Promise.resolve({ rows: row ? [row] : [] });
+      }
+      if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
+        return Promise.resolve({ rows: [{ cnt: playerList.length }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  }
+
+  // ── Backward-compatibility tests ────────────────────────────────────────────
+
+  describe('backward compatibility (no client)', () => {
+    it('should NOT call cleanupExpiredEffects when no client is provided', async () => {
+      // db.query is used in the no-client path
+      (db.query as jest.Mock).mockResolvedValue({ rows: [] });
+      const { getSocketIO } = await import('../services/socketService');
+      (getSocketIO as jest.Mock).mockReturnValue(null);
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1);
+
+      expect(mockCleanupExpiredEffects).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call consumeLostTurn when no client is provided', async () => {
+      (db.query as jest.Mock).mockResolvedValue({ rows: [] });
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1);
+
+      expect(mockConsumeLostTurn).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Effect expiry tests ──────────────────────────────────────────────────────
+
+  describe('cleanupExpiredEffects (with client)', () => {
+    it('should call cleanupExpiredEffects with prevPlayerIndex and turnNumber', async () => {
+      const players = [
+        { id: 'p0', current_turn_number: 3 },
+        { id: 'p1', current_turn_number: 3 },
+      ];
+      setupClientWithPlayers(players);
+
+      // prevPlayerIndex = 0, nextPlayerIndex = 1
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0);
+
+      expect(mockCleanupExpiredEffects).toHaveBeenCalledWith(
+        gameId,
+        0,   // prevPlayerIndex
+        3,   // turnNumber from prev player
+        mockClient,
+      );
+    });
+
+    it('should log expired card IDs when effects expire', async () => {
+      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const players = [{ id: 'p0', current_turn_number: 2 }, { id: 'p1', current_turn_number: 2 }];
+      setupClientWithPlayers(players);
+      mockCleanupExpiredEffects.mockResolvedValue({ expiredCardIds: [121, 130] });
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0);
+
+      const allLogs = [...infoSpy.mock.calls, ...warnSpy.mock.calls].flat();
+      const logText = allLogs.join(' ');
+      expect(logText).toMatch(/121|130/);
+
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it('should NOT log when no effects expire', async () => {
+      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+      const players = [{ id: 'p0', current_turn_number: 1 }, { id: 'p1', current_turn_number: 1 }];
+      setupClientWithPlayers(players);
+      mockCleanupExpiredEffects.mockResolvedValue({ expiredCardIds: [] });
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0);
+
+      // Should not log "expired" noise for empty result
+      const expiredLog = infoSpy.mock.calls.find(c => String(c[0]).toLowerCase().includes('expired'));
+      expect(expiredLog).toBeUndefined();
+
+      infoSpy.mockRestore();
+    });
+  });
+
+  // ── Turn-skip (consumeLostTurn) tests ───────────────────────────────────────
+
+  describe('consumeLostTurn (with client)', () => {
+    it('should call consumeLostTurn for the next player', async () => {
+      const players = [
+        { id: 'p0', current_turn_number: 1 },
+        { id: 'p1', current_turn_number: 1 },
+      ];
+      setupClientWithPlayers(players);
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0);
+
+      expect(mockConsumeLostTurn).toHaveBeenCalledWith(gameId, 'p1', mockClient);
+    });
+
+    it('should skip a player whose turn is lost and advance to next', async () => {
+      const players = [
+        { id: 'p0', current_turn_number: 1 },
+        { id: 'p1', current_turn_number: 1 },
+        { id: 'p2', current_turn_number: 1 },
+      ];
+      setupClientWithPlayers(players);
+
+      // p1 has lost turn, p2 does not
+      mockConsumeLostTurn
+        .mockResolvedValueOnce(true)   // p1 loses turn
+        .mockResolvedValueOnce(false); // p2 is fine
+
+      const { emitTurnChange } = await import('../services/socketService');
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0);
+
+      // Should emit for p2 (index 2), not p1
+      expect(emitTurnChange).toHaveBeenCalledWith(gameId, 2, 'p2');
+    });
+
+    it('should log a turn-skip when consumeLostTurn returns true', async () => {
+      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const players = [
+        { id: 'p0', current_turn_number: 1 },
+        { id: 'p1', current_turn_number: 1 },
+        { id: 'p2', current_turn_number: 1 },
+      ];
+      setupClientWithPlayers(players);
+
+      mockConsumeLostTurn
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0);
+
+      const allLogs = [...infoSpy.mock.calls, ...warnSpy.mock.calls].flat();
+      const logText = allLogs.join(' ');
+      expect(logText).toMatch(/skip|lost|derail/i);
+
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it('should skip multiple consecutive players with lost turns', async () => {
+      const players = [
+        { id: 'p0', current_turn_number: 1 },
+        { id: 'p1', current_turn_number: 1 },
+        { id: 'p2', current_turn_number: 1 },
+        { id: 'p3', current_turn_number: 1 },
+      ];
+      setupClientWithPlayers(players);
+
+      // p1 and p2 lose turn, p3 does not
+      mockConsumeLostTurn
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      const { emitTurnChange } = await import('../services/socketService');
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0);
+
+      expect(emitTurnChange).toHaveBeenCalledWith(gameId, 3, 'p3');
+    });
+
+    it('should guard against infinite loop if all players have lost turns', async () => {
+      const players = [
+        { id: 'p0', current_turn_number: 1 },
+        { id: 'p1', current_turn_number: 1 },
+        { id: 'p2', current_turn_number: 1 },
+      ];
+      setupClientWithPlayers(players);
+
+      // ALL players have lost turns — should stop after player_count iterations
+      mockConsumeLostTurn.mockResolvedValue(true);
+
+      const { emitTurnChange } = await import('../services/socketService');
+
+      // Should not throw and should still emit for some player
+      await expect(
+        PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0),
+      ).resolves.not.toThrow();
+
+      expect(emitTurnChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Integration: expiry + skip in same advancement ──────────────────────────
+
+  describe('combined expiry + skip', () => {
+    it('should both cleanup effects and skip the derailed player', async () => {
+      const players = [
+        { id: 'p0', current_turn_number: 5 },
+        { id: 'p1', current_turn_number: 5 },
+        { id: 'p2', current_turn_number: 5 },
+      ];
+      setupClientWithPlayers(players);
+
+      mockCleanupExpiredEffects.mockResolvedValue({ expiredCardIds: [125] });
+      mockConsumeLostTurn
+        .mockResolvedValueOnce(true)   // p1 skipped
+        .mockResolvedValueOnce(false); // p2 ok
+
+      const { emitTurnChange } = await import('../services/socketService');
+
+      await PlayerService.updateCurrentPlayerIndex(gameId, 1, mockClient as any, 0);
+
+      expect(mockCleanupExpiredEffects).toHaveBeenCalled();
+      expect(emitTurnChange).toHaveBeenCalledWith(gameId, 2, 'p2');
+    });
+  });
+});

--- a/src/server/services/EventCardService.ts
+++ b/src/server/services/EventCardService.ts
@@ -408,6 +408,7 @@ export class EventCardService {
       perPlayerEffects,
       floodSegmentsRemoved,
       persistentEffectDescriptor: descriptor,
+      floodedRiver: effect.river,
     };
   }
 

--- a/src/server/services/playerService.ts
+++ b/src/server/services/playerService.ts
@@ -631,26 +631,130 @@ export class PlayerService {
     }
   }
 
+  /**
+   * Advance the current player index for a game.
+   *
+   * When `client` and `prevPlayerIndex` are provided (transactional path):
+   *  1. Uses `client.query` for the UPDATE (participates in caller's transaction).
+   *  2. Calls `cleanupExpiredEffects` for the previous player.
+   *  3. Calls `consumeLostTurn` for the next player; if lost, recursively
+   *     advances with an infinite-loop guard (at most playerCount skips).
+   *  4. Emits `emitTurnChange` for the final active player.
+   *
+   * When neither `client` nor `prevPlayerIndex` is provided (legacy path),
+   * skips effect management entirely — existing callers are unaffected.
+   */
   static async updateCurrentPlayerIndex(
     gameId: string,
-    currentPlayerIndex: number
+    currentPlayerIndex: number,
+    client?: import('pg').PoolClient,
+    prevPlayerIndex?: number,
   ): Promise<void> {
     const query = `
-            UPDATE games 
+            UPDATE games
             SET current_player_index = $1, updated_at = CURRENT_TIMESTAMP
             WHERE id = $2
         `;
-    await db.query(query, [currentPlayerIndex, gameId]);
-    
-    // Emit turn change event to all clients in the game room
+
+    if (client) {
+      await client.query(query, [currentPlayerIndex, gameId]);
+    } else {
+      await db.query(query, [currentPlayerIndex, gameId]);
+    }
+
+    // ── Transactional turn lifecycle (SP-3) ──────────────────────────────────
+    if (client && prevPlayerIndex !== undefined) {
+      // Step 1: Clean up effects that expired when prevPlayer completed their turn.
+      // Use the previous player's current_turn_number as the completed turn number.
+      const prevPlayerRow = await client.query(
+        'SELECT id, current_turn_number FROM players WHERE game_id = $1 ORDER BY created_at ASC LIMIT 1 OFFSET $2',
+        [gameId, prevPlayerIndex],
+      );
+      const prevTurnNumber: number = Number(prevPlayerRow.rows[0]?.current_turn_number ?? 0);
+
+      const { expiredCardIds } = await activeEffectManager.cleanupExpiredEffects(
+        gameId,
+        prevPlayerIndex,
+        prevTurnNumber,
+        client,
+      );
+      if (expiredCardIds.length > 0) {
+        // SP-4 will broadcast socket events; for now log for observability.
+        console.info(
+          `[PlayerService] Effects expired on turn end: cardIds=${expiredCardIds.join(',')} prevPlayerIndex=${prevPlayerIndex} gameId=${gameId}`,
+        );
+      }
+
+      // Step 2: Determine total player count so we can guard against infinite skips.
+      const countRow = await client.query(
+        'SELECT COUNT(*) AS cnt FROM players WHERE game_id = $1',
+        [gameId],
+      );
+      const playerCount = Number(countRow.rows[0]?.cnt ?? 1);
+
+      // Step 3: Check for Derailment turn-skips, advancing until an active player.
+      let resolvedIndex = currentPlayerIndex;
+      let skipsRemaining = playerCount; // guard: at most playerCount advances
+
+      while (skipsRemaining > 0) {
+        const nextRow = await client.query(
+          'SELECT id, current_turn_number FROM players WHERE game_id = $1 ORDER BY created_at ASC LIMIT 1 OFFSET $2',
+          [gameId, resolvedIndex],
+        );
+        const nextPlayerId: string | undefined = nextRow.rows[0]?.id as string | undefined;
+
+        if (!nextPlayerId) {
+          console.warn(`[PlayerService] No player found at index ${resolvedIndex} in game ${gameId}`);
+          break;
+        }
+
+        const turnSkipped = await activeEffectManager.consumeLostTurn(gameId, nextPlayerId, client);
+
+        if (!turnSkipped) {
+          // This player is active — stop here.
+          break;
+        }
+
+        // Player was skipped due to Derailment.
+        console.info(
+          `[PlayerService] Player turn skipped (Derailment): playerId=${nextPlayerId} index=${resolvedIndex} gameId=${gameId}`,
+        );
+
+        resolvedIndex = (resolvedIndex + 1) % playerCount;
+        skipsRemaining--;
+      }
+
+      // Step 4: Emit turn change for the resolved active player.
+      const { emitTurnChange } = await import('./socketService');
+      const finalRow = await client.query(
+        'SELECT id, current_turn_number FROM players WHERE game_id = $1 ORDER BY created_at ASC LIMIT 1 OFFSET $2',
+        [gameId, resolvedIndex],
+      );
+      const finalPlayerId: string | undefined = finalRow.rows[0]?.id as string | undefined;
+      if (finalPlayerId) {
+        // Update the stored index if we advanced past skipped players.
+        if (resolvedIndex !== currentPlayerIndex) {
+          await client.query(
+            `UPDATE games SET current_player_index = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`,
+            [resolvedIndex, gameId],
+          );
+        }
+        emitTurnChange(gameId, resolvedIndex, finalPlayerId);
+      } else {
+        console.warn(`[PlayerService] No player found at resolved index ${resolvedIndex} for game ${gameId}`);
+      }
+
+      return;
+    }
+
+    // ── Legacy path: no client — emit turn change via db.query ───────────────
     const { getSocketIO } = await import('./socketService');
     const io = getSocketIO();
     if (io) {
-      // Get the player ID for the current player (internal query - doesn't need hand data)
       // Query players in same order as getPlayers (ORDER BY created_at ASC for consistency)
       const playerQuery = await db.query(
         'SELECT id FROM players WHERE game_id = $1 ORDER BY created_at ASC LIMIT 1 OFFSET $2',
-        [gameId, currentPlayerIndex]
+        [gameId, currentPlayerIndex],
       );
       // Validate that we have a valid player at this index
       if (playerQuery.rows && playerQuery.rows.length > 0 && currentPlayerIndex >= 0) {
@@ -787,7 +891,17 @@ export class PlayerService {
       let drawResult = demandDeckService.drawCard();
       while (drawResult !== null && drawResult.type === 'event') {
         console.info(`[fulfillDemand] Drew event card ${drawResult.card.id} — processing via EventCardService`);
-        await EventCardService.processEventCard(gameId, drawResult.card, playerId, client);
+        const eventResult = await EventCardService.processEventCard(gameId, drawResult.card, playerId, client);
+        if (eventResult.persistentEffectDescriptor) {
+          console.info(`[fulfillDemand] Persisting active effect: cardId=${drawResult.card.id} gameId=${gameId}`);
+          await activeEffectManager.addActiveEffect(
+            gameId,
+            eventResult.persistentEffectDescriptor,
+            eventResult.cardType,
+            eventResult.perPlayerEffects,
+            client,
+          );
+        }
         demandDeckService.discardEventCard(drawResult.card.id);
         drawResult = demandDeckService.drawCard();
       }
@@ -948,7 +1062,17 @@ export class PlayerService {
         const eventCardId = newDrawResult.card.id;
         discardedEventCardIds.push(eventCardId);
         console.info(`[deliverLoad] Drew event card ${eventCardId} — processing via EventCardService`);
-        await EventCardService.processEventCard(gameId, newDrawResult.card, playerId, client);
+        const deliverEventResult = await EventCardService.processEventCard(gameId, newDrawResult.card, playerId, client);
+        if (deliverEventResult.persistentEffectDescriptor) {
+          console.info(`[deliverLoad] Persisting active effect: cardId=${eventCardId} gameId=${gameId}`);
+          await activeEffectManager.addActiveEffect(
+            gameId,
+            deliverEventResult.persistentEffectDescriptor,
+            deliverEventResult.cardType,
+            deliverEventResult.perPlayerEffects,
+            client,
+          );
+        }
         demandDeckService.discardEventCard(eventCardId);
         newDrawResult = demandDeckService.drawCard();
       }
@@ -1756,7 +1880,17 @@ export class PlayerService {
       if (result.type === 'event') {
         // Process the event card via EventCardService (replaces Project 1 discard stub)
         console.info(`[discardHandCore] Drew event card ${result.card.id} — processing via EventCardService`);
-        await EventCardService.processEventCard(gameId, result.card, playerId, client);
+        const discardEventResult = await EventCardService.processEventCard(gameId, result.card, playerId, client);
+        if (discardEventResult.persistentEffectDescriptor) {
+          console.info(`[discardHandCore] Persisting active effect: cardId=${result.card.id} gameId=${gameId}`);
+          await activeEffectManager.addActiveEffect(
+            gameId,
+            discardEventResult.persistentEffectDescriptor,
+            discardEventResult.cardType,
+            discardEventResult.perPlayerEffects,
+            client,
+          );
+        }
         demandDeckService.discardEventCard(result.card.id);
         discardedEventIds.push(result.card.id);
         continue;

--- a/src/server/services/playerService.ts
+++ b/src/server/services/playerService.ts
@@ -14,7 +14,7 @@ import { getFerryEdges } from "../../shared/services/majorCityGroups";
 import { TrackSegment } from "../../shared/types/TrackTypes";
 import { EventCardService } from "./EventCardService";
 import { activeEffectManager } from "./ActiveEffectManager";
-import { EventCardType } from "../../shared/types/EventCard";
+import { EventCardType, EventCardResult } from "../../shared/types/EventCard";
 
 type TurnActionDeliver = {
   kind: "deliver";
@@ -50,6 +50,29 @@ interface PlayerRow {
 }
 
 export class PlayerService {
+  /**
+   * Persist an active effect produced by an event card draw.
+   * Extracted to eliminate duplication across fulfillDemand, deliverLoad, and discardHandCore.
+   */
+  private static async persistEventEffect(
+    gameId: string,
+    eventResult: EventCardResult,
+    client: import('pg').PoolClient,
+    logPrefix: string,
+  ): Promise<void> {
+    if (eventResult.persistentEffectDescriptor) {
+      console.info(`[${logPrefix}] Persisting active effect: cardId=${eventResult.cardId} gameId=${gameId}`);
+      await activeEffectManager.addActiveEffect(
+        gameId,
+        eventResult.persistentEffectDescriptor,
+        eventResult.cardType,
+        eventResult.perPlayerEffects,
+        client,
+        eventResult.floodedRiver,
+      );
+    }
+  }
+
   /**
    * Return the canonical milepost key ("row,col") for a city name by looking
    * up the grid. Returns null if the city is not found.
@@ -892,16 +915,7 @@ export class PlayerService {
       while (drawResult !== null && drawResult.type === 'event') {
         console.info(`[fulfillDemand] Drew event card ${drawResult.card.id} — processing via EventCardService`);
         const eventResult = await EventCardService.processEventCard(gameId, drawResult.card, playerId, client);
-        if (eventResult.persistentEffectDescriptor) {
-          console.info(`[fulfillDemand] Persisting active effect: cardId=${drawResult.card.id} gameId=${gameId}`);
-          await activeEffectManager.addActiveEffect(
-            gameId,
-            eventResult.persistentEffectDescriptor,
-            eventResult.cardType,
-            eventResult.perPlayerEffects,
-            client,
-          );
-        }
+        await PlayerService.persistEventEffect(gameId, eventResult, client, 'fulfillDemand');
         demandDeckService.discardEventCard(drawResult.card.id);
         drawResult = demandDeckService.drawCard();
       }
@@ -1063,16 +1077,7 @@ export class PlayerService {
         discardedEventCardIds.push(eventCardId);
         console.info(`[deliverLoad] Drew event card ${eventCardId} — processing via EventCardService`);
         const deliverEventResult = await EventCardService.processEventCard(gameId, newDrawResult.card, playerId, client);
-        if (deliverEventResult.persistentEffectDescriptor) {
-          console.info(`[deliverLoad] Persisting active effect: cardId=${eventCardId} gameId=${gameId}`);
-          await activeEffectManager.addActiveEffect(
-            gameId,
-            deliverEventResult.persistentEffectDescriptor,
-            deliverEventResult.cardType,
-            deliverEventResult.perPlayerEffects,
-            client,
-          );
-        }
+        await PlayerService.persistEventEffect(gameId, deliverEventResult, client, 'deliverLoad');
         demandDeckService.discardEventCard(eventCardId);
         newDrawResult = demandDeckService.drawCard();
       }
@@ -1881,16 +1886,7 @@ export class PlayerService {
         // Process the event card via EventCardService (replaces Project 1 discard stub)
         console.info(`[discardHandCore] Drew event card ${result.card.id} — processing via EventCardService`);
         const discardEventResult = await EventCardService.processEventCard(gameId, result.card, playerId, client);
-        if (discardEventResult.persistentEffectDescriptor) {
-          console.info(`[discardHandCore] Persisting active effect: cardId=${result.card.id} gameId=${gameId}`);
-          await activeEffectManager.addActiveEffect(
-            gameId,
-            discardEventResult.persistentEffectDescriptor,
-            discardEventResult.cardType,
-            discardEventResult.perPlayerEffects,
-            client,
-          );
-        }
+        await PlayerService.persistEventEffect(gameId, discardEventResult, client, 'discardHandCore');
         demandDeckService.discardEventCard(result.card.id);
         discardedEventIds.push(result.card.id);
         continue;

--- a/src/shared/types/EventCard.ts
+++ b/src/shared/types/EventCard.ts
@@ -245,4 +245,6 @@ export interface EventCardResult {
   floodSegmentsRemoved: Array<{ playerId: string; removedCount: number }>;
   /** Present for all event types that produce persistent effects */
   persistentEffectDescriptor?: ActiveEffectDescriptor;
+  /** Flood only — river name for addActiveEffect persistence */
+  floodedRiver?: string;
 }


### PR DESCRIPTION
## Summary
- Refactored `PlayerService.updateCurrentPlayerIndex` to accept optional `PoolClient` for transactional operations, calling `cleanupExpiredEffects` for the previous player and `consumeLostTurn` for the next player with recursive advancement and infinite loop guard
- Integrated `ActiveEffectManager.addActiveEffect` into all three draw loop paths (`fulfillDemand`, `deliverLoadForUser`, `discardHandCore`) to persist event card effects when `persistentEffectDescriptor` is present
- Added 18 new unit tests covering turn-skip logic, effect expiry, infinite loop guard, and draw loop persistence

## Test plan
- [x] All 2340 existing tests pass
- [x] New turn-skip tests validate cleanup, skip, recursive advancement, and loop guard
- [x] New draw-loop tests validate effect persistence across all three paths
- [ ] Manual integration test with Derailment event causing turn skip

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR implements turn lifecycle management and draw loop integration for Phase 3 Sprint 3 of the EuroRails game. It enhances turn advancement with transactional effect expiry cleanup and Derailment turn-skipping logic, while integrating active effect persistence across all three draw loop paths (fulfillDemand, deliverLoadForUser, discardHandCore) to handle persistent event card effects. The implementation includes comprehensive test coverage and maintains backward compatibility.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>adds transactional turn lifecycle management in PlayerService.updateCurrentPlayerIndex with effect expiry cleanup and Derailment turn-skipping</li>

<li>integrates active effect persistence into demand fulfillment, load delivery, and hand discard draw loops</li>

<li>adds floodedRiver field support for Flood event persistence in EventCardResult interface and EventCardService</li>

<li>adds comprehensive unit tests covering turn-skip logic, effect expiry, infinite loop guard, and draw loop persistence</li>

</ul>
</details>

</div>