### PR TITLE
Fix Kalingrad grid location

### DIFF
--- a/configuration/gridPoints.json
+++ b/configuration/gridPoints.json
@@ -15057,10 +15057,26 @@
   },
   {
     "Id": "d5c6a0bb-bc2d-48e7-9cee-591d3b8be702",
+    "Type": "Small City",
+    "Name": "Kaliningrad",
+    "GridX": 63,
+    "GridY": 20,
+    "Ocean": null
+  },
+  {
+    "Id": "70e764f5-f314-4645-8e0e-22557405c70f",
     "Type": "Milepost",
     "Name": null,
     "GridX": 61,
-    "GridY": 20,
+    "GridY": 22,
+    "Ocean": null
+  },
+  {
+    "Id": "239c0ba9-eb16-49e4-b067-8871d2a2bb66",
+    "Type": "Milepost",
+    "Name": null,
+    "GridX": 63,
+    "GridY": 19,
     "Ocean": null
   },
   {
@@ -15068,7 +15084,7 @@
     "Type": "Milepost",
     "Name": null,
     "GridX": 61,
-    "GridY": 22,
+    "GridY": 20,
     "Ocean": null
   },
   {
@@ -15668,7 +15684,7 @@
     "Type": "Milepost",
     "Name": null,
     "GridX": 63,
-    "GridY": 20,
+    "GridY": 23,
     "Ocean": null
   },
   {
@@ -15832,27 +15848,11 @@
     "Ocean": null
   },
   {
-    "Id": "70e764f5-f314-4645-8e0e-22557405c70f",
-    "Type": "Milepost",
-    "Name": null,
-    "GridX": 63,
-    "GridY": 23,
-    "Ocean": null
-  },
-  {
     "Id": "d0547c6f-6ccc-440d-8174-97e21ac6fdfa",
     "Type": "Milepost",
     "Name": null,
     "GridX": 63,
     "GridY": 48,
-    "Ocean": null
-  },
-  {
-    "Id": "239c0ba9-eb16-49e4-b067-8871d2a2bb66",
-    "Type": "Small City",
-    "Name": "Kaliningrad",
-    "GridX": 63,
-    "GridY": 19,
     "Ocean": null
   },
   {


### PR DESCRIPTION
Kalingrad is on the edge and can only be reached from one gridpoint. This is due to slight misalignment and no 65th column of points. Point positioning on the map is very sensitive and it's easier to just move Kalingrad (even though a breaking change for any existing game) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Kalingrad is on the edge and can only be reached from one gridpoint. This is due to slight misalignment and no 65th column of points. Point positioning on the map is very sensitive and it's easier to just move Kalingrad (even though a breaking change for any existing game). This PR also adds real-time broadcasting of event card events in the Eurorails game, allowing clients to receive live updates when event cards are drawn, effects are applied or expired, and active effects are restored on reconnection.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds new socket event types for event card broadcasting in socketService.ts.</li>

<li>Modifies playerService.ts to emit events after DB persistence of event effects.</li>

<li>Updates state:init to include activeEffects for client reconnection.</li>

<li>Adds integration tests for event card lifecycle with real DB and mocked sockets.</li>

<li>Adds unit tests for socketService event broadcasting functions.</li>

</ul>
</details>

</div>