### PR TITLE
fix(ai): JIRA-257 — guardrail G1 bypasses pickup/delivery restriction

### DIFF
--- a/docs/ai/done/jira-257-guardrailG1BypassesPickupDeliveryRestriction-behavioral.md
+++ b/docs/ai/done/jira-257-guardrailG1BypassesPickupDeliveryRestriction-behavioral.md
@@ -1,0 +1,55 @@
+# JIRA-257 — Guardrail G1 "Force DELIVER" bypasses the pickup/delivery restriction predicate, causing 3-turn loops when an active Strike blocks the bot's only deliverable city (behavioral)
+
+In game `182bfd36-3d3d-46ef-9c1d-0c87373b983f` (Phase 4 — JIRA-256 in effect), a Coastal Strike event was active starting around turn 31. Players Haiku and s1 were each carrying a load with a matching demand at a coastal city covered by the Strike (Haiku: Marble at London; s1: Cars at Antwerpen). The bots' LLM/route-executor correctly chose `PassTurn` (Haiku) or `BuildTrack` (s1) as the turn action. The GuardrailEnforcer overrode that choice with a Forced DELIVER. PlayerService then rejected the delivery with `ActionRestrictionError(COASTAL_STRIKE_BLOCKED)`. The same override-and-reject sequence repeated for 3 consecutive turns per player before the Strike expired.
+
+## Source
+
+`logs/game-182bfd36-3d3d-46ef-9c1d-0c87373b983f.ndjson`, players Haiku (turns 31, 32, 33) and s1 (turns 31, 32).
+
+## Observed trace — Haiku at London with Marble (card 43, payout 31M)
+
+| Turn | LLM/executor chose | guardrailOverride | guardrailReason | TurnExecutor outcome | rejectionReason.code | cash after |
+|------|---------------------|-------------------|------------------|-----------------------|----------------------|------------|
+| 31 | PassTurn (`[stuck-route-abandon] no progress for 16 turns`) | true | "Forced DELIVER: Marble at London for 31M (LLM chose PassTurn)" | success=false; error="Delivery blocked by active event (Strike): city London is within the coastal strike zone" | COASTAL_STRIKE_BLOCKED | 31 (unchanged) |
+| 32 | PassTurn (`[route-planned] Deliver Marble at London…`) | true | (same) | success=false; (same error) | COASTAL_STRIKE_BLOCKED | 31 (unchanged) |
+| 33 | PassTurn (`[route-executor] stop 0/1, phase=build`) | true | (same) | success=false; (same error) | COASTAL_STRIKE_BLOCKED | 31 (unchanged) |
+
+## Observed trace — s1 at Antwerpen with Cars (card 110, payout 12M)
+
+| Turn | LLM/executor chose | guardrailOverride | guardrailReason | TurnExecutor outcome | rejectionReason.code |
+|------|---------------------|-------------------|------------------|-----------------------|----------------------|
+| 31 | PassTurn (`[stuck-route-abandon] no progress for 11 turns`) | true | "Forced DELIVER: Cars at Antwerpen for 12M (LLM chose PassTurn)" | success=false; error="Delivery blocked by active event (Strike): city Antwerpen is within the coastal strike zone" | COASTAL_STRIKE_BLOCKED |
+| 32 | BuildTrack (`[route-planned] [deterministic-top-1] pair:110-Cars+102-Copper…`) | true | "Forced DELIVER: Cars at Antwerpen for 12M (LLM chose BuildTrack)" | success=false; (same error) | COASTAL_STRIKE_BLOCKED |
+
+## Expected behavior
+
+When the GuardrailEnforcer is considering forcing a DELIVER override (i.e., the bot's hand has a deliverable load at its current city and the LLM chose something else), it should first check the active pickup/delivery restrictions and skip the override if the candidate delivery is blocked. The override exists to correct LLM strategy mistakes ("you should be delivering, not building"); it must not force an action that the game-rule layer will then reject as illegal.
+
+In the specific cases above:
+- Haiku turns 31–33: the LLM's `PassTurn` was the correct response to "I can't legally deliver Marble at London while the coastal Strike is active." The guardrail should have respected that and not overridden.
+- s1 turn 32: the LLM's `BuildTrack` toward Beograd was a legitimate non-delivery action during the Strike. The guardrail should have respected that and not overridden.
+
+## User-facing impact
+
+Per player, per active Strike that covers a city where the bot has a deliverable load: 2–3 wasted turns of `guardrailOverride: true` → `success: false` → no progress. Two players were hit simultaneously in this game; the Strike likely affected several other cities and players too, but those evidence rows weren't surveyed. Compounds with multiple Strike-vulnerable carried loads could lose 4–6 turns.
+
+There's also a downstream log-fidelity bug — the rejected DeliverLoad still appears in `loadsDelivered` and `actionTimeline` in the turn entry, falsely implying a successful delivery. That's tracked separately in JIRA-258 (different code locus).
+
+## Acceptance
+
+- **AC1** — Replicate Haiku T31 snapshot: bot at London carrying Marble, demand card `Marble→London` in hand, active effect `CoastalStrike` listing London in its restricted city set. Invoke `AIStrategyEngine.takeTurn` (or directly `GuardrailEnforcer.checkPlan` with a `PassTurn` plan and a `canDeliver` context containing Marble@London). Assert: the returned plan is NOT a forced DELIVER — it is the original PassTurn passed through.
+- **AC2** — Same fixture but no Strike active. Assert: G1 still fires and forces DELIVER (regression guard — the predicate-aware path must only suppress the override when the delivery is actually blocked).
+- **AC3** — Hand has TWO carried-deliverable loads, only one of which is at a Strike-blocked city. Bot is positioned at the blocked city; the other deliverable's city is on the bot's route but not currently reached. Assert: G1 does not force DELIVER for the blocked city. (Whether it forces DELIVER for the other city depends on `context.canDeliver` semantics — if the other isn't a `canDeliver`, then `PassTurn` should pass through.)
+- **AC4** — Integration: replay Haiku T31 of game `182bfd36-3d3d-46ef-9c1d-0c87373b983f`. Assert: the bot's turn action is `PassTurn` (not Forced DELIVER), `guardrailOverride` is `false` or `undefined`, and `rejectionReason` does NOT appear in the turn entry.
+
+## Not in scope
+
+- Any change to the `isPickupDeliveryBlocked` predicate itself — the predicate is correct (it correctly rejected the deliveries inside PlayerService); the bug is that the guardrail doesn't consult it before forcing.
+- Forced-DELIVER suppression for other restriction families (movement, build, lost-turn). Only the pickup/delivery family is in scope here.
+- The "loadsDelivered populated despite failed delivery" log-fidelity bug — see JIRA-258.
+- The "TripPlanner picks routes through Strike-blocked cities" candidate-enumeration bug — see JIRA-259.
+
+## Relationship to existing JIRAs
+
+- **JIRA-256** (Phase 4 — Bot Event-Card Awareness): this defect is a regression in BE-006's GuardrailEnforcer integration. BE-006 added the `PICKUP_DELIVERY_RESTRICTION_VIOLATION` gate inside `checkPlan`, but that gate runs AFTER the G1 Force DELIVER short-circuit, so it never gets a chance to suppress the override.
+- **JIRA-251** (bot blind to active rail strike): adjacent failure mode that JIRA-256 was meant to fix. The G1 bypass is the residual hole.

--- a/docs/ai/done/jira-257-guardrailG1BypassesPickupDeliveryRestriction-technical.md
+++ b/docs/ai/done/jira-257-guardrailG1BypassesPickupDeliveryRestriction-technical.md
@@ -1,0 +1,62 @@
+# JIRA-257 — Suppress Guardrail G1 force-delivery when the candidate is blocked by an active pickup/delivery restriction (technical)
+
+Companion to `jira-257-guardrailG1BypassesPickupDeliveryRestriction-behavioral.md`.
+
+## Defect locus
+
+`src/server/services/ai/GuardrailEnforcer.ts:70-86` — the first block of `checkPlan`, "Guardrail 1: Force DELIVER when canDeliver has opportunities". This block fires whenever `context.canDeliver.length > 0 && planType !== AIActionType.DeliverLoad` and returns immediately with `overridden: true`.
+
+The `isPickupDeliveryBlocked` predicate is correctly imported at line 36 and IS consulted inside the same `checkPlan` method at line 318 (the new BE-006 `PICKUP_DELIVERY_RESTRICTION_VIOLATION` gate). But that gate runs after G1, so when G1 short-circuits, the predicate-aware gate never runs against the forced plan.
+
+## Fix shape
+
+Inside the G1 block, after selecting `best = GuardrailEnforcer.bestDelivery(context)`, consult `isPickupDeliveryBlocked` against the candidate's delivery city BEFORE constructing the override. If the candidate is blocked, fall through to the next guardrail (do not return the override).
+
+Approximate change at GuardrailEnforcer.ts:70-86:
+
+```ts
+if (context.canDeliver.length > 0 && planType !== AIActionType.DeliverLoad) {
+  const best = GuardrailEnforcer.bestDelivery(context);
+  const activeEffects = snapshot.activeEffects ?? [];
+  const pickupDeliveryRestrictions = activeEffects.flatMap(e => e.restrictions.pickupDelivery);
+  const cityKey = getCityMilepointKey(best.deliveryCity);
+  const blocked = cityKey !== null && isPickupDeliveryBlocked(pickupDeliveryRestrictions, cityKey);
+  if (blocked) {
+    console.warn(`[Guardrail 1] Suppressing forced DELIVER: ${best.loadType} at ${best.deliveryCity} — blocked by active pickup/delivery restriction (event card)`);
+    // fall through — do NOT return the override
+  } else {
+    console.warn(`[Guardrail 1] Forced DELIVER: ${best.loadType} at ${best.deliveryCity} for ${best.payout}M (LLM chose ${planType})`);
+    return {
+      plan: { type: AIActionType.DeliverLoad, load: best.loadType, city: best.deliveryCity, cardId: best.cardIndex, payout: best.payout },
+      overridden: true,
+      reason: `Forced DELIVER: ${best.loadType} at ${best.deliveryCity} for ${best.payout}M (LLM chose ${planType})`,
+    };
+  }
+}
+```
+
+If `context.canDeliver` includes multiple options, the current `bestDelivery` picks the highest-payout one and stops; the simple fix above suppresses the override even if a non-blocked alternative exists in `canDeliver`. A second-pass refinement (out of scope for this ticket; file follow-up if needed): iterate `context.canDeliver` and return the highest-payout option whose delivery city is NOT blocked. The first-pass fix matches the immediate observed bug and avoids over-engineering until a real case appears where the bot has multiple simultaneous deliverable opportunities at differently-restricted cities.
+
+## Acceptance from behavioral
+
+- **AC1** — Unit test on `GuardrailEnforcer.checkPlan`: fixture with `context.canDeliver = [{ loadType: 'Marble', deliveryCity: 'London', payout: 31, cardIndex: 43 }]`, `plan = { type: PassTurn }`, `snapshot.activeEffects = [{ restrictions: { pickupDelivery: [{ kind: 'COASTAL_STRIKE_CITIES', cityMilepointKeys: [getCityMilepointKey('London')!] }] } }]`. Assert: returned plan has `overridden: false` (or `undefined`) and the original PassTurn passes through.
+- **AC2** — Unit test, same fixture but `snapshot.activeEffects = []`. Assert: G1 fires, returns `{ type: DeliverLoad, load: 'Marble', city: 'London' }`, `overridden: true`. Regression guard.
+- **AC3** — Unit test, two `canDeliver` entries — Marble@London (blocked by Strike) and Iron@Bremen (not blocked). Assert: with the simple first-pass fix, the override is suppressed (because `bestDelivery` picks London first). Document this in the test as a known limitation; the multi-candidate iteration is a follow-up.
+- **AC4** — Integration: replay Haiku T31 of game `182bfd36-3d3d-46ef-9c1d-0c87373b983f` via the existing replay harness (if available) or a synthetic snapshot matching that turn. Assert: turn entry has `action: PassTurn`, no `guardrailOverride`, no `rejectionReason`.
+
+## Validation hooks to inspect during fix
+
+- The new console.warn line `[Guardrail 1] Suppressing forced DELIVER` should appear in stderr for Haiku turns 31–33 and s1 turns 31–32 when replaying.
+- Turn entries for those turns should NOT have `rejectionReason: { code: 'COASTAL_STRIKE_BLOCKED', ... }` after the fix.
+- `cash` should still be 31 (Haiku) and 20 (s1) — the bot couldn't actually earn anything during the Strike — but the bot now legally passes/builds rather than spamming a rejected delivery.
+
+## Not in scope
+
+- Multi-candidate iteration through `context.canDeliver` to find a non-blocked alternative. First-pass fix suppresses-or-allows the top candidate only.
+- Equivalent suppression logic for other guardrails (broke-and-stuck DiscardHand, etc.) — those don't construct forced deliveries.
+- Changes to `isPickupDeliveryBlocked` itself, or to `WorldSnapshotService` population of `activeEffects`. The predicate and snapshot are correct; only the guardrail caller is missing the check.
+- Generalizing to a `checkPredicatesBeforeOverride` helper. The G1 block is the only override that constructs a DeliverLoad; no other overrides need this gate.
+
+## Relationship to existing JIRAs
+
+- **JIRA-256 / BE-006**: this is a fix-up to the BE-006 integration. The fix is small and self-contained; no spec change to JIRA-256 needed beyond adding a note that the G1 override path also needs the predicate consultation.

--- a/src/server/__tests__/GuardrailEnforcer.test.ts
+++ b/src/server/__tests__/GuardrailEnforcer.test.ts
@@ -463,4 +463,69 @@ describe('GuardrailEnforcer.checkPlan — broke-and-stuck guardrail (JIRA-177, J
       expect(result.violationCode).toBe('PICKUP_DELIVERY_RESTRICTION_VIOLATION');
     });
   });
+
+  // JIRA-257: G1 (force deliver) must consult pickup/delivery restriction predicate
+  // before constructing the override, otherwise it forces a delivery the rule layer
+  // will reject and the bot loops every turn until the Strike expires.
+  describe('Event card: G1 force-deliver suppression (JIRA-257)', () => {
+    it('suppresses forced DELIVER when best canDeliver target is in active Strike zone — original PassTurn passes through', async () => {
+      const snapshot = makeSnapshot();
+      snapshot.activeEffects = [
+        makeActiveEffect({
+          pickupDelivery: [{ type: 'no_pickup_delivery_in_zone', zone: ['20,47'] }], // Hamburg key
+        }),
+      ];
+      const canDeliver = [{ loadType: 'Coal', deliveryCity: 'Hamburg', payout: 31, cardIndex: 43 }];
+      const context = makeContext({
+        canDeliver,
+        demands: [makeDemand({ isAffordable: true, isSupplyOnNetwork: true, isDeliveryOnNetwork: true })],
+      } as any);
+
+      const result = await GuardrailEnforcer.checkPlan(passTurnPlan, context, snapshot, true);
+
+      expect(result.plan.type).toBe(AIActionType.PassTurn);
+      expect(result.overridden).toBe(false);
+    });
+
+    it('still forces DELIVER when no Strike is active (regression guard)', async () => {
+      const snapshot = makeSnapshot();
+      snapshot.activeEffects = [];
+      const canDeliver = [{ loadType: 'Coal', deliveryCity: 'Hamburg', payout: 31, cardIndex: 43 }];
+      const context = makeContext({
+        canDeliver,
+        demands: [makeDemand({ isAffordable: true, isSupplyOnNetwork: true, isDeliveryOnNetwork: true })],
+      } as any);
+
+      const result = await GuardrailEnforcer.checkPlan(passTurnPlan, context, snapshot, true);
+
+      expect(result.plan.type).toBe(AIActionType.DeliverLoad);
+      expect(result.overridden).toBe(true);
+    });
+
+    it('suppresses forced DELIVER when bestDelivery picks blocked candidate, even if non-blocked alternative exists (documented first-pass limitation)', async () => {
+      // Best by payout = Hamburg-blocked at 31M. Paris alternative at 12M not blocked.
+      // The simple fix suppresses the override entirely because bestDelivery picks Hamburg.
+      // Iterating canDeliver for a non-blocked alternative is intentionally out of scope —
+      // documented in the JIRA-257 technical ticket as a follow-up if observed in production.
+      const snapshot = makeSnapshot();
+      snapshot.activeEffects = [
+        makeActiveEffect({
+          pickupDelivery: [{ type: 'no_pickup_delivery_in_zone', zone: ['20,47'] }], // Hamburg
+        }),
+      ];
+      const canDeliver = [
+        { loadType: 'Coal', deliveryCity: 'Hamburg', payout: 31, cardIndex: 43 },
+        { loadType: 'Iron', deliveryCity: 'Paris', payout: 12, cardIndex: 44 },
+      ];
+      const context = makeContext({
+        canDeliver,
+        demands: [makeDemand({ isAffordable: true, isSupplyOnNetwork: true, isDeliveryOnNetwork: true })],
+      } as any);
+
+      const result = await GuardrailEnforcer.checkPlan(passTurnPlan, context, snapshot, true);
+
+      expect(result.plan.type).toBe(AIActionType.PassTurn);
+      expect(result.overridden).toBe(false);
+    });
+  });
 });

--- a/src/server/services/ai/GuardrailEnforcer.ts
+++ b/src/server/services/ai/GuardrailEnforcer.ts
@@ -69,20 +69,38 @@ export class GuardrailEnforcer {
 
     // Guardrail 1: Force DELIVER when canDeliver has opportunities
     // Checked FIRST — delivery opportunities must never be blocked by stuck detection (JIRA-47)
+    //
+    // JIRA-257: Before forcing the override, consult the active pickup/delivery
+    // restrictions. If the candidate's delivery city is blocked by an active
+    // event (e.g., Coastal Strike), suppress the override and fall through —
+    // forcing a delivery the rule layer will reject just produces a wasted-turn
+    // loop. The downstream PICKUP_DELIVERY_RESTRICTION gate would catch it on
+    // an LLM-issued plan but never runs once G1 short-circuits with `overridden`.
     if (context.canDeliver.length > 0 && planType !== AIActionType.DeliverLoad) {
       const best = GuardrailEnforcer.bestDelivery(context);
-      console.warn(`[Guardrail 1] Forced DELIVER: ${best.loadType} at ${best.deliveryCity} for ${best.payout}M (LLM chose ${planType})`);
-      return {
-        plan: {
-          type: AIActionType.DeliverLoad,
-          load: best.loadType,
-          city: best.deliveryCity,
-          cardId: best.cardIndex,
-          payout: best.payout,
-        },
-        overridden: true,
-        reason: `Forced DELIVER: ${best.loadType} at ${best.deliveryCity} for ${best.payout}M (LLM chose ${planType})`,
-      };
+      const g1ActiveEffects = snapshot.activeEffects ?? [];
+      const g1PickupDeliveryRestrictions = g1ActiveEffects.flatMap(e => e.restrictions.pickupDelivery);
+      let g1Blocked = false;
+      if (g1PickupDeliveryRestrictions.length > 0) {
+        const cityKey = getCityMilepointKey(best.deliveryCity) ?? '';
+        g1Blocked = isPickupDeliveryBlocked(g1PickupDeliveryRestrictions, cityKey).blocked;
+      }
+      if (g1Blocked) {
+        console.warn(`[Guardrail 1] Suppressed forced DELIVER: ${best.loadType} at ${best.deliveryCity} is blocked by active event card (pickup/delivery restriction) — falling through`);
+      } else {
+        console.warn(`[Guardrail 1] Forced DELIVER: ${best.loadType} at ${best.deliveryCity} for ${best.payout}M (LLM chose ${planType})`);
+        return {
+          plan: {
+            type: AIActionType.DeliverLoad,
+            load: best.loadType,
+            city: best.deliveryCity,
+            cardId: best.cardIndex,
+            payout: best.payout,
+          },
+          overridden: true,
+          reason: `Forced DELIVER: ${best.loadType} at ${best.deliveryCity} for ${best.payout}M (LLM chose ${planType})`,
+        };
+      }
     }
 
     // Stuck / Unaffordable-and-stuck guardrail: force DiscardHand when the bot has no active


### PR DESCRIPTION
## Summary

Phase 2 fix stacked on **PR #247** (JIRA-256 foundation). When a Strike or other pickup/delivery restriction is active, guardrail G1 was forcing a delivery without first consulting the restriction predicate. This PR makes G1 check `restrictionPredicates.canDeliver` before forcing the action, falling through to the next guardrail when blocked.

## Per-ticket docs
- `docs/ai/done/jira-257-guardrailG1BypassesPickupDeliveryRestriction-behavioral.md`
- `docs/ai/done/jira-257-guardrailG1BypassesPickupDeliveryRestriction-technical.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Once PR #247 merges, retarget base to `main`

**Base**: `pr/jira-256-foundation` (PR #247). Will retarget to `main` once foundation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)