### PR TITLE
fix(ai): JIRA-258 — turn-log shows fake delivery on rejected action

### DIFF
--- a/docs/ai/done/jira-258-turnLogShowsFakeDeliveryOnRejectedAction-behavioral.md
+++ b/docs/ai/done/jira-258-turnLogShowsFakeDeliveryOnRejectedAction-behavioral.md
@@ -1,0 +1,58 @@
+# JIRA-258 — Turn-log `loadsDelivered` and `actionTimeline` show a delivery that didn't actually happen when the underlying action was rejected by an event-card restriction (behavioral)
+
+In game `182bfd36-3d3d-46ef-9c1d-0c87373b983f`, several turn entries for Haiku and s1 have a `rejectionReason` populated (the action was rejected by an active Strike), `success: false`, an `error` describing the rejection, AND `cash` unchanged across turns — clearly indicating no delivery payment was received. Yet the same turn entries also populate `loadsDelivered` and `actionTimeline` with the rejected delivery as though it had succeeded. This makes the NDJSON log misleading to anyone reading it (human or downstream tool) and breaks any aggregation that totals "loads delivered this game" from log data.
+
+## Source
+
+`logs/game-182bfd36-3d3d-46ef-9c1d-0c87373b983f.ndjson`, Haiku turn 31, fields below excerpted from a single line:
+
+```json
+{
+  "turn": 31,
+  "playerName": "Haiku",
+  "success": false,
+  "error": "Delivery blocked by active event (Strike): city London is within the coastal strike zone",
+  "rejectionReason": {
+    "code": "COASTAL_STRIKE_BLOCKED",
+    "message": "Delivery blocked by active event (Strike): city London is within the coastal strike zone"
+  },
+  "loadsDelivered": [
+    { "loadType": "Marble", "city": "London", "payment": 31, "cardId": 43 }
+  ],
+  "actionTimeline": [
+    { "type": "deliver", "loadType": "Marble", "city": "London", "payment": 31, "cardId": 43 }
+  ],
+  "cash": 31,
+  "victoryCheck": { "outcome": "insufficient-funds", "netWorth": 31, "threshold": 250 }
+}
+```
+
+`cash` stays at 31 across turns 31, 32, and 33 — confirming the 31M Marble delivery never paid out. The matching s1 entries at Antwerpen show the same pattern (`loadsDelivered: [{Cars, Antwerpen, 12, 110}]` with `success: false` and `cash: 20` unchanged).
+
+## Expected behavior
+
+The per-turn log fields `loadsDelivered` and `actionTimeline` should reflect what was actually executed and accepted by the game-rule layer — not what the plan intended to execute. When `TurnExecutor.handleDeliverLoad` (or its sibling handlers) returns `success: false` with a `rejectionReason`, the corresponding action should NOT appear in `loadsDelivered` (delivery didn't happen) and should EITHER be excluded from `actionTimeline` OR be marked with an outcome field (e.g. `outcome: 'rejected', code: 'COASTAL_STRIKE_BLOCKED'`) so downstream consumers can tell apart "executed" from "attempted-and-rejected".
+
+The exact serialization (exclude vs. annotate) is a design call — see the technical ticket for the recommended option.
+
+## Acceptance
+
+- **AC1** — Replicate Haiku T31 snapshot. Run the turn through `AIStrategyEngine.takeTurn` with the BE-006 PICKUP_DELIVERY restriction active. Assert: the resulting turn-log entry has `success: false`, `rejectionReason.code = 'COASTAL_STRIKE_BLOCKED'`, AND `loadsDelivered` is either absent or empty.
+- **AC2** — Same fixture, no Strike active. Assert: turn-log entry has `success: true`, `loadsDelivered = [{ loadType: 'Marble', city: 'London', payment: 31, cardId: 43 }]`. Regression guard.
+- **AC3** — `actionTimeline` policy decision (decided in technical ticket): assert the chosen behavior — either the rejected step is excluded, or it's present with an `outcome: 'rejected'` annotation. One option must be chosen and tested; both are acceptable, but the chosen one must be consistent across pickup, delivery, build, and move handlers.
+- **AC4** — Integration: replay Haiku T31 of game `182bfd36-3d3d-46ef-9c1d-0c87373b983f`. Assert: the turn entry's `loadsDelivered` is absent/empty.
+
+## Not in scope
+
+- The root-cause behavior that produced the rejected deliveries in the first place — that's JIRA-257.
+- Other field inconsistencies in the turn log (e.g., `actionBreakdown`, `compositionTrace.deliveries`). If those have the same plan-vs-outcome divergence under rejection, file follow-ups; this ticket scopes to `loadsDelivered` and `actionTimeline` because those are the two fields demonstrably misleading in the observed game.
+- Backfilling old logs. Apply the fix going forward only; historical NDJSON files can stay as-is.
+
+## User-facing impact
+
+Per turn where a delivery is rejected by an event-card restriction: one fake `loadsDelivered` entry. Across two players in this single game's 3-turn Strike window: 5 fake entries (3 Haiku, 2 s1). At scale, any analyst running "deliveries per game" or "income per player" queries off the NDJSON gets the wrong number whenever an event card rejected a delivery.
+
+## Relationship to existing JIRAs
+
+- **JIRA-256 / BE-008**: BE-008 added `rejectionReason` plumbing in `TurnExecutor` (the per-action handlers) and `ExecutionResult`. That part is correct — the handlers DO return clean `success: false` results. The bug is upstream of that, in `AIStrategyEngine.takeTurn`'s log-building loop which walks plan steps, not execution outcomes.
+- **JIRA-257**: closely related — the rejected deliveries that surface this log bug were caused by the guardrail bypass. Fixing 257 reduces (but doesn't eliminate) the symptom; this ticket fixes the log fidelity independently so future event-card rejections from any cause also produce accurate logs.

--- a/docs/ai/done/jira-258-turnLogShowsFakeDeliveryOnRejectedAction-technical.md
+++ b/docs/ai/done/jira-258-turnLogShowsFakeDeliveryOnRejectedAction-technical.md
@@ -1,0 +1,91 @@
+# JIRA-258 — Make turn-log `loadsDelivered` and `actionTimeline` reflect execution outcomes, not plan intent, when an action is rejected (technical)
+
+Companion to `jira-258-turnLogShowsFakeDeliveryOnRejectedAction-behavioral.md`.
+
+## Defect locus
+
+`src/server/services/ai/AIStrategyEngine.ts:883-912` — the post-execution log-assembly loop in `takeTurn`. The loop walks `allSteps` (which is `finalPlan.type === 'MultiAction' ? finalPlan.steps : [finalPlan]`) and pushes every `DeliverLoad` step into `loadsDelivered` and every step into `actionTimeline` (via `buildActionTimeline(allSteps)`). It uses the **plan** as the source of truth, not the per-step execution outcome.
+
+Specifically:
+
+```ts
+// line 898-905
+if (step.type === AIActionType.DeliverLoad && 'load' in step && 'city' in step) {
+  loadsDelivered.push({
+    loadType: step.load as string,
+    city: step.city as string,
+    payment: (step as any).payout ?? 0,
+    cardId: (step as any).cardId ?? 0,
+  });
+}
+```
+
+There's no consultation of the `ExecutionResult` (or its new `rejectionReason` field from BE-008). Same problem applies to `buildActionTimeline(allSteps)` at line 915.
+
+## Fix shape
+
+Two viable approaches; recommendation = (B) Annotated, because it preserves auditability ("the plan tried to deliver, but the rejection happened") while keeping `loadsDelivered` honest.
+
+### Option A — Exclude rejected steps
+
+In `TurnExecutor.execute`, attach the per-step `ExecutionResult` (or just its `success` flag + `rejectionReason`) to each step in a parallel array. Pass that array out alongside the final composed plan. In `AIStrategyEngine.takeTurn`, only push to `loadsDelivered` if the corresponding step's execution result has `success: true`. Drop rejected steps from `actionTimeline` entirely.
+
+Pros: simplest log semantics ("if it's in the log, it happened").
+Cons: loses the audit trail of "the bot tried X and got rejected" — though `rejectionReason` at the turn level still captures that.
+
+### Option B — Annotate rejected steps (recommended)
+
+Same per-step result plumbing as Option A. In `AIStrategyEngine.takeTurn`:
+- For `loadsDelivered`: only push the step if execution succeeded. (No "rejected delivery" entry — `loadsDelivered` should only contain actual deliveries by name.)
+- For `actionTimeline`: include the step regardless, but annotate with an `outcome` field: `'executed' | 'rejected'`, plus `rejectionCode` when rejected. This preserves the timeline order ("the bot was at London, tried to deliver Marble, got rejected") for replay/animation purposes.
+
+Type change in `GameLogger.ts:187`:
+
+```ts
+loadsDelivered?: Array<{ loadType: string; city: string; payment: number; cardId: number }>;
+```
+
+stays as-is.
+
+Type change for `actionTimeline` entries:
+
+```ts
+type ActionTimelineEntry =
+  | { type: 'move' | 'pickup' | 'build'; /* existing fields */ outcome?: 'executed' | 'rejected'; rejectionCode?: string }
+  | { type: 'deliver'; loadType: string; city: string; payment: number; cardId: number; outcome?: 'executed' | 'rejected'; rejectionCode?: string };
+```
+
+(The `outcome` field is optional to preserve backward compatibility with existing log entries where every step was assumed executed.)
+
+### Plumbing details
+
+`TurnExecutor.execute` currently returns a single composed `ExecutionResult` for the whole turn. It needs to surface per-step outcomes so the log builder can match them up. Two options:
+
+1. **Inline on the plan**: monkey-patch each step's object with an `_outcome` field after the executor processes it (ugly, mutates plan objects).
+2. **Side array**: have `TurnExecutor.execute` return `{ result: ExecutionResult, stepResults: Array<{ index: number, success: boolean, rejectionReason?: { code, message } }> }`. The log builder zips `allSteps` with `stepResults` by index.
+
+Option 2 is cleaner; recommended.
+
+## Acceptance from behavioral
+
+- **AC1** Unit test on the log builder: pass a fixture plan with one `DeliverLoad` step and a `stepResults` array marking that step as `success: false, rejectionReason: { code: 'COASTAL_STRIKE_BLOCKED' }`. Assert: returned log fields have `loadsDelivered` absent/empty.
+- **AC2** Unit test, same fixture but `stepResults: [{ index: 0, success: true }]`. Assert: `loadsDelivered = [{ loadType: 'Marble', city: 'London', payment: 31, cardId: 43 }]`. Regression guard.
+- **AC3** Unit test on `actionTimeline`: chosen policy (Option B recommended) — assert the rejected step appears in `actionTimeline` with `outcome: 'rejected', rejectionCode: 'COASTAL_STRIKE_BLOCKED'`. If Option A is chosen instead, assert the step is excluded.
+- **AC4** Integration: replay Haiku T31 of game `182bfd36-3d3d-46ef-9c1d-0c87373b983f` (or a synthetic snapshot matching it). Assert: turn-log entry's `loadsDelivered` is absent/empty.
+
+## Validation hooks to inspect during fix
+
+- After the fix, grep the NDJSON for entries where `rejectionReason` is set AND `loadsDelivered` is non-empty:
+  `jq -c 'select(.rejectionReason and (.loadsDelivered|length // 0) > 0)' logs/game-*.ndjson` should return zero rows for any post-fix game.
+- The existing `logRoutes.ts` consumers at lines 476, 502, 671 read `loadsDelivered` for deliveries-per-turn aggregation; after the fix those counts will be accurate.
+
+## Not in scope
+
+- Fixing other plan-vs-outcome divergences for `actionBreakdown`, `compositionTrace.deliveries`, `compositionTrace.pickups`, `milepostsMoved`. If those have the same issue under rejection, file follow-ups — this ticket scopes to `loadsDelivered` and `actionTimeline`.
+- Reverting historical NDJSON files. Going-forward only.
+- Replacing the "walk plan steps" approach with "consume TurnExecutor's per-action audit log" wholesale. Stays a minimal patch that augments the existing loop with per-step outcomes.
+
+## Relationship to existing JIRAs
+
+- **JIRA-256 / BE-008**: BE-008 added `rejectionReason` to `ExecutionResult` and to per-handler returns inside `TurnExecutor`. That work is intact and correct. This ticket extends the surfacing of those rejections one level up — into the per-step accounting consumed by the log builder in `AIStrategyEngine.takeTurn`.
+- **JIRA-257**: the cause of the rejected deliveries surfaced in this game. Fix 257 first if implementing both — it eliminates most occurrences of the symptom. But 258 is an independent log-fidelity fix that should land regardless, so future rejections (from any cause: lost-turn, movement restriction, etc.) also log honestly.

--- a/src/server/__tests__/TurnExecutor.rejectionReason.test.ts
+++ b/src/server/__tests__/TurnExecutor.rejectionReason.test.ts
@@ -246,4 +246,84 @@ describe('TurnExecutor — rejection plumbing (ActionRestrictionError)', () => {
       await expect(TurnExecutor.executePlan(plan as any, makeSnapshot())).rejects.toThrow('Demand card not in hand');
     });
   });
+
+  // JIRA-258: failedStepIndex plumbing so the log builder can distinguish
+  // executed steps from rejected/unattempted steps.
+  describe('JIRA-258 failedStepIndex', () => {
+    it('single-action rejection populates failedStepIndex = 0', async () => {
+      const error = makeRestrictionError('COASTAL_STRIKE_BLOCKED', 'Delivery blocked by Strike');
+      mockDeliverLoadForUser.mockRejectedValue(error);
+
+      const plan = {
+        type: AIActionType.DeliverLoad,
+        load: 'Coal',
+        city: 'Hamburg',
+        cardId: 1,
+        payout: 20,
+      };
+
+      const result = await TurnExecutor.executePlan(plan as any, makeSnapshot());
+
+      expect(result.success).toBe(false);
+      expect(result.failedStepIndex).toBe(0);
+    });
+
+    it('successful single-action leaves failedStepIndex undefined', async () => {
+      mockDeliverLoadForUser.mockResolvedValue({
+        payment: 20,
+        newCard: { id: 99 },
+        updatedMoney: 70,
+      } as any);
+
+      const plan = {
+        type: AIActionType.DeliverLoad,
+        load: 'Coal',
+        city: 'Hamburg',
+        cardId: 1,
+        payout: 20,
+      };
+
+      const result = await TurnExecutor.executePlan(plan as any, makeSnapshot());
+
+      expect(result.success).toBe(true);
+      expect(result.failedStepIndex).toBeUndefined();
+    });
+
+    it('MultiAction rejection at step 1 populates failedStepIndex = 1 (step 0 already committed)', async () => {
+      // Step 0: MoveTrain succeeds. Step 1: DeliverLoad rejected.
+      // Configure the MapTopology mock so the post-move position '10,11' has a
+      // named city — otherwise executeMultiAction's JIRA-83 skip drops the
+      // DeliverLoad step before it can fail.
+      const mapTopology = jest.requireMock('../services/MapTopology') as any;
+      mapTopology.loadGridPoints.mockReturnValueOnce(new Map([
+        ['10,11', { name: 'Hamburg', terrain: 2 }],
+      ]));
+      mockMoveTrainForUser.mockResolvedValue({ ok: true, updatedMoney: 50 } as any);
+      const error = makeRestrictionError('COASTAL_STRIKE_BLOCKED', 'Delivery blocked by Strike');
+      mockDeliverLoadForUser.mockRejectedValue(error);
+
+      const multiPlan = {
+        type: 'MultiAction',
+        steps: [
+          {
+            type: AIActionType.MoveTrain,
+            path: [{ row: 10, col: 10 }, { row: 10, col: 11 }],
+          },
+          {
+            type: AIActionType.DeliverLoad,
+            load: 'Coal',
+            city: 'Hamburg',
+            cardId: 1,
+            payout: 20,
+          },
+        ],
+      };
+
+      const result = await TurnExecutor.executePlan(multiPlan as any, makeSnapshot());
+
+      expect(result.success).toBe(false);
+      expect(result.failedStepIndex).toBe(1);
+      expect(result.rejectionReason?.code).toBe('COASTAL_STRIKE_BLOCKED');
+    });
+  });
 });

--- a/src/server/__tests__/ai/AIStrategyEngine.timeline.test.ts
+++ b/src/server/__tests__/ai/AIStrategyEngine.timeline.test.ts
@@ -175,4 +175,76 @@ describe('buildActionTimeline', () => {
     expect(result).toHaveLength(5);
     expect(result.map(s => s.type)).toEqual(['move', 'pickup', 'move', 'deliver', 'move']);
   });
+
+  // JIRA-258: when a step is rejected, the failed step is annotated with
+  // outcome: 'rejected' and any steps after it are dropped from the timeline.
+  describe('JIRA-258 rejection annotation', () => {
+    it('annotates the failed step with outcome: rejected and rejectionCode when failedStepIndex is provided', () => {
+      const steps: TurnPlan[] = [
+        {
+          type: AIActionType.DeliverLoad,
+          load: 'Marble',
+          city: 'London',
+          cardId: 43,
+          payout: 31,
+        },
+      ];
+      const result = AIStrategyEngine.buildActionTimeline(steps, 0, 'COASTAL_STRIKE_BLOCKED');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: 'deliver',
+        loadType: 'Marble',
+        city: 'London',
+        outcome: 'rejected',
+        rejectionCode: 'COASTAL_STRIKE_BLOCKED',
+      });
+    });
+
+    it('drops steps after the failed step (those steps were never attempted)', () => {
+      const steps: TurnPlan[] = [
+        {
+          type: AIActionType.MoveTrain,
+          path: [{ row: 1, col: 1 }, { row: 1, col: 2 }],
+          fees: new Set(),
+          totalFee: 0,
+        } as any,
+        {
+          type: AIActionType.DeliverLoad,
+          load: 'Marble',
+          city: 'London',
+          cardId: 43,
+          payout: 31,
+        } as any,
+        {
+          type: AIActionType.MoveTrain,
+          path: [{ row: 1, col: 2 }, { row: 1, col: 3 }],
+          fees: new Set(),
+          totalFee: 0,
+        } as any,
+      ];
+      const result = AIStrategyEngine.buildActionTimeline(steps, 1, 'COASTAL_STRIKE_BLOCKED');
+      // First move (succeeded) + rejected deliver. The second move is dropped (not attempted).
+      expect(result).toHaveLength(2);
+      expect(result[0].type).toBe('move');
+      expect((result[0] as any).outcome).toBeUndefined();
+      expect(result[1]).toMatchObject({ type: 'deliver', outcome: 'rejected', rejectionCode: 'COASTAL_STRIKE_BLOCKED' });
+    });
+
+    it('regression guard: no failedStepIndex means no rejection annotation (existing callers unchanged)', () => {
+      const steps: TurnPlan[] = [
+        {
+          type: AIActionType.DeliverLoad,
+          load: 'Marble',
+          city: 'London',
+          cardId: 43,
+          payout: 31,
+        },
+      ];
+      const result = AIStrategyEngine.buildActionTimeline(steps);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ type: 'deliver' });
+      expect((result[0] as any).outcome).toBeUndefined();
+      expect((result[0] as any).rejectionCode).toBeUndefined();
+    });
+  });
 });

--- a/src/server/services/ai/AIStrategyEngine.ts
+++ b/src/server/services/ai/AIStrategyEngine.ts
@@ -884,7 +884,17 @@ export class AIStrategyEngine {
       const loadsPickedUp: Array<{ loadType: string; city: string }> = [];
       const allSteps = finalPlan.type === 'MultiAction' ? finalPlan.steps : [finalPlan];
       const majorCityLookupForLog = getMajorCityLookup();
-      for (const step of allSteps) {
+      // JIRA-258: walk only steps that actually executed. When result.success
+      // is false, result.failedStepIndex marks the step that the rule layer
+      // rejected; steps before it committed normally and stay in the log,
+      // and steps at-or-after it are skipped from the success-claim fields
+      // (loadsDelivered / loadsPickedUp / milepostsMoved / movementPath).
+      const failedStepIndex = result.failedStepIndex;
+      const lastExecutedIndex = !result.success && failedStepIndex !== undefined
+        ? failedStepIndex - 1
+        : allSteps.length - 1;
+      for (let i = 0; i <= lastExecutedIndex; i++) {
+        const step = allSteps[i];
         if (step.type === AIActionType.MoveTrain) {
           milepostsMoved = (milepostsMoved ?? 0) + (step.path.length > 0 ? computeEffectivePathLength(step.path, majorCityLookupForLog) : 0);
           trackUsageFee = (trackUsageFee ?? 0) + step.totalFee;
@@ -911,8 +921,14 @@ export class AIStrategyEngine {
         }
       }
 
-      // Build structured action timeline for animated partial turn movements
-      const actionTimeline = AIStrategyEngine.buildActionTimeline(allSteps);
+      // Build structured action timeline for animated partial turn movements.
+      // JIRA-258: pass execution outcome so the failed step is marked rejected
+      // and unattempted later steps are dropped from the timeline.
+      const actionTimeline = AIStrategyEngine.buildActionTimeline(
+        allSteps,
+        result.success ? undefined : failedStepIndex,
+        result.success ? undefined : result.rejectionReason?.code,
+      );
 
       // JIRA-143: Map model → actor metadata
       const actorMeta = AIStrategyEngine.mapActorMetadata(decision.model, guardrailResult.overridden);
@@ -1144,14 +1160,34 @@ export class AIStrategyEngine {
     }
   }
 
-  /** Build a structured action timeline from composed plan steps. */
-  static buildActionTimeline(allSteps: TurnPlan[]): TimelineStep[] {
+  /**
+   * Build a structured action timeline from composed plan steps.
+   *
+   * JIRA-258: when an execution failure is reported, the step at
+   * `failedStepIndex` is annotated with `outcome: 'rejected'` (and the
+   * provided `rejectionCode`); steps at indices > failedStepIndex are
+   * dropped because executeMultiAction stops at the first failure and
+   * those steps were never attempted.
+   */
+  static buildActionTimeline(
+    allSteps: TurnPlan[],
+    failedStepIndex?: number,
+    rejectionCode?: string,
+  ): TimelineStep[] {
     const timeline: TimelineStep[] = [];
-    for (const step of allSteps) {
+    const lastIncludedIndex = failedStepIndex !== undefined
+      ? failedStepIndex
+      : allSteps.length - 1;
+    for (let i = 0; i <= lastIncludedIndex && i < allSteps.length; i++) {
+      const step = allSteps[i];
+      const rejected = failedStepIndex !== undefined && i === failedStepIndex;
+      const annotation = rejected
+        ? { outcome: 'rejected' as const, rejectionCode }
+        : {};
       switch (step.type) {
         case AIActionType.MoveTrain:
           if (step.path && step.path.length > 0) {
-            timeline.push({ type: 'move', path: step.path.map(p => ({ row: p.row, col: p.col })) });
+            timeline.push({ type: 'move', path: step.path.map(p => ({ row: p.row, col: p.col })), ...annotation });
           }
           break;
         case AIActionType.DeliverLoad:
@@ -1161,6 +1197,7 @@ export class AIStrategyEngine {
             city: (step as any).city ?? '',
             payment: (step as any).payout ?? 0,
             cardId: (step as any).cardId ?? 0,
+            ...annotation,
           });
           break;
         case AIActionType.PickupLoad:
@@ -1168,6 +1205,7 @@ export class AIStrategyEngine {
             type: 'pickup',
             loadType: (step as any).load ?? '',
             city: (step as any).city ?? '',
+            ...annotation,
           });
           break;
         case AIActionType.BuildTrack:
@@ -1175,6 +1213,7 @@ export class AIStrategyEngine {
             type: 'build',
             segmentsBuilt: (step as any).segments?.length ?? 0,
             cost: (step as any).cost ?? 0,
+            ...annotation,
           });
           break;
         case AIActionType.UpgradeTrain:

--- a/src/server/services/ai/TurnExecutor.ts
+++ b/src/server/services/ai/TurnExecutor.ts
@@ -42,6 +42,15 @@ export interface ExecutionResult {
    * cards drawn during card replacement.
    */
   cardsDrawnDuringAction?: number;
+  /**
+   * JIRA-258: Index of the step that failed within the executed plan's step list.
+   * For single-action plans this is always 0 when success === false; for
+   * MultiAction plans it points to the first failing step (subsequent steps were
+   * not attempted). Undefined when success === true.
+   * Consumed by AIStrategyEngine's log builder to avoid stamping a "delivery
+   * happened" log line for an action the rule layer rejected.
+   */
+  failedStepIndex?: number;
 }
 
 export class TurnExecutor {
@@ -114,6 +123,13 @@ export class TurnExecutor {
 
     const option = TurnExecutor.planToOption(plan);
     const result = await TurnExecutor.execute(option, snapshot);
+
+    // JIRA-258: tag single-action failures with the (only) step's index so the
+    // log builder can tell apart "delivery happened" from "delivery attempted
+    // and rejected." MultiAction sets failedStepIndex in executeMultiAction.
+    if (!result.success && result.failedStepIndex === undefined) {
+      result.failedStepIndex = 0;
+    }
 
     // Mid-turn re-snapshot: when an action draws new cards (e.g., a delivery), the
     // active event effects may have changed because event cards can be drawn as part
@@ -238,7 +254,8 @@ export class TurnExecutor {
     let lastResult: ExecutionResult | null = null;
     const concatenatedPath: { row: number; col: number }[] = [];
 
-    for (const step of steps) {
+    for (let stepIndex = 0; stepIndex < steps.length; stepIndex++) {
+      const step = steps[stepIndex];
       // JIRA-173: Skip plans that were already executed during TurnExecutorPlanner's
       // early delivery path. The delivery has already been committed to DB and the
       // plan carries preExecuted=true to prevent double-execution here.
@@ -279,6 +296,8 @@ export class TurnExecutor {
           remainingMoney: snapshot.bot.money,
           durationMs: Date.now() - startTime,
           error: stepError instanceof Error ? stepError.message : String(stepError),
+          // JIRA-258: report which step in the MultiAction list failed.
+          failedStepIndex: stepIndex,
         };
       }
 
@@ -288,6 +307,8 @@ export class TurnExecutor {
           cost: totalCost + result.cost,
           segmentsBuilt: totalSegments + result.segmentsBuilt,
           durationMs: Date.now() - startTime,
+          // JIRA-258: report which step in the MultiAction list failed.
+          failedStepIndex: stepIndex,
         };
       }
 

--- a/src/shared/types/GameTypes.ts
+++ b/src/shared/types/GameTypes.ts
@@ -434,10 +434,20 @@ export enum AIActionType {
     DiscardHand = 'DiscardHand',
 }
 
-/** Timeline step types for animated partial turn movements */
+/**
+ * Timeline step types for animated partial turn movements.
+ *
+ * JIRA-258: the `outcome` and `rejectionCode` fields are optional and surface
+ * when the rule layer rejected this step (e.g., active event card restriction).
+ * Steps with `outcome: 'rejected'` did NOT successfully execute — earlier
+ * steps in the same plan did execute and commit; later steps were not
+ * attempted (executeMultiAction stops on first failure).
+ */
 export interface MoveTimelineStep {
   type: 'move';
   path: { row: number; col: number }[];
+  outcome?: 'rejected';
+  rejectionCode?: string;
 }
 
 export interface DeliverTimelineStep {
@@ -446,18 +456,24 @@ export interface DeliverTimelineStep {
   city: string;
   payment: number;
   cardId: number;
+  outcome?: 'rejected';
+  rejectionCode?: string;
 }
 
 export interface PickupTimelineStep {
   type: 'pickup';
   loadType: string;
   city: string;
+  outcome?: 'rejected';
+  rejectionCode?: string;
 }
 
 export interface BuildTimelineStep {
   type: 'build';
   segmentsBuilt: number;
   cost: number;
+  outcome?: 'rejected';
+  rejectionCode?: string;
 }
 
 export interface UpgradeTimelineStep {


### PR DESCRIPTION
## Summary

Phase 2 fix stacked on **PR #247** (JIRA-256 foundation). The bot's turn log was reporting `delivery: { city, payoff }` based on the *planned* action, not the *executed* outcome. When an `ActionRestrictionError` rejected the delivery (e.g. Strike active), the turn log still recorded a successful payoff — misleading for replay and post-mortems. This PR sources turn-log fields from `TurnExecutor`'s execution results, not plan intent.

## Per-ticket docs
- `docs/ai/done/jira-258-turnLogShowsFakeDeliveryOnRejectedAction-behavioral.md`
- `docs/ai/done/jira-258-turnLogShowsFakeDeliveryOnRejectedAction-technical.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Once PR #247 merges, retarget base to `main`

**Base**: `pr/jira-256-foundation` (PR #247).

🤖 Generated with [Claude Code](https://claude.com/claude-code)