### PR TITLE
fix(ai): JIRA-259 — trip planner ignores active strike when picking route

### DIFF
--- a/docs/ai/done/jira-259-tripPlannerIgnoresActiveStrikeWhenPickingRoute-behavioral.md
+++ b/docs/ai/done/jira-259-tripPlannerIgnoresActiveStrikeWhenPickingRoute-behavioral.md
@@ -1,0 +1,57 @@
+# JIRA-259 — Trip planner picks routes whose first delivery is at a coastal-Strike-blocked city, leading the bot to execute into the wall (behavioral)
+
+In game `182bfd36-3d3d-46ef-9c1d-0c87373b983f`, with a Coastal Strike active and London + Antwerpen in the restricted set, the deterministic trip planner ranked routes whose first stop is a delivery at one of those blocked cities as the top candidate for the affected players. The bot then executed the route, which the game-rule layer rejected; on the next turn the planner picked the same restricted route again. The trip planner is consulting `snapshot.activeEffects` correctly inside the movement and build planners (via the BE-005 wiring), but its candidate-enumeration / ranking step apparently does not filter or down-rank candidates that lead with a delivery at a city in the active pickup/delivery restriction set.
+
+## Source
+
+`logs/game-182bfd36-3d3d-46ef-9c1d-0c87373b983f.ndjson`, players s1 (turn 31 — picked `pair:110-Cars+102-Copper:delAfirst-sup:null-Beograd` whose stop 1 is "deliver Cars at Antwerpen"; the player was already at Antwerpen and the Strike was active).
+
+Excerpt from the s1 T31 reasoning field:
+
+```
+[route-planned] [deterministic-top-1] pair:110-Cars+102-Copper:delAfirst-sup:null-Beograd chosen.
+  Picked: pair-carry+fresh — payout 31M, build 10M, 11 turns, NET 21M
+  Aggregate: 1.96 M/turn (standalone — no feasible follow-up)
+  Stops: 1) deliver Cars at Antwerpen; 2) pickup Copper at Beograd; 3) deliver Copper at Bruxelles
+  …
+  Candidates: raw=780 survivors=69 enumerationMs=5239
+```
+
+The same route was re-picked on T32 after the first execution failed. The planner is choosing a route whose first stop is rejected by the active Strike, with no awareness that the stop is blocked.
+
+## Observed contrast
+
+- The movement planner (`MovementPhasePlanner.ts:168`) reads `snapshot.activeEffects` and consults `pickupDeliveryRestrictions` when generating movement candidates → it correctly avoids moving the train to a Strike-blocked city.
+- The build planner (`BuildPhasePlanner.ts:179`) reads `snapshot.activeEffects` for Flood-rebuild gating → it correctly avoids building over rebuildable-flood segments.
+- The deterministic **trip planner** (the layer above the movement / build planners) does not appear to consult `pickupDeliveryRestrictions` when enumerating or ranking candidate routes — so it picks routes whose first stop is a deliver at a blocked city, even when the bot is positioned right there and the Strike is active.
+
+## Expected behavior
+
+When the deterministic trip planner enumerates candidate routes for a turn where `snapshot.activeEffects` contains pickup/delivery restrictions, it should drop or heavily down-rank any candidate whose first stop is a pickup or delivery at a city in the restricted set. The planner can keep routes whose later stops touch restricted cities — Strikes typically expire within 1-2 turns, so a 5-turn route ending at a currently-blocked city may be fine if the Strike clears before the bot arrives — but the immediate-next stop must be feasible.
+
+A minimal safe behavior: filter the candidate set to drop any route whose `stops[0]` is a `pickup` or `deliver` at a city in the active pickup/delivery restriction set. If the filter empties the candidate set, fall back to the existing "no feasible route" path (which the bot already handles by passing the turn or discarding the hand).
+
+## Acceptance
+
+- **AC1** — Replicate s1 T31 snapshot: bot at Antwerpen carrying Cars, demand hand has `Cars→Antwerpen` and `Copper@Beograd→Bruxelles`, `snapshot.activeEffects` has a `CoastalStrike` listing Antwerpen as a restricted city. Invoke `planTripDeterministic`. Assert: the chosen route is NOT a route whose stop 0 is `deliver Cars at Antwerpen`. (It may be a "no feasible route" outcome, or it may be a different route picking up Copper first — either is acceptable.)
+- **AC2** — Same fixture but no Strike. Assert: the `pair:110-Cars+102-Copper:delAfirst-sup:null-Beograd` route IS selected as top-1 (regression guard — the filter must not over-suppress).
+- **AC3** — Bot at Antwerpen, Strike active, the ONLY route candidate the planner can build leads with the blocked delivery. Assert: the planner returns "no feasible route" and the bot falls through to whatever the no-route path does (likely a PassTurn or DiscardHand depending on hand state). The bot should NOT pick the blocked route.
+- **AC4** — Stop 0 is fine (e.g., a pickup at Beograd which is not blocked), but a LATER stop touches a Strike-blocked city. Assert: the route IS selected. The planner only filters on stop 0; later stops are deferred to the per-turn re-evaluation (the Strike likely expires by the time the bot reaches the later stop).
+- **AC5** — Integration: replay s1 T31 of game `182bfd36-3d3d-46ef-9c1d-0c87373b983f`. Assert: the chosen route's stops[0] is NOT a `deliver` or `pickup` at Antwerpen.
+
+## Not in scope
+
+- LLM-path candidate selection (Hard skill). If the LLM trip planner ignores active effects too, file a separate follow-up; this ticket scopes to the deterministic path because that's what fired in the observed game.
+- Down-ranking (vs. hard filtering) of candidates whose LATER stops touch blocked cities. Strikes have short durations; modeling expiration into ranking is a separate optimization ticket.
+- Movement-blocked or build-blocked candidate filtering. Those are already handled by the movement / build planners' per-turn logic; the trip planner doesn't need to duplicate them.
+- Lost-turn pre-emption affecting the trip planner. The BE-005 lost-turn pre-emption is at the strategy-engine level (AIStrategyEngine.ts:215-218); the trip planner doesn't need to consult it.
+
+## User-facing impact
+
+Per Strike-active turn where the bot's top-ranked route leads with a blocked stop: one wasted turn (LLM picks the route, executor rejects it, guardrail loop until expiry — see also JIRA-257 for the guardrail's contribution to the same loop). Compounding with JIRA-257, the bot can lose 3+ consecutive turns to this pattern per Strike. The fix here prevents the planner from generating the bad route in the first place, which (combined with JIRA-257) makes the bot legally pass or pivot during Strikes.
+
+## Relationship to existing JIRAs
+
+- **JIRA-256 / BE-005**: BE-005 integrated `restrictionPredicates` into `MovementPhasePlanner` and `BuildPhasePlanner`, plus `routeHelpers.ts`. But it didn't update the deterministic trip planner's candidate enumeration / ranking. That's the residual gap this ticket fills.
+- **JIRA-257**: closely related — the guardrail bypass and the trip-planner-ignores-strikes are two layers of the same failure mode. Either fix on its own helps; together they fully prevent the wasted-turn loop.
+- **JIRA-251** (bot blind to active rail strike): predecessor concern that JIRA-256 was meant to address; this ticket plugs the trip-planner-layer hole.

--- a/docs/ai/done/jira-259-tripPlannerIgnoresActiveStrikeWhenPickingRoute-technical.md
+++ b/docs/ai/done/jira-259-tripPlannerIgnoresActiveStrikeWhenPickingRoute-technical.md
@@ -1,0 +1,67 @@
+# JIRA-259 — Filter trip-planner candidates whose first stop is at a city blocked by an active pickup/delivery restriction (technical)
+
+Companion to `jira-259-tripPlannerIgnoresActiveStrikeWhenPickingRoute-behavioral.md`.
+
+## Defect locus
+
+The deterministic trip planner candidate enumeration / ranking layer — likely `src/server/services/ai/DeterministicTripPlanner.ts` (the same file that JIRA-248, JIRA-250, JIRA-254 patched). The exact entry point for candidate generation should be verified during implementation; the reasoning string `[deterministic-top-1] pair:110-Cars+102-Copper:delAfirst-sup:null-Beograd chosen` and `Candidates: raw=780 survivors=69 enumerationMs=5239` point to a `planTripDeterministic` / `enumerateCandidates` / `scoreCandidate` pipeline that doesn't currently consult `snapshot.activeEffects`.
+
+Verify during implementation:
+
+```bash
+grep -n "activeEffects\|pickupDeliveryRestrictions\|isPickupDeliveryBlocked" src/server/services/ai/DeterministicTripPlanner.ts src/server/services/ai/routeHelpers.ts src/server/services/ai/TripPlanner.ts 2>/dev/null
+```
+
+(Spec BE-005 listed `routeHelpers.ts` as a target; the candidate-enumeration layer above route-helpers is the remaining gap.)
+
+## Fix shape
+
+After candidate enumeration but before scoring (or as a post-scoring filter, depending on the pipeline shape), drop any candidate whose `stops[0]` is a `pickup` or `deliver` at a city in the active pickup/delivery restriction set.
+
+Approximate change:
+
+```ts
+// After enumerateCandidates(...) returns the raw candidate set:
+const pickupDeliveryRestrictions = (snapshot.activeEffects ?? []).flatMap(e => e.restrictions.pickupDelivery);
+const restrictedCityKeys = new Set(pickupDeliveryRestrictions.flatMap(r => r.cityMilepointKeys));
+
+const survivors = candidates.filter(c => {
+  const stop0 = c.stops[0];
+  if (!stop0) return true;
+  if (stop0.action !== 'pickup' && stop0.action !== 'deliver') return true;
+  const cityKey = getCityMilepointKey(stop0.city);
+  if (cityKey === null) return true; // unknown city — don't filter
+  return !restrictedCityKeys.has(cityKey);
+});
+```
+
+The exact integration point depends on whether the planner currently uses a single-pass scoring loop or a multi-pass prune-then-score pipeline. Use the existing prune-survivor pattern (the log says `Survivors after spatial prune: 69 of 780 raw. Discarded by prune: 697 (turns > 12) | 14 (build > 130M)`) and add the restriction-filter as an additional prune stage.
+
+Log the filter as part of the standard `Candidates:` reasoning line so future debugging can see "discarded by active-effect filter: N".
+
+## Acceptance from behavioral
+
+- **AC1** Unit test on the enumeration/filter pipeline: fixture with bot at Antwerpen carrying Cars, demands as in s1 T31, `snapshot.activeEffects` with a Coastal Strike listing Antwerpen. Assert: no surviving candidate has `stops[0] = { action: 'deliver', city: 'Antwerpen' }`. Either a different route is chosen or no route is feasible.
+- **AC2** Unit test, same fixture but no Strike. Assert: the `pair:110-Cars+102-Copper:delAfirst-sup:null-Beograd` route is the top-1 (regression guard).
+- **AC3** Unit test: bot in a state where the ONLY enumerable routes lead with a blocked stop. Assert: the filter drops them all and the planner returns "no feasible route" (matching the existing no-feasible-route path's contract).
+- **AC4** Unit test: bot at Antwerpen, Strike active, an alternate candidate exists that leads with `pickup Copper at Beograd` (a non-restricted city), with the Cars delivery deferred to a later stop. Assert: the alternate is selected; the filter only drops candidates with a restricted stop 0, not later stops.
+- **AC5** Integration: replay s1 T31 of game `182bfd36-3d3d-46ef-9c1d-0c87373b983f` and verify the chosen route's `stops[0]` is not at Antwerpen.
+
+## Validation hooks to inspect during fix
+
+- After the fix, the reasoning string for s1 T31 should NOT pick `pair:110-Cars+102-Copper:delAfirst`. It should either pick a different ordering (e.g., `pickup Copper first`) or report "no feasible route".
+- Add a `discardedByActiveEffectFilter` counter to the `Candidates:` line so the same log already in place at line 9 of the example excerpt shows the filter's effect.
+- The `compositionTrace.candidates` field (if the planner emits it) should not contain any survivor whose stop 0 is at a restricted city, post-fix.
+
+## Not in scope
+
+- LLM-path trip planning (Hard skill). If the LLM also picks blocked routes, file a separate follow-up. Scope here is the deterministic Medium-skill path.
+- Down-ranking candidates whose LATER stops are blocked (probabilistic feasibility based on Strike expiry timing). Hard-filter on stop 0 only.
+- Equivalent filters for movement and build restrictions — those are already wired in BE-005's planner-level integrations. This ticket plugs the trip-planner candidate-enumeration gap specifically.
+- Telemetry / metrics on "how often did the active-effect filter drop candidates". Counter in the reasoning string is sufficient; richer telemetry can be a follow-up if event-card pressure becomes a frequent diagnostic question.
+
+## Relationship to existing JIRAs
+
+- **JIRA-256 / BE-005**: this is a follow-up gap. BE-005 covered `MovementPhasePlanner`, `BuildPhasePlanner`, `routeHelpers.ts` — but the deterministic trip planner's candidate enumeration layer above route-helpers is what BE-005 missed.
+- **JIRA-257**: complementary fix at the guardrail layer. Either ticket alone reduces the wasted-turn loop; together they fully prevent the planner from selecting and the guardrail from forcing a blocked delivery.
+- **JIRA-248 / JIRA-250 / JIRA-254**: prior tickets in the same DeterministicTripPlanner area. The fix here lives in the same file and the same enumeration/prune pipeline.

--- a/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
+++ b/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
@@ -1326,6 +1326,120 @@ describe('planTripDeterministic', () => {
   });
 });
 
+// ── JIRA-259: active pickup/delivery restriction filter ──────────────
+
+describe('planTripDeterministic — JIRA-259 active-effect candidate filter', () => {
+  function makeStrikeEffect(zone: string[]): any {
+    return {
+      cardId: 121,
+      cardType: 'Strike',
+      drawingPlayerId: 'player-2',
+      drawingPlayerIndex: 1,
+      drawingPlayerTurnNumber: 4,
+      expiresAfterTurnNumber: 6,
+      affectedZone: new Set(zone),
+      restrictions: {
+        movement: [],
+        build: [],
+        pickupDelivery: [{ type: 'no_pickup_delivery_in_zone', zone }],
+      },
+      pendingLostTurns: [],
+    };
+  }
+
+  it('drops candidate whose stops[0] is a deliver at a Strike-blocked city (AC1)', () => {
+    // single-carry candidate: deliver Ham at DeliveryCity (key '7,7'). Strike blocks '7,7'.
+    mockSimulateTrip.mockReturnValue({ turnsToComplete: 1, totalBuildCost: 0, feasible: true, minCashRelative: 0, finalCashRelative: 0, builtSegments: [] });
+    const demands = [
+      makeDemand({
+        cardIndex: 1,
+        loadType: 'Ham',
+        supplyCity: null,
+        deliveryCity: 'DeliveryCity',
+        payout: 31,
+        isLoadOnTrain: true,
+      }),
+    ];
+    const snapshot = makeSnapshot({ loads: ['Ham'] });
+    snapshot.activeEffects = [makeStrikeEffect(['7,7'])];
+    const context = makeContext(demands);
+    const memory = makeMemory();
+
+    const result = planTripDeterministic(snapshot, context, memory);
+
+    expect(result.outcome).toBe('no_feasible_candidates');
+    expect(result.route).toBeNull();
+    expect(result.reasoning).toContain('stop 0 at city blocked by active event');
+  });
+
+  it('regression guard: same fixture with no active Strike → route IS selected (AC2)', () => {
+    mockSimulateTrip.mockReturnValue({ turnsToComplete: 1, totalBuildCost: 0, feasible: true, minCashRelative: 0, finalCashRelative: 0, builtSegments: [] });
+    const demands = [
+      makeDemand({
+        cardIndex: 1,
+        loadType: 'Ham',
+        supplyCity: null,
+        deliveryCity: 'DeliveryCity',
+        payout: 31,
+        isLoadOnTrain: true,
+      }),
+    ];
+    const snapshot = makeSnapshot({ loads: ['Ham'] });
+    snapshot.activeEffects = [];
+    const context = makeContext(demands);
+    const memory = makeMemory();
+
+    const result = planTripDeterministic(snapshot, context, memory);
+
+    expect(result.outcome).toBe('success');
+    expect(result.route).not.toBeNull();
+    expect(result.route!.stops[0]).toMatchObject({ action: 'deliver', city: 'DeliveryCity' });
+  });
+
+  it('returns no_feasible_candidates when ALL enumerated candidates lead with a blocked stop (AC3)', () => {
+    // Two demands, both delivering to DeliveryCity. All enumerated candidates have stops[0] = deliver at DeliveryCity.
+    mockSimulateTrip.mockReturnValue({ turnsToComplete: 1, totalBuildCost: 0, feasible: true, minCashRelative: 0, finalCashRelative: 0, builtSegments: [] });
+    const demands = [
+      makeDemand({ cardIndex: 1, loadType: 'Ham', supplyCity: null, deliveryCity: 'DeliveryCity', payout: 31, isLoadOnTrain: true }),
+    ];
+    const snapshot = makeSnapshot({ loads: ['Ham'] });
+    snapshot.activeEffects = [makeStrikeEffect(['7,7'])];
+    const context = makeContext(demands);
+    const memory = makeMemory();
+
+    const result = planTripDeterministic(snapshot, context, memory);
+
+    expect(result.outcome).toBe('no_feasible_candidates');
+    expect(result.route).toBeNull();
+  });
+
+  it('keeps candidate whose stops[0] is fine even if a LATER stop is at a Strike-blocked city (AC4)', () => {
+    // single-fresh candidate: pickup Coal at CityA (2,2 — not blocked), deliver Coal at DeliveryCity (7,7 — blocked).
+    // Only stops[0] is filtered, so this candidate survives.
+    mockSimulateTrip.mockReturnValue({ turnsToComplete: 2, totalBuildCost: 5, feasible: true, minCashRelative: 0, finalCashRelative: 0, builtSegments: [] });
+    const demands = [
+      makeDemand({
+        cardIndex: 1,
+        loadType: 'Coal',
+        supplyCity: 'CityA',
+        deliveryCity: 'DeliveryCity',
+        payout: 20,
+        isLoadOnTrain: false,
+      }),
+    ];
+    const snapshot = makeSnapshot();
+    snapshot.activeEffects = [makeStrikeEffect(['7,7'])]; // DeliveryCity blocked
+    const context = makeContext(demands);
+    const memory = makeMemory();
+
+    const result = planTripDeterministic(snapshot, context, memory);
+
+    expect(result.outcome).toBe('success');
+    expect(result.route).not.toBeNull();
+    expect(result.route!.stops[0]).toMatchObject({ action: 'pickup', city: 'CityA' });
+  });
+});
+
 // ── Upgrade emission (JIRA-220 follow-up) ─────────────────────────────
 
 describe('planTripDeterministic — upgrade emission', () => {

--- a/src/server/services/ai/DeterministicTripPlanner.ts
+++ b/src/server/services/ai/DeterministicTripPlanner.ts
@@ -35,6 +35,7 @@ import {
   VICTORY_CITY_COUNT,
 } from '../../../shared/types/GameTypes';
 import { cheapestUnconnectedMajorConnectorCost } from './victoryRules';
+import { getCityMilepointKey, isPickupDeliveryBlocked } from '../restrictionPredicates';
 
 // ── Tunables ───────────────────────────────────────────────────────────
 
@@ -195,6 +196,9 @@ interface PruneStats {
   survivors: number;
   prunedByTurns: number;
   prunedByBuild: number;
+  // JIRA-259: count of candidates dropped because stops[0] is at a city
+  // blocked by an active pickup/delivery restriction (e.g., Coastal Strike).
+  prunedByActiveEffect: number;
 }
 
 // ── City coordinate lookup ─────────────────────────────────────────────
@@ -1177,7 +1181,10 @@ function synthesizeReasoning(
   }
 
   reasoning += `  Survivors after spatial prune: ${stats.survivors} of ${stats.total} raw.\n`;
-  reasoning += `  Discarded by prune: ${stats.prunedByTurns} (turns > ${opts.pruneMaxTurns}) | ${stats.prunedByBuild} (build > ${opts.pruneMaxBuildM}M).`;
+  const activeEffectDiscardNote = stats.prunedByActiveEffect > 0
+    ? ` | ${stats.prunedByActiveEffect} (stop 0 at city blocked by active event)`
+    : '';
+  reasoning += `  Discarded by prune: ${stats.prunedByTurns} (turns > ${opts.pruneMaxTurns}) | ${stats.prunedByBuild} (build > ${opts.pruneMaxBuildM}M)${activeEffectDiscardNote}.`;
 
   // JIRA-230 BE-004: per-replan enumeration telemetry
   if (enumerationMs !== undefined) {
@@ -1403,9 +1410,29 @@ export function planTripDeterministic(
   // Spatial prune
   let prunedByTurns = 0;
   let prunedByBuild = 0;
+  // JIRA-259: drop candidates whose first stop is a pickup or deliver at a
+  // city blocked by an active pickup/delivery restriction (e.g., a Coastal
+  // Strike). Filtering only stops[0] is intentional — Strikes typically
+  // expire within 1-2 turns, so a 5-turn route that lands at a currently
+  // blocked city later may be fine if the Strike clears before arrival.
+  // The bot's immediate-next action, however, must be feasible.
+  let prunedByActiveEffect = 0;
+  const pickupDeliveryRestrictions = (snapshot.activeEffects ?? [])
+    .flatMap(e => e.restrictions.pickupDelivery);
+  const hasActivePickupDeliveryRestriction = pickupDeliveryRestrictions.length > 0;
   const survivors: Candidate[] = [];
 
   for (const cand of allCandidates) {
+    if (hasActivePickupDeliveryRestriction) {
+      const stop0 = cand.stops[0];
+      if (stop0 && (stop0.action === 'pickup' || stop0.action === 'deliver')) {
+        const cityKey = getCityMilepointKey(stop0.city) ?? '';
+        if (cityKey && isPickupDeliveryBlocked(pickupDeliveryRestrictions, cityKey).blocked) {
+          prunedByActiveEffect++;
+          continue;
+        }
+      }
+    }
     const { keep, estTurns, estBuild } = cheapPrune(cand, startPos, speed, opts, snapshot);
     if (keep) {
       survivors.push(cand);
@@ -1435,14 +1462,18 @@ export function planTripDeterministic(
     survivors: survivors.length,
     prunedByTurns,
     prunedByBuild,
+    prunedByActiveEffect,
   };
 
   // All pruned check (R8)
   if (survivors.length === 0) {
     const latencyMs = Date.now() - startMs;
+    const activeEffectNote = prunedByActiveEffect > 0
+      ? ` | ${prunedByActiveEffect} (stop 0 at city blocked by active event)`
+      : '';
     const reasoning =
       `[deterministic-top-1] All ${allCandidates.length} candidates pruned.\n` +
-      `  Discarded by prune: ${prunedByTurns} (turns > ${opts.pruneMaxTurns}) | ${prunedByBuild} (build > ${opts.pruneMaxBuildM}M).\n` +
+      `  Discarded by prune: ${prunedByTurns} (turns > ${opts.pruneMaxTurns}) | ${prunedByBuild} (build > ${opts.pruneMaxBuildM}M)${activeEffectNote}.\n` +
       `  Survivors after spatial prune: 0 of ${allCandidates.length} raw.\n` +
       `  Candidates: raw=${rawCount} survivors=0 enumerationMs=${enumerationMs}`;
     return {


### PR DESCRIPTION
## Summary

Phase 2 fix stacked on **PR #247** (JIRA-256 foundation). `DeterministicTripPlanner` was enumerating candidates whose `stops[0]` (the first pickup/delivery) sat at a city blocked by an active pickup/delivery restriction — so the bot would commit to an unreachable plan and only discover the block at execution time. This PR pre-filters candidates against `restrictionPredicates` before the prune loop and records the count via a new `PruneStats.prunedByActiveEffect` field.

## Per-ticket docs
- `docs/ai/done/jira-259-tripPlannerIgnoresActiveStrikeWhenPickingRoute-behavioral.md`
- `docs/ai/done/jira-259-tripPlannerIgnoresActiveStrikeWhenPickingRoute-technical.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Once PR #247 merges, retarget base to `main`

**Base**: `pr/jira-256-foundation` (PR #247).

🤖 Generated with [Claude Code](https://claude.com/claude-code)