### PR TITLE
docs(ai): JIRA-260 — absorbed by PR #246 advanceTurn consolidation

### DIFF
--- a/docs/ai/done/jira-260-derailmentLostTurnNeverConsumed-behavioral.md
+++ b/docs/ai/done/jira-260-derailmentLostTurnNeverConsumed-behavioral.md
@@ -1,0 +1,58 @@
+# JIRA-260 — Haiku stuck in an infinite Derailment "lost turn" loop in an all-bot game (behavioral)
+
+In game `f3ed7b8f-8ebb-45f9-9010-90c3fbfac628` (an all-bot game — Haiku + Sonnet), Haiku drew or was caught by Derailment event card #125 on or before turn 41. Per the game rules, a Derailment causes the affected player to **lose one turn** and **one load**. Haiku then passed turns 41 through 47 (at least) consecutively, every turn emitting the identical reasoning string `"Lost turn due to Derailment event card #125."`. The pending-lost-turn entry that should have been consumed after the first PassTurn was never cleared, so the lost-turn pre-emption fired again every time Haiku's turn came back around.
+
+## Source
+
+`logs/game-f3ed7b8f-8ebb-45f9-9010-90c3fbfac628.ndjson`, Haiku turns 41 through 47 (and probably continuing past 47 — the log shows the loop still ongoing when the snapshot was taken).
+
+## Observed trace — Haiku
+
+| Turn | action | reasoning |
+|------|--------|-----------|
+| 40 | UpgradeTrain | `[route-executor] stop 1/2, phase=build; replan triggered\n\nSheep Bilbao→Lodz is the highest-efficiency option …` |
+| 41 | PassTurn | `Lost turn due to Derailment event card #125.` |
+| 42 | PassTurn | `Lost turn due to Derailment event card #125.` |
+| 43 | PassTurn | `Lost turn due to Derailment event card #125.` |
+| 44 | PassTurn | `Lost turn due to Derailment event card #125.` |
+| 45 | PassTurn | `Lost turn due to Derailment event card #125.` |
+| 46 | PassTurn | `Lost turn due to Derailment event card #125.` |
+| 47 | PassTurn | `Lost turn due to Derailment event card #125.` |
+
+The reasoning string and the persistent `card #125` reference indicate the lost-turn pre-emption in `AIStrategyEngine.takeTurn` is firing every time — meaning `snapshot.activeEffects` still contains an effect with `pendingLostTurns: [{ playerId: <Haiku> }]` on every one of these turns.
+
+## Expected behavior
+
+Per the rulebook: "When a Derailment Event occurs, only trains in the affected area at the moment the card is drawn are impacted. … When a train loses a load, the player operating the train chooses which load is lost from those currently being carried." And: a Derailment causes the affected player to **lose one turn and one load**, then the player's regular turns resume.
+
+Concretely:
+- After Haiku consumes the lost turn on T41 (the first PassTurn), the corresponding `pendingLostTurns` entry for Haiku should be removed.
+- T42 should be a normal Haiku turn — back to building, moving, delivering.
+- The Derailment ActiveEffect itself should also expire at the end of the drawing player's next turn (per the rulebook's general Event card lifecycle).
+
+## Acceptance
+
+- **AC1** — Reproducer fixture: Haiku snapshot at T41 with `activeEffects: [{ cardId: 125, cardType: 'Derailment', pendingLostTurns: [{ playerId: <Haiku> }], … }]`. After Haiku's T41 turn completes (PassTurn via lost-turn pre-emption), `pendingLostTurns` for Haiku should be empty in the persisted `games.active_event` row.
+- **AC2** — Replay T42 against the persisted state from AC1. Assert: `isBotInPendingLostTurns(snapshot.activeEffects, <Haiku>)` returns false. AIStrategyEngine.takeTurn does NOT fire the lost-turn pre-emption. Haiku's normal planning path runs.
+- **AC3** — All-bot integration test: two bots, one of them draws Derailment, gets a pending lost turn. After 1 full round (both bots take their turn), assert the pending lost turn for the affected bot is gone.
+- **AC4** — Mixed game regression guard: human + bot game. Bot gets a Derailment pending lost turn. After bot turn ends and human plays, assert pending lost turn is gone (existing transactional path should still fire — this is a guard that the fix doesn't break it).
+- **AC5** — Replay Haiku T41 of `f3ed7b8f-8ebb-45f9-9010-90c3fbfac628` and assert the bot does NOT enter the multi-turn loop.
+
+## Not in scope
+
+- Load loss accounting (which carried load is dropped on Derailment, and the rulebook's "player chooses" wording). This ticket scopes to the lost-turn portion. If load-loss has a parallel bug, file separately.
+- Derailment area-of-effect (the 3-mileposts-from-affected-cities zone). The current implementation appears to be computing it correctly — Haiku's pending entry implies the zone hit Haiku. This ticket scopes to consumption, not detection.
+- LLM-side reasoning. The lost-turn pre-emption is a deterministic system-actor path; no model reasoning is involved.
+
+## User-facing impact
+
+For all-bot games, any Derailment effectively removes the affected bot from the game for the remainder of play. Haiku in this game has lost 7+ turns and counting, with no way out — the game would have to end on victory by another player (or stall). For mixed games with at least one human, the existing transactional turn-advance path (called when the human's turn ends) would consume the bot's lost turn correctly, masking the bug.
+
+## Likely-related adjacent observation (in scope for the same fix locus)
+
+In game `182bfd36-3d3d-46ef-9c1d-0c87373b983f` (the prior JIRA-256 testing game, also all-bot), Coastal Strike rejections continued across multiple turns for Haiku at London and s1 at Antwerpen. Strikes are supposed to expire after the drawing player's next turn. The persistence-of-restrictions pattern there matches the persistence-of-lost-turns pattern here: both are managed by the same `ActiveEffectManager` operations (`consumeLostTurn` + `cleanupExpiredEffects`), and both gates run inside the transactional path of `PlayerService.updateCurrentPlayerIndex`. The same code locus likely affects expiration of all event cards in all-bot games. Worth verifying during implementation; if confirmed, an AC for "Strike expires after drawing player's next turn in an all-bot game" should be added alongside AC3.
+
+## Relationship to existing JIRAs
+
+- **JIRA-256 / BE-005 / BE-007**: BE-005 added the lost-turn pre-emption in `AIStrategyEngine.takeTurn`, and BE-007 added the mid-turn re-snapshot for activeEffect changes. Both correctly *detect* a pending lost turn; neither attempts to *consume* it. The consumption path predates JIRA-256 and lives in `ActiveEffectManager.consumeLostTurn`, but is only reachable via the transactional path of `PlayerService.updateCurrentPlayerIndex` (which `BotTurnTrigger` does not use).
+- **JIRA-257 / JIRA-259**: these fixed the planner/guardrail not consulting active restrictions, but the underlying issue here is different — the restriction *should* eventually clear and is not, due to the bot-only turn-advance bypassing effect lifecycle hooks.

--- a/docs/ai/done/jira-260-derailmentLostTurnNeverConsumed-technical.md
+++ b/docs/ai/done/jira-260-derailmentLostTurnNeverConsumed-technical.md
@@ -1,0 +1,79 @@
+# JIRA-260 — Bot turn-advance bypasses the transactional effect-lifecycle path; route bot turn-end through it so consumeLostTurn + cleanupExpiredEffects fire (technical)
+
+Companion to `jira-260-derailmentLostTurnNeverConsumed-behavioral.md`.
+
+## Defect locus
+
+`src/server/services/ai/BotTurnTrigger.ts:446` — `await PlayerService.updateCurrentPlayerIndex(gameId, nextIndex);`
+
+This call passes no `client` and no `prevPlayerIndex`. Per `PlayerService.updateCurrentPlayerIndex` (`src/server/services/playerService.ts:797-800`, comment block at lines 782-784): "When neither `client` nor `prevPlayerIndex` is provided (legacy path), skips effect management entirely — existing callers are unaffected." That means `cleanupExpiredEffects` and `consumeLostTurn` are not called when a bot's turn ends.
+
+`PlayerService.updateCurrentPlayerIndex` callers:
+- `src/server/routes/playerRoutes.ts:321` — also legacy path, but it's the human end-turn HTTP route (a different gap; not in scope for this ticket because the bug user observed is the bot-only-game case).
+- `src/server/services/ai/BotTurnTrigger.ts:446` — bot end-of-turn (the locus).
+
+In games where every turn-advance goes through `BotTurnTrigger` (all-bot games), `consumeLostTurn` and `cleanupExpiredEffects` never run. Hence:
+- Derailment `pendingLostTurns` entries accumulate and never clear → infinite "lost turn" loop (observed).
+- Strike / Snow / Flood expirations may also never fire → restrictions persist past their intended duration (likely-related, see behavioral ticket).
+
+## Fix shape
+
+Open a transaction inside `BotTurnTrigger`'s end-of-turn block and call the transactional form of `updateCurrentPlayerIndex(gameId, nextIndex, client, prevPlayerIndex)`. The transactional path already does the right thing — it cleans up expired effects from the prev player and consumes the next player's lost turn, recursively advancing if the next player is also lost.
+
+Approximate change in `BotTurnTrigger.ts:446`:
+
+```ts
+const prevIndex = game.current_player_index;
+const nextIndex = (prevIndex + 1) % playerCount;
+const client = await db.connect();
+try {
+  await client.query('BEGIN');
+  await PlayerService.updateCurrentPlayerIndex(gameId, nextIndex, client, prevIndex);
+  await client.query('COMMIT');
+} catch (err) {
+  await client.query('ROLLBACK');
+  throw err;
+} finally {
+  client.release();
+}
+```
+
+`db.connect()` is the project's `pg.Pool.connect()` wrapper — confirm exact import path during implementation (search for existing `db.connect()` usages in `playerService.ts` for the canonical pattern).
+
+## Why this fix works for the observed bug
+
+Trace post-fix for the game-`f3ed7b8f` scenario (Haiku + Sonnet):
+
+1. Haiku draws Derailment on T40, gets `pendingLostTurns[<Haiku>]` added.
+2. Haiku's T40 ends → BotTurnTrigger fires the transactional path with `prevIdx=Haiku, nextIdx=Sonnet`. `consumeLostTurn(<Sonnet>)` returns false (no entry) → Sonnet's turn proceeds.
+3. Sonnet's T41 ends → BotTurnTrigger transactional path with `prevIdx=Sonnet, nextIdx=Haiku`. `cleanupExpiredEffects` runs; `consumeLostTurn(<Haiku>)` finds the entry → removes it AND skips Haiku → advance to Sonnet again. (Per rulebook, "the player loses one turn" — Sonnet plays the slot that would have been Haiku's.)
+4. Sonnet's next turn ends → BotTurnTrigger transactional path with `prevIdx=Sonnet, nextIdx=Haiku`. `consumeLostTurn(<Haiku>)` returns false now (entry was already consumed at step 3). Haiku resumes normal play.
+
+The recursive skip-while-lost loop already exists at `playerService.ts:846-869`; the only change is making sure the call gets there.
+
+## Acceptance from behavioral
+
+- **AC1** — Unit / integration test on `BotTurnTrigger`'s end-of-turn block: fixture with two players, one of them holds a `pendingLostTurns` entry, no human players. After one bot finishes, assert that on the next `consumeLostTurn` call (during the OTHER bot's turn-end), the lost-turn entry is removed from `games.active_event`.
+- **AC2** — Replay-style test using a snapshot matching Haiku T41 (`pendingLostTurns: [{ playerId: <Haiku> }]`). After running BotTurnTrigger's advance machinery through one full round, assert `games.active_event[*].pendingLostTurns` no longer contains Haiku.
+- **AC3** — Same as the behavioral AC3: full all-bot integration test with two bots, one drawing Derailment. After 1 full round, pendingLostTurns is empty.
+- **AC4** — Mixed-game regression guard: human + bot. The human end-turn route (`playerRoutes.ts:321`) also uses the legacy path, so this fix does NOT change that path. Assert: the bot's lost turn is consumed via the EXISTING transactional path when called from somewhere else (e.g., when the next human turn-end fires from a different code path that does pass `client + prevPlayerIndex`). If no such other path exists, this AC should be deferred / dropped — the mixed-game case may currently happen to work due to incidental ordering, and a more thorough fix could land in a follow-up.
+- **AC5** — Integration: replay Haiku T41 of `f3ed7b8f-8ebb-45f9-9010-90c3fbfac628`; assert PassTurn fires exactly once (the original T41), then T42 enters normal planning.
+
+## Validation hooks to inspect during fix
+
+- `[ActiveEffectManager] Consumed lost turn for player=<playerId> gameId=<gameId>` log line should appear once per Derailment per affected player after the fix; should NOT appear repeatedly across consecutive turns.
+- `[ActiveEffectManager] Cleaned up expired effects: cardIds=<list>` should fire at the end of the drawing player's next turn for short-duration cards (Strike, Snow); verify with a Strike replay separately.
+- The PassTurn-with-Derailment-reasoning entries in the NDJSON should reduce to exactly one per Derailment hit per affected player after the fix.
+
+## Not in scope
+
+- The matching gap at `playerRoutes.ts:321` (human end-turn HTTP route also using the legacy path). That's a separate fix surface — file a follow-up if testing shows mixed-game expirations also fail. The user's observation is the bot-only case.
+- Refactoring `updateCurrentPlayerIndex` to make the transactional path the only path. The legacy path is documented and existing callers may rely on it for initial setup or migrations. Keep both.
+- Cleanup of `cleanupExpiredEffects` semantics or expiry timing rules. The expire-after-turn-N rule lives in `cleanupExpiredEffects`; this fix just ensures it runs.
+- Load loss accounting on Derailment. The behavioral ticket scopes this fix to lost-turn consumption; load loss has its own write-path and is not implicated by the locus here.
+
+## Relationship to existing JIRAs
+
+- **JIRA-256 / BE-005 / BE-007**: The pre-emption + re-snapshot work introduced by Phase 4 correctly *detects* pending lost turns. The bug is that consumption was never wired through for bot-only games. The two-layer fix (Phase 4 detection + this ticket's consumption) gives complete coverage.
+- **JIRA-251** (bot blind to active rail strike): the Coastal Strike side of the same root cause may be the residual reason rejections persisted there even after JIRA-257/259 land. Worth verifying once this fix is in.
+- **JIRA-257, JIRA-259**: orthogonal — those fixed planner/guardrail consultation of active effects. This fix is about the lifecycle of those effects, not their consultation.


### PR DESCRIPTION
## Summary

**No code change.** Audit-trail PR for the 1-PR-per-JIRA policy.

JIRA-260's behavior fix — *Derailment lost-turn never consumed in all-bot games* — was absorbed by **PR #246** (Jeff's event-card UI), which added `PlayerService.advanceTurn()` as the consolidated transactional path. `main` now routes `BotTurnTrigger.advanceTurnAfterBot` through that method for both all-bot and mixed games, so the event-card lifecycle runs atomically in all paths.

The original JIRA-260 commit on `matt/may-29` (`b5e4337`) implemented the same logic *inline* in `BotTurnTrigger`. PR #246's consolidated method is strictly better — the inline version is dropped from the PR stack.

## What this PR contains
- `docs/ai/done/jira-260-derailmentLostTurnNeverConsumed-behavioral.md`
- `docs/ai/done/jira-260-derailmentLostTurnNeverConsumed-technical.md`

## Test plan
- N/A (docs only). The actual fix shipped in PR #246.

**Base**: `pr/jira-256-foundation` (PR #247).

🤖 Generated with [Claude Code](https://claude.com/claude-code)