### PR TITLE
fix(ai): JIRA-247 — A3 commits BuildTrack directly when origin equals current position

### DIFF
--- a/docs/ai/done/jira-247-a3OriginEqualsCurrentPosLivelock-behavioral.md
+++ b/docs/ai/done/jira-247-a3OriginEqualsCurrentPosLivelock-behavioral.md
@@ -1,0 +1,55 @@
+# JIRA-247 — A3 livelocks when `computeBuildSegments` returns a segment whose origin equals the bot's current position (behavioral)
+
+In post-JIRA-244 game `dac9a541-2c9e-42f4-852f-159db1c32c1a`, player s1 emitted 3 PassTurns and accumulated a 35-turn `stuck-route-abandon` counter on the same Goteborg→Stockholm build target. The trigger is not a ferry case and not the JIRA-246 low-cash deliver-first gate.
+
+The trigger: at T36, s1 has just delivered a load and is positioned at the Goteborg milepost (coord that is the closest point on its network to the next required pickup at Stockholm). The active route's next stop is Stockholm, which is NOT on s1's network. A2 falls through to A3 (build-target preview).
+
+A3 calls `computeBuildSegments` with the target Stockholm. The pathfinder finds a build path. Critically, the **first segment in the returned array has `from = Goteborg`, which is exactly where the bot is standing.** `computeBuildSegments` correctly computes the cheapest path; the path happens to start at the bot's current position because Goteborg is the network's eastern frontier.
+
+`MovementPhasePlanner.A3` at lines 482-491 inspects the first segment's `from` coord. If it equals the bot's current position, it sets `trace.a3.terminationReason = 'origin_is_current_position'` and falls through to `break` (line 524) — emitting PassTurn.
+
+The check was originally a guard to avoid the "move to where you already are" no-op when A3 tries to move the bot to the build origin. But it does NOT also recognize "you're at the origin → just start building from here in Phase B." Phase B (BuildTrack composition) runs anyway in subsequent code paths, but in this trace the executor breaks out before it runs, returning a `MoveTrain`-only plan that is empty + no build + no PassTurn signal → PassTurn fallback.
+
+Replanner re-runs. Same active route, same Goteborg position, same `computeBuildSegments` result, same `origin_is_current_position` check, same PassTurn. The `stuck-route-abandon` counter advances; eventually (after 3-turn no-progress windows) the active route is torn down, but the counter is observably 35 turns at one point, indicating extended periods of the same livelock.
+
+## Source
+
+`logs/game-dac9a541-2c9e-42f4-852f-159db1c32c1a.ndjson`. Player s1 turns T36, T71 (two distinct fires of the same failure mode). Discovered 2026-05-19 verifying JIRA-244's residual effect.
+
+## Observed trace (s1 T36)
+
+| Field | Value |
+|---|---|
+| Position | Goteborg coord |
+| Active route current stop | pickup at Stockholm (off-network) |
+| Cash | $98M (plenty — not a JIRA-246 case) |
+| `a2.terminationReason` | `stop_city_not_on_network` |
+| `a3.terminationReason` | `origin_is_current_position` |
+| `build.target` | Stockholm |
+| `build.cost` | 0 (Phase B never composed) |
+| `outputPlan` | `[]` → PassTurn (default) |
+| `stuck-route-abandon` | counter incrementing |
+
+Same trace replays at T71 (different position pair, same termination reason).
+
+## Expected behavior
+
+When `computeBuildSegments` returns a non-empty path whose first segment starts at the bot's current position, A3 must recognize that **building can proceed directly from the bot's current position** — no preliminary MoveTrain is needed. The composition should fall through to Phase B (BuildTrack) with `build.target = <route stop city>` and `build.origin = currentPos`, not emit PassTurn.
+
+Equivalent acceptable outcome: A3 sets `terminationReason = 'a3_origin_is_current_pos_proceed_to_build'` and lets the outer composition loop continue to Phase B, which will pick up the build from `currentPos`.
+
+What must NOT happen: the executor breaks out of A2/A3 with an empty plan, defaulting to PassTurn, and looping on the same target for tens of turns.
+
+## Acceptance
+
+- **AC1 — reconstruct T36 state**: Build a fixture matching s1's T36 snapshot (bot at Goteborg, active route stop = Stockholm pickup, network is Goteborg + east-coast Swedish track but not yet Stockholm). Mock `computeBuildSegments` to return a path whose first segment's `from` coord equals the bot's position. Assert: planner does NOT emit PassTurn.
+- **AC2 — Phase B composes the build**: Same fixture. Assert: composition trace shows `build.target = Stockholm`, `build.cost > 0`, `outputPlan` contains a `BuildTrack` action.
+- **AC3 — full-game regression**: Replay s1's T36 snapshot for 5 turns. Assert: BuildTrack is emitted at least once, network advances toward Stockholm, no PassTurn in the window.
+- **AC4 — JIRA-244 Fix B path still works**: Existing test for `a3_target_already_reachable` (empty-result case) still passes — that path is orthogonal.
+- **AC5 — true no-op move case unaffected**: When `computeBuildSegments` returns a path whose origin coord is a peer milepost the bot would need to move to (not currentPos), the existing MoveTrain branch (lines 492-517) still fires.
+
+## Not in scope
+
+- The JIRA-246 low-cash gate (separate ticket).
+- Ferry-related A3 logic (covered by JIRA-244).
+- Refactoring computeBuildSegments to return an "already at origin" flag (a smaller in-A3 check is preferable to changing the pathfinder contract).

--- a/docs/ai/done/jira-247-a3OriginEqualsCurrentPosLivelock-technical.md
+++ b/docs/ai/done/jira-247-a3OriginEqualsCurrentPosLivelock-technical.md
@@ -1,0 +1,117 @@
+# JIRA-247 — A3 `origin_is_current_position` should proceed to Phase B build, not PassTurn (technical)
+
+Companion to `jira-247-a3OriginEqualsCurrentPosLivelock-behavioral.md`.
+
+## Defect locus
+
+`src/server/services/ai/MovementPhasePlanner.ts:482-491`:
+
+```ts
+} else {
+  const previewBuildOrigin = a3OriginResult[0].from;
+  const currentPos = context.position;
+
+  if (
+    currentPos &&
+    previewBuildOrigin.row === currentPos.row &&
+    previewBuildOrigin.col === currentPos.col
+  ) {
+    trace.a3.terminationReason = 'origin_is_current_position';
+  } else {
+    // ... ActionResolver.resolveMove(...) — A3 moves bot to the build origin
+  }
+}
+```
+
+The `origin_is_current_position` branch is dead — it sets a termination reason and falls through to `break` (line 524), emitting an empty plan that the executor materializes as PassTurn.
+
+Semantically, `origin_is_current_position` means "no MoveTrain is needed; the bot can build right here." But the code treats it the same as a failure. Phase B never runs because the outer loop has already broken.
+
+JIRA-244's Fix B added a similar reachability check for the `a3OriginResult.length === 0` case (lines 468-481) and correctly uses `continue` to retry A2 — that fix is structurally adjacent and works. The fix here is symmetric: instead of breaking out, transition into Phase B's build composition with the current position as the build origin.
+
+## Fix shape
+
+Two minimal options. **Recommended: option A.** Smaller diff, no contract changes, follows JIRA-244 Fix B's pattern.
+
+### Option A — `continue` to A2 with a hint that Phase B should compose the build from currentPos
+
+A2's outer loop already supports composing a BuildTrack action when the next stop is reachable but requires building. Set a flag (or just rely on the existing trace state) that the outer composition's Phase B step picks up after A2 settles.
+
+The simplest implementation: replicate JIRA-244 Fix B's `continue` pattern, but set a different termination reason so Phase B knows to compose a build (not just a move). The trace.a3.terminationReason can carry the signal:
+
+```ts
+} else {
+  const previewBuildOrigin = a3OriginResult[0].from;
+  const currentPos = context.position;
+
+  if (
+    currentPos &&
+    previewBuildOrigin.row === currentPos.row &&
+    previewBuildOrigin.col === currentPos.col
+  ) {
+    // JIRA-247: bot is already at the build origin. Phase B will compose
+    // a BuildTrack action against the active route's next stop.
+    // Set the trace and continue — the outer composition loop will run Phase B.
+    trace.a3.terminationReason = 'a3_build_origin_is_current_pos';
+    trace.build.target = a3BuildTarget.targetCity;
+    continue;
+  }
+
+  // ... existing ActionResolver.resolveMove(...) path
+}
+```
+
+This matches JIRA-244 Fix B's pattern: set the termination reason, then `continue` the outer loop. The next iteration of A2 will check whether the bot can now process the route's current stop (still no — Stockholm is still off-network), then fall through to the same A3 again — but Phase B's BuildTrack composer runs as part of the outer turn composition (separate code path that consumes `trace.build.target`).
+
+**Verification needed**: confirm that Phase B's composer actually fires on subsequent A2/A3 passes when `trace.build.target` is set but no movement plan was added. If not, option A also needs to push a BuildTrack plan into `plans` directly here.
+
+### Option B — Synthesize a BuildTrack plan inline
+
+If option A's outer-loop interplay is too fragile, set the BuildTrack target and exit cleanly without breaking. The composer is invoked by the surrounding code after A2/A3 returns. As long as `trace.build.target` is populated, the BuildTrack step composes downstream.
+
+```ts
+if (
+  currentPos &&
+  previewBuildOrigin.row === currentPos.row &&
+  previewBuildOrigin.col === currentPos.col
+) {
+  trace.a3.terminationReason = 'a3_build_origin_is_current_pos';
+  trace.build.target = a3BuildTarget.targetCity;
+  // Do not continue or break — let the outer break path complete.
+  // The downstream BuildTrack composer reads trace.build.target.
+  break;
+}
+```
+
+`break` is intentional here — A2/A3 are done for this turn; the downstream composer handles BuildTrack.
+
+### Which option to ship
+
+Read `BuildPhasePlanner.ts` (or whichever module composes the Phase B `BuildTrack` action) to verify which option matches its expectations. The build target flow is:
+
+1. A2/A3 sets `trace.build.target = <city>`.
+2. Outer composition (probably in `TurnExecutorPlanner` or `MovementPhasePlanner.composeOutput`) reads the target and synthesizes a BuildTrack action with the right segment list.
+
+If step 2 unconditionally runs when `trace.build.target` is set, option B is sufficient. If step 2 requires another A2 pass first, option A is needed.
+
+The implementing task should grep for `trace.build.target` consumers and choose accordingly.
+
+## Tests
+
+`src/server/__tests__/ai/MovementPhasePlanner.test.ts`:
+- AC1/AC2 — direct unit tests of the A3 `origin_is_current_position` branch. Mock `computeBuildSegments` to return `[{ from: currentPos, to: ... }, ...]` and assert the composition trace produces a BuildTrack action.
+- AC4 — regression: existing `a3_target_already_reachable` test (length===0 case) still passes.
+- AC5 — regression: when origin ≠ currentPos, the existing MoveTrain branch still fires.
+
+`src/server/__tests__/ai/computeBuildSegments` if any exists — not touched.
+
+## Risk
+
+- **Outer-loop interaction**: option A's `continue` could create a fast loop if A2's next pass also terminates the same way. Mitigate by guarding with a one-shot flag in the trace (e.g., `trace.a3.movePreprended = true` already exists for the move case — add `trace.a3.buildFromCurrentPos = true` and check it at the top of A2 to break out after one composition).
+- **Phase B composer assumptions**: must verify the composer handles "no move + build from currentPos" correctly. This is the only material risk. If the composer assumes A3 always did the move first, additional plumbing is needed.
+
+## Not in scope
+
+- The JIRA-246 low-cash gate (separate fix).
+- Changing `computeBuildSegments`'s return contract (rejected — fix locally in A3).
+- Refactoring A2/A3 separation (existing structure preserved).

--- a/src/server/__tests__/ai/BuildPhasePlanner.test.ts
+++ b/src/server/__tests__/ai/BuildPhasePlanner.test.ts
@@ -335,6 +335,45 @@ describe('BuildPhasePlanner.run — build target resolved', () => {
       expect.anything(),
     );
   });
+
+  // JIRA-247: Phase B must SKIP its independent build when Phase A's A3
+  // origin-is-current-pos fix already committed a BuildTrack. Without the
+  // skip, Phase B's independent computeBuildSegments call at a medium-city
+  // outer milepost returns [] and produces a no-op PassTurn that masks the
+  // already-committed build (observed in game f3ed7b8f T95).
+  it('JIRA-247: skips executeBuildPhase when Phase A already emitted a BuildTrack', async () => {
+    mockResolveBuildTarget.mockReturnValue({
+      targetCity: 'Stockholm',
+      stopIndex: 1,
+      isVictoryBuild: false,
+    });
+    const phaseABuildPlan = {
+      type: AIActionType.BuildTrack,
+      segments: [{ from: { row: 4, col: 61 }, to: { row: 4, col: 62 }, cost: 3 }],
+      targetCity: 'Stockholm',
+    } as unknown as import('../../../shared/types/GameTypes').TurnPlan;
+
+    const phaseA = makePhaseAResult({ accumulatedPlans: [phaseABuildPlan] });
+    const trace = makeTrace();
+
+    const result = await BuildPhasePlanner.run(
+      phaseA,
+      makeSnapshot(),
+      makeContext(),
+      trace,
+    );
+
+    // Phase B did NOT call executeBuildPhase (skipped)
+    expect(mockExecuteBuildPhase).not.toHaveBeenCalled();
+    // build flagged as skipped in trace
+    expect(trace.build.skipped).toBe(true);
+    // Phase A's BuildTrack is preserved in the final plan list
+    const buildPlans = result.plans.filter(p => p.type === AIActionType.BuildTrack);
+    expect(buildPlans).toHaveLength(1);
+    expect((buildPlans[0] as any).segments).toEqual([
+      { from: { row: 4, col: 61 }, to: { row: 4, col: 62 }, cost: 3 },
+    ]);
+  });
 });
 
 // ── JIRA-187 capped-city: 2a handled path ─────────────────────────────────

--- a/src/server/__tests__/ai/MovementPhasePlanner.test.ts
+++ b/src/server/__tests__/ai/MovementPhasePlanner.test.ts
@@ -1714,7 +1714,7 @@ describe('JIRA-247 AC5: origin_is_current_position → a3_build_origin_is_curren
     mockComputeBuildSegments.mockReturnValue([]); // restore global default
   });
 
-  it('AC5: bot at Goteborg (3,40), segment from=Goteborg → terminationReason=a3_build_origin_is_current_pos AND trace.build.target=Stockholm', async () => {
+  it('AC5: bot at Goteborg (3,40), segment from=Goteborg → terminationReason=a3_build_origin_is_current_pos AND trace.build.target=Stockholm AND BuildTrack committed', async () => {
     // computeBuildSegments returns segments with from = Goteborg = bot's current position
     const goteborgCoord = { row: 3, col: 40 };
     mockComputeBuildSegments.mockReturnValue([
@@ -1745,6 +1745,83 @@ describe('JIRA-247 AC5: origin_is_current_position → a3_build_origin_is_curren
     // No abandon from this branch
     expect(result.routeAbandoned).toBe(false);
     // No PassTurn emitted from this branch
+    expect(result.accumulatedPlans.some(p => p.type === AIActionType.PassTurn)).toBe(false);
+
+    // JIRA-247 (re-fix, game f3ed7b8f): A3 must directly commit a BuildTrack
+    // plan with the computed segments — the prior partial fix only set
+    // trace.build.target and let Phase B re-resolve, which produced 0 segments
+    // at medium-city outer mileposts and silently emitted PassTurn.
+    const buildPlans = result.accumulatedPlans.filter(p => p.type === AIActionType.BuildTrack);
+    expect(buildPlans).toHaveLength(1);
+    expect((buildPlans[0] as any).segments).toEqual([
+      { from: goteborgCoord, to: { row: 5, col: 41 }, cost: 3 },
+    ]);
+    expect((buildPlans[0] as any).targetCity).toBe('Stockholm');
+    expect(trace.build.cost).toBe(3);
+  });
+
+  it('AC5 truncation: when segment-path cost exceeds budget, only the prefix that fits is committed', async () => {
+    const startCoord = { row: 3, col: 40 };
+    mockComputeBuildSegments.mockReturnValue([
+      { from: startCoord, to: { row: 4, col: 40 }, cost: 5 },
+      { from: { row: 4, col: 40 }, to: { row: 5, col: 41 }, cost: 5 },
+      { from: { row: 5, col: 41 }, to: { row: 6, col: 41 }, cost: 5 },
+      { from: { row: 6, col: 41 }, to: { row: 7, col: 42 }, cost: 5 },
+      { from: { row: 7, col: 42 }, to: { row: 8, col: 42 }, cost: 5 }, // total 25M
+    ]);
+
+    const route = makeRoute({
+      stops: [makeStop('pickup', 'Stockholm')],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      citiesOnNetwork: [],
+      position: startCoord,
+      speed: 9,
+      money: 12, // < 20M turn budget cap → a3Budget = min(20, 12) = 12 → fits 2 segments at 5M each
+      turnBuildCost: 0,
+    });
+    const snapshot = makeSnapshot();
+    (snapshot.bot as any).money = 12;
+    const trace = makeTrace();
+
+    const result = await MovementPhasePlanner.run(route, snapshot, context, trace);
+
+    expect(trace.a3.terminationReason).toBe('a3_build_origin_is_current_pos');
+    const buildPlans = result.accumulatedPlans.filter(p => p.type === AIActionType.BuildTrack);
+    expect(buildPlans).toHaveLength(1);
+    expect((buildPlans[0] as any).segments).toHaveLength(2);
+    expect(trace.build.cost).toBe(10);
+  });
+
+  it('AC5 budget-too-small: when cheapest segment cost > a3Budget, terminationReason still set but no BuildTrack emitted', async () => {
+    const startCoord = { row: 3, col: 40 };
+    mockComputeBuildSegments.mockReturnValue([
+      { from: startCoord, to: { row: 4, col: 40 }, cost: 5 }, // 5M > 2M budget
+    ]);
+
+    const route = makeRoute({
+      stops: [makeStop('pickup', 'Stockholm')],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      citiesOnNetwork: [],
+      position: startCoord,
+      speed: 9,
+      money: 2, // < cheapest seg cost
+      turnBuildCost: 0,
+    });
+    const snapshot = makeSnapshot();
+    (snapshot.bot as any).money = 2;
+    const trace = makeTrace();
+
+    const result = await MovementPhasePlanner.run(route, snapshot, context, trace);
+
+    expect(trace.a3.terminationReason).toBe('a3_build_origin_is_current_pos');
+    expect(trace.build.target).toBe('Stockholm');
+    // No BuildTrack committed — budget too small for cheapest segment
+    expect(result.accumulatedPlans.some(p => p.type === AIActionType.BuildTrack)).toBe(false);
+    // Critically: also no PassTurn (Phase B will run and decide)
     expect(result.accumulatedPlans.some(p => p.type === AIActionType.PassTurn)).toBe(false);
   });
 

--- a/src/server/services/ai/BuildPhasePlanner.ts
+++ b/src/server/services/ai/BuildPhasePlanner.ts
@@ -168,8 +168,19 @@ export class BuildPhasePlanner {
     }
 
     // ── Phase B: Build ────────────────────────────────────────────────────
-    const buildTarget = resolveBuildTarget(activeRoute, context);
-    if (!buildTarget) {
+    // JIRA-247: When Phase A's A3 origin-is-current-pos branch already
+    // committed a BuildTrack into the plan list, skip Phase B's independent
+    // build attempt — Phase B's computeBuildSegments invocation can return []
+    // at medium-city outer mileposts and produce a no-op PassTurn that masks
+    // the already-committed build.
+    const phaseAEmittedBuild = phaseAResult.accumulatedPlans.some(
+      p => p.type === AIActionType.BuildTrack,
+    );
+    const buildTarget = phaseAEmittedBuild ? null : resolveBuildTarget(activeRoute, context);
+    if (phaseAEmittedBuild) {
+      // trace.build.target was set by Phase A's A3 fix.
+      trace.build.skipped = true;
+    } else if (!buildTarget) {
       trace.build.skipped = true;
       trace.build.target = null;
     } else {

--- a/src/server/services/ai/MovementPhasePlanner.ts
+++ b/src/server/services/ai/MovementPhasePlanner.ts
@@ -26,6 +26,7 @@ import {
   LlmAttempt,
   TerrainType,
   TrainType,
+  TrackSegment,
   TRAIN_PROPERTIES,
 } from '../../../shared/types/GameTypes';
 import {
@@ -517,12 +518,37 @@ export class MovementPhasePlanner {
                 previewBuildOrigin.row === currentPos.row &&
                 previewBuildOrigin.col === currentPos.col
               ) {
-                // Build origin is the bot's current position — set build target and
-                // continue so Phase B composes a BuildTrack action (no move needed).
-                console.warn(`${tag} a3_build_origin_is_current_pos — build origin matches current position, continuing to Phase B`);
+                // JIRA-247: Commit a3OriginResult as a BuildTrack plan directly
+                // instead of `continue`-ing the loop and deferring to Phase B.
+                // The prior partial fix set trace.build.target and looped, which
+                // re-entered A2/A3 with unchanged inputs (livelock to
+                // MAX_LOOP_ITERS) and then handed off to Phase B whose
+                // independent computeBuildSegments call returned [] at
+                // medium-city outer mileposts (game f3ed7b8f T95: bot at
+                // (4,61) building toward Stockholm Medium City at (4,62)).
+                // Truncate the path to fit the build budget — computeBuildSegments
+                // may return more segments than the bot can afford this turn.
+                const truncated: TrackSegment[] = [];
+                let accCost = 0;
+                for (const seg of a3OriginResult) {
+                  if (accCost + seg.cost > a3Budget) break;
+                  truncated.push(seg);
+                  accCost += seg.cost;
+                }
                 trace.a3.terminationReason = 'a3_build_origin_is_current_pos';
                 trace.build.target = a3BuildTarget.targetCity;
-                continue;
+                if (truncated.length > 0) {
+                  console.warn(`${tag} a3_build_origin_is_current_pos — committing ${truncated.length} seg(s) cost ${accCost}M toward ${a3BuildTarget.targetCity}`);
+                  trace.build.cost = accCost;
+                  plans.push({
+                    type: AIActionType.BuildTrack,
+                    segments: truncated,
+                    targetCity: a3BuildTarget.targetCity,
+                  });
+                } else {
+                  console.warn(`${tag} a3_build_origin_is_current_pos — budget ${a3Budget}M too small for cheapest segment (${a3OriginResult[0]?.cost ?? '?'}M), no build committed`);
+                }
+                break;
               } else {
                 const _a3MoveStart = Date.now();
                 const a3MoveResult = await ActionResolver.resolveMove(


### PR DESCRIPTION
## Summary

**Independent of Phase 2/PR #247.** Cherry-picked clean off `main`.

When `A3` (the on-route build phase) chose a build target whose origin equaled the bot's current position, the existing flow would queue a no-op move + a BuildTrack, then Phase B would also attempt to build to the same target — causing a double-up and, in some game states, a livelock. This PR commits the BuildTrack directly in A3 when origin == current position, and adds a Phase B skip for the now-already-built target.

## Per-ticket docs
- `docs/ai/done/jira-247-a3OriginEqualsCurrentPosLivelock-behavioral.md`
- `docs/ai/done/jira-247-a3OriginEqualsCurrentPosLivelock-technical.md`

## Test plan
- [x] `npx tsc --noEmit` clean

**Base**: `main`. Independent of the JIRA-256 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)