### PR TITLE
fix(ai): JIRA-248 + JIRA-249 + JIRA-250 — carried-load planner overhaul (combined)

### DIFF
--- a/docs/ai/done/jira-248-replanDropsCarriedLoadDelivery-behavioral.md
+++ b/docs/ai/done/jira-248-replanDropsCarriedLoadDelivery-behavioral.md
@@ -1,0 +1,67 @@
+# JIRA-248 — Replan drops the delivery stop for a load the bot is still carrying (behavioral)
+
+In game `75c6afc8-8d99-49b0-b878-e5e19512478d`, player Sonnet (Medium skill) carries a Labor load whose only matching demand card is `Labor → Bern`. At T28 the active route's stop list ends with a `deliver(Labor@Bern)` stop, consistent with the carried load. At T29 the trip planner is re-invoked and produces a brand-new route — `pickup(Tourists@Ruhr) → deliver(Tourists@Napoli)` — that **omits the Labor→Bern delivery entirely**. The `Labor → Bern` demand card stays in the hand. The Labor load stays on the train.
+
+The bot then executes this new Tourists trip across multiple turns without ever revisiting the carried Labor delivery. Across T29–T35 the route never re-includes a Bern stop; the user observed the bot physically passing Bern multiple times while still carrying the Labor load.
+
+## Source
+
+`logs/game-75c6afc8-8d99-49b0-b878-e5e19512478d.ndjson`, player Sonnet, T28 → T29 replan boundary.
+
+Second confirming observation: `logs/game-3da56057-cf04-49c0-a194-b43fd0010bd4.ndjson`, player Sonnet, T62 → T64 replan boundary. Different game, different game state, same pattern — see "Second observation" section below.
+
+## Observed trace (Sonnet T28–T32 abbreviated)
+
+| Turn | Action       | Route stops                                                                                                     | Labor→Bern in demands? |
+|------|--------------|------------------------------------------------------------------------------------------------------------------|------------------------|
+| T28  | MoveTrain    | `pickup(Labor@Beograd), pickup(Wood@Sarajevo), deliver(Wood@Bremen), deliver(Labor@Bern)`                       | Yes (supplyCity=null = carried) |
+| T29  | BuildTrack   | `pickup(Tourists@Ruhr), deliver(Tourists@Napoli)`                                                               | Yes (still in hand, still null) |
+| T30  | BuildTrack   | `pickup(Tourists@Ruhr), deliver(Tourists@Napoli)`                                                               | Yes |
+| T31  | MoveTrain    | `pickup(Tourists@Ruhr), deliver(Tourists@Napoli)`                                                               | Yes |
+| T32  | UpgradeTrain | `pickup(Tobacco@Napoli), deliver(Tobacco@Hamburg)`                                                              | Yes |
+
+`supplyCity = null` on a Labor demand means the load is already on the bot's train. The T28 route's `pickup(Labor@Beograd)` step is itself suspect (the load is not at Beograd; the bot is carrying it), but the bigger issue is the T29 replan: a load that is in the bot's possession and has a matching demand card disappears from the route.
+
+## Expected behavior
+
+When the trip planner is re-invoked, any demand card whose load type is already on the bot's train (i.e. `supplyCity = null` for a `loadOnTrain` reason) MUST be considered for inclusion as a `deliver` stop in the new route. The planner may legitimately decide that visiting the delivery city right now is more expensive than the alternative routes — but the decision must be visible in the planner's reasoning, not implicit by omission. Dropping a carried-load delivery silently is never correct: the load occupies a cargo slot, and the demand card stays in the hand, so the bot is paying a strategic cost (reduced capacity + a wasted demand card slot) for an outcome the planner did not consider.
+
+What must NOT happen: the trip planner produces a route that fully ignores carried loads — neither delivering them nor explicitly choosing to defer them. The user observed the bot passing Bern multiple times across T29–T35 with a Labor load still on board.
+
+## Acceptance
+
+- **AC1** — Reproduce a fixture matching T28→T29: bot carrying one Labor load, demand hand contains `Labor → Bern` with `supplyCity = null`, and at least one alternative `pickup(X) → deliver(X)` candidate with higher per-turn score in isolation. Assert: the planner's chosen route either includes a `deliver(Labor@Bern)` stop or its reasoning explicitly cites why deferring Labor delivery beats including it.
+- **AC2** — Same fixture, vary alternative count from 1 to 5. Assert: at no fixture configuration does the planner emit a route with zero references to the carried load's delivery city, without a recorded deferral rationale.
+- **AC3** — Full-game regression on the Sonnet T28–T35 segment. Assert: across the segment, the bot either delivers the carried Labor → Bern OR drops it at a city (legal in Eurorails). The bot must not retain a carried load across more than N consecutive replans without addressing it (N to be defined; suggest 3).
+- **AC4** — The T28 route itself is malformed (`pickup(Labor@Beograd)` for a load the bot already carries). Validate that the planner's grammar / validator rejects a `pickup` stop for a load type the bot is already carrying when the demand's `supplyCity = null`.
+
+## Second observation — game `3da56057`, Sonnet T62-T64
+
+Independent reproduction in a different game with a Heavy/Superfreight bot (capacity 3) and a same-supply pair pickup. Pattern is identical: post-delivery replan drops a still-carried delivery from the new route.
+
+### Observed trace (Sonnet T62–T65, game `3da56057-cf04-49c0-a194-b43fd0010bd4`)
+
+| Turn | Action     | `carriedLoads` | Active route stops                                                                | composition.pickups   | composition.deliveries |
+|------|------------|----------------|------------------------------------------------------------------------------------|------------------------|------------------------|
+| T62  | MoveTrain  | `["Oil","Oil"]` | `pickup(Oil@Newcastle), pickup(Oil@Newcastle), deliver(Oil@Antwerpen), deliver(Oil@Hamburg)` | **2× Oil@Newcastle** | — |
+| T63  | BuildTrack | `["Oil","Oil"]` | (same)                                                                             | —                       | — |
+| T64  | MoveTrain  | **`["Oil"]`**  | **`pickup(Machinery@Bremen), deliver(Machinery@Szczecin)`** ← Hamburg dropped     | —                       | Oil@Antwerpen |
+| T65  | BuildTrack | `["Oil"]`      | (Machinery route)                                                                  | —                       | — |
+
+The bot correctly picked up both Oil loads at Newcastle at T62 (`composition.pickups` shows two entries). It then delivered one Oil at Antwerpen at T64 (T64 `composition.deliveries: [Oil@Antwerpen]`, `carriedLoads` drops from 2 to 1). The post-delivery replan emitted a brand-new route — `pickup(Machinery@Bremen) → deliver(Machinery@Szczecin)` — that **does not include the still-carried Oil's delivery at Hamburg**. The `Oil → Hamburg` demand card stays in the hand (with `supplyCity = null` confirming the load is treated as carried) but the bot is now executing a route that takes it away from Hamburg toward Bremen.
+
+Net cost (same shape as the original observation): the bot retains one Oil cargo slot indefinitely with a matching demand card it will never service under the current plan, until either the load times out or the planner happens to choose Hamburg in a future replan.
+
+User initially described this as "only picks up one oil" — that was the visible *outcome* (only one Oil ever got delivered), but `carriedLoads` traces show the pickup was correct (two Oils) and the bug is post-delivery on the replan side. Same bug as the T28 → T29 Labor case.
+
+### Why this second trace matters
+
+1. **Train capacity is different** — Superfreight (capacity 3) vs the original observation's lower capacity. Confirms the bug isn't capacity-specific.
+2. **Pair pickup** — both demands had `supplyCity = Newcastle`, so the candidate generator must have correctly emitted the same-supply corridor candidate at T61. The bug is NOT in JIRA-250's corridor enumeration (that worked). The bug is the SUBSEQUENT replan after the first delivery.
+3. **Fix-branch regression target** — the T62 snapshot should be replayed in a regression fixture in addition to the T28 fixture. Two independent fixtures for the same defect raise confidence that the fix generalizes.
+
+## Not in scope
+
+- The "pickup Labor at Beograd" garbage stop at T28 may be a separate planner bug; address it in this ticket only if the same fix removes it, otherwise file a follow-up.
+- Whether the bot should physically *drop* a carried load to free a cargo slot when no demand exists (covered by JIRA-92 cargo conflict evaluation).
+- Trip scoring weight tuning (this ticket is about the inclusion guarantee, not the relative score).

--- a/docs/ai/done/jira-248-replanDropsCarriedLoadDelivery-technical.md
+++ b/docs/ai/done/jira-248-replanDropsCarriedLoadDelivery-technical.md
@@ -1,0 +1,67 @@
+# JIRA-248 — Carried-load deliveries must be a hard inclusion in every replan (technical)
+
+Companion to `jira-248-replanDropsCarriedLoadDelivery-behavioral.md`.
+
+## Defect locus (provisional — needs log validation)
+
+The trip planner's candidate generator builds candidate routes from `context.demands`. For a demand card with `supplyCity = null` (= load already on train), the candidate-builder must treat the delivery city as a **required stop** — not an optional one weighed against alternatives.
+
+Likely sites:
+
+- `src/server/services/ai/DeterministicTripPlanner.ts` — `enumerateCandidates` and downstream `scoreCandidate` / `computeAggregateScore`. The aggregation may be choosing a single best candidate without enforcing the constraint "every carried load with a matching demand must appear as a deliver stop." When the alternative-pair score (Tourists pair) is higher than the carried-load-inclusive pair, the carried delivery gets dropped.
+- `src/server/services/ai/prompts/ContextSerializer.ts` — if the LLM path is used (Hard skill) the prompt may not make carried loads sufficiently salient, but Sonnet here is Medium so this is the deterministic path.
+- `src/server/services/ai/context/DemandEngine.ts` — `scoreDemand` may be rejecting `isLoadOnTrain && supplyCity === null` cards under some filter (`isAffordable` / network reachability), even though their delivery is mechanically achievable.
+
+## Suspect: the affordability gate filters out carried-load demands when cash is low
+
+The JIRA-207B "no actionable demands → short-circuit DiscardHand" filter (`TripPlanner.ts:145-166`) requires `d.isAffordable` for a demand to be considered. For a carried-load demand, `isAffordable` likely measures cost-to-reach-delivery. If the bot is low on cash or far from Bern, the Labor→Bern demand may evaluate `isAffordable = false`, exiting the planner's actionable-demand set.
+
+If that's the cause, the fix is to **bypass the affordability check for `isLoadOnTrain` demands**: a carried load is sunk cost, the delivery requires only `cost-to-reach-delivery` (no pickup detour), and the planner must always consider it.
+
+## Fix shape
+
+Two layers — both should be applied.
+
+### Layer 1 — `DeterministicTripPlanner.enumerateCandidates` (the contract)
+
+When building candidate routes, every `pickup → deliver` pair must respect this invariant: **for every demand `d` in `context.demands` where `d.isLoadOnTrain === true` AND `d.deliveryCity` is reachable**, the candidate's stops must include a `deliver(d.loadType, d.deliveryCity)` stop OR the candidate must record an explicit deferral reason.
+
+Concretely:
+1. Partition `context.demands` into `mandatoryDeliveries` (carried loads with matching demand cards) and `optionalPairs` (everything else).
+2. The base candidate is `mandatoryDeliveries.map(d => deliverStop(d))`. This is the "deliver-only" candidate.
+3. Optional pickup/deliver pairs from `optionalPairs` are added if they improve aggregate score WITHOUT removing mandatory deliveries.
+4. If a candidate proposes removing a mandatory delivery, it must record `deferredReason: string` on the route metadata, and the deferred load's cargo cost must be counted against the candidate's score.
+
+### Layer 2 — `TripPlanner.planTrip` JIRA-207B short-circuit (the affordability gate)
+
+In `TripPlanner.ts:145-166`, change `actionableDemands` filter from:
+```ts
+const actionableDemands = context.demands.filter(d => d.isAffordable && (!d.isLoadOnTrain || !hasRemainingStops));
+```
+to something like:
+```ts
+const carriedDeliveryDemands = context.demands.filter(d => d.isLoadOnTrain && d.isDeliveryReachable);
+const freshDemands = context.demands.filter(d => !d.isLoadOnTrain && d.isAffordable);
+const actionableDemands = [...carriedDeliveryDemands, ...freshDemands];
+```
+
+Carried-load deliveries are never "unaffordable" in the same sense fresh demands are, because no pickup spend is required.
+
+## Acceptance from behavioral
+
+- **AC1** Unit test: fixture with one carried Labor + matching demand card + 4 cheap alternatives. `planTrip` returns a route that either includes `deliver(Labor@Bern)` or has a non-empty `deferredReason`.
+- **AC2** Unit test: vary `bot.money` from 0 to 100. Assert `deliver(Labor@Bern)` candidate is always evaluated (not filtered by affordability gate).
+- **AC3** Integration test: replay Sonnet T28 snapshot for 5 turns; assert the bot either delivers Labor→Bern within 4 turns or drops the load.
+- **AC4** Validator test: `pickup(Labor@Beograd)` is rejected by the action grammar validator when bot.loads already contains Labor (the T28 garbage stop).
+
+## Not in scope
+
+- Re-tuning the affordability heuristic itself (separate JIRA if needed).
+- Adding a UI surface for the bot to *announce* a deferral reason to the player (logging is enough).
+- Phase 4 event-card interactions with carried loads.
+
+## Validation hooks to inspect during fix
+
+- `composition.a1.opportunitiesFound` — should include carried-load deliveries when bot is near a matching delivery city.
+- `composition.deliveries` — should NOT be empty across multiple consecutive turns when a carried-load demand exists.
+- `demandRanking[*]` — carried-load demands should appear in the ranking with a non-degenerate score (currently they may be filtered out).

--- a/docs/ai/done/jira-249-routeOmitsPickupForNewDemand-behavioral.md
+++ b/docs/ai/done/jira-249-routeOmitsPickupForNewDemand-behavioral.md
@@ -1,0 +1,52 @@
+# JIRA-249 — Trip planner emits `deliver(X)` stop without a preceding `pickup(X)` when a new demand card is drawn (behavioral)
+
+In game `75c6afc8-8d99-49b0-b878-e5e19512478d`, player Sonnet at T15 has just had its demand hand refreshed. A new `Wine → Praha (supply Frankfurt)` card is in hand. The trip planner produces an active route consisting of a **single stop**: `deliver(Wine@Praha)`. There is no preceding `pickup(Wine@Frankfurt)` stop.
+
+The bot has no Wine on its train at T15 — Wine load is at the Frankfurt supply city. The route is therefore unexecutable as written: the bot cannot deliver a load it does not possess.
+
+The bot follows the malformed route anyway. T16–T17: BuildTrack and MoveTrain toward Praha. T17: arrives at Praha (`positionEnd: "Praha"`). T18: bot is at Praha, route's only stop is `deliver(Wine@Praha)`, no Wine is on board, so the executor emits **PassTurn**. Bot stands at Praha for a turn doing nothing.
+
+T19: trip planner re-runs and produces a *correct* route — `pickup(Cars@Stuttgart) → deliver(Cars@Antwerpen) → pickup(Wine@Frankfurt) → deliver(Wine@Praha)`. The Wine→Praha delivery is now properly preceded by a pickup at Frankfurt. T20–T22 the bot continues correcting course and backtracks westward toward Frankfurt to actually pick up Wine.
+
+Net cost: ~5 wasted turns (T15 planning the bad route, T16–T17 travel toward Praha, T18 PassTurn at Praha, plus T20+ backtracking to Frankfurt).
+
+## Source
+
+`logs/game-75c6afc8-8d99-49b0-b878-e5e19512478d.ndjson`, player Sonnet, T14 → T15 replan boundary through T19 recovery.
+
+## Observed trace (Sonnet T13–T19)
+
+| Turn | Action       | Position end | Route stops                                                                          | Wine demand |
+|------|--------------|--------------|--------------------------------------------------------------------------------------|-------------|
+| T13  | MoveTrain    | —            | `pickup(Wine@Frankfurt), deliver(Oil@Kaliningrad), deliver(Wine@Warszawa)`           | Wine→Warszawa (carried, supplyCity=null) |
+| T14  | BuildTrack   | —            | `pickup(Wine@Frankfurt), deliver(Oil@Kaliningrad), deliver(Wine@Warszawa)`           | Wine→Warszawa (carried) |
+| T15  | UpgradeTrain | —            | **`deliver(Wine@Praha)`**                                                            | **Wine→Praha (supply Frankfurt)** |
+| T16  | BuildTrack   | —            | `deliver(Wine@Praha)`                                                                | Wine→Praha |
+| T17  | MoveTrain    | **Praha**    | `deliver(Wine@Praha)`                                                                | Wine→Praha |
+| T18  | **PassTurn** | Praha        | `deliver(Wine@Praha)`                                                                | Wine→Praha |
+| T19  | BuildTrack   | —            | `pickup(Cars@Stuttgart), deliver(Cars@Antwerpen), pickup(Wine@Frankfurt), deliver(Wine@Praha)` | Wine→Praha |
+
+The hand turnover happens between T14 (Wine→Warszawa, carried) and T15 (Wine→Praha, supply=Frankfurt). The bot apparently delivered Wine→Warszawa or discarded the hand, drew the new Wine→Praha card, and the planner produced a route assuming Wine was still on the train.
+
+## Expected behavior
+
+When the trip planner generates a route stop sequence, every `deliver(X@city)` stop must have one of the following preconditions:
+1. A preceding `pickup(X@supplyCity)` stop in the same route, OR
+2. Load `X` is currently in `bot.loads` (carried).
+
+If neither holds, the candidate is malformed and must be rejected before becoming the active route. The planner should regenerate or fall back rather than commit a route that cannot execute.
+
+What must NOT happen: the bot drives to a delivery city, arrives without the load, emits a PassTurn, and only then re-plans. The malformed route should never have been chosen.
+
+## Acceptance
+
+- **AC1** — Replicate T15 snapshot: `bot.loads = []` (or whatever the actual loads are at T15 — needs log verification), demand hand contains `Wine → Praha (supply Frankfurt)`. Invoke trip planner. Assert: the returned route either (a) contains `pickup(Wine@Frankfurt)` before `deliver(Wine@Praha)`, or (b) does not include the Wine→Praha delivery at all.
+- **AC2** — The planner's candidate validator rejects any candidate whose deliver stop has no matching prior pickup AND whose load is not in `bot.loads`. The action-grammar validator already enforces this in the LLM action prompt (`TRIP_PLANNING_SYSTEM_SUFFIX` lines 183-186) — the deterministic candidate generator must enforce the same constraint.
+- **AC3** — Full-game regression on the T14 → T19 segment. Replay T14 snapshot, simulate the demand-hand turnover at T15 boundary. Assert: bot's T15 route contains a Wine pickup stop OR doesn't reference Wine at all. Bot does not arrive at Praha empty-handed.
+- **AC4** — Snapshot synchronization check. If the root cause is `bot.loads` being stale at the planner invocation point (`snapshot.bot.loads` still contains Wine from the carried state, even after Wine→Warszawa delivered), the snapshot mirror logic must be audited. (See `TurnExecutor.handleDeliverLoad` post-delivery `snapshot.bot.loads = ...filter(...)` — same site as the JIRA-220 follow-up.)
+
+## Not in scope
+
+- The T18 PassTurn-when-route-malformed behavior is a separate concern (could be useful to log a `malformed_route_arrived_empty_handed` reason). Outside this ticket.
+- Whether the bot should *cancel* the active route and re-plan immediately upon detecting a missing-pickup error (deferred — JIRA-249 just asserts the malformed route is never produced in the first place).
+- Demand-hand turnover policy / what triggers the T14→T15 hand change (orthogonal).

--- a/docs/ai/done/jira-249-routeOmitsPickupForNewDemand-technical.md
+++ b/docs/ai/done/jira-249-routeOmitsPickupForNewDemand-technical.md
@@ -1,0 +1,85 @@
+# JIRA-249 — Deterministic candidate generator must enforce the pickup-precedes-deliver invariant (technical)
+
+Companion to `jira-249-routeOmitsPickupForNewDemand-behavioral.md`.
+
+## Defect locus (provisional — needs log validation)
+
+Two likely sites; the fix probably needs both.
+
+### Site A — `DeterministicTripPlanner.ts` candidate generation
+
+`src/server/services/ai/DeterministicTripPlanner.ts` — `enumerateCandidates` (or whichever function builds the candidate's `stops` array). When the trip planner is invoked at T15 with a freshly drawn `Wine → Praha (supply Frankfurt)` card, the generator either:
+
+1. Looked at the *stale* `snapshot.bot.loads` that still contained Wine (a snapshot-sync bug), and concluded the load is "already carried" so no pickup needed, OR
+2. Generated a candidate with only the deliver stop because the new demand's `supplyCity` field was being misread or the candidate template defaulted to deliver-only.
+
+Path (1) is more likely given the T14 → T15 transition involves a `Wine` load delivery (`Wine → Warszawa` was carried at T14), so `snapshot.bot.loads` may not have been updated to reflect the delivery before the new trip plan ran.
+
+### Site B — `TripPlanner.ts` candidate validation
+
+`src/server/services/ai/TripPlanner.ts` — `scoreCandidates` / `validCandidates`. Whatever validation runs on the candidate set should reject a candidate with a deliver stop for which `(no prior pickup) AND (load not in snapshot.bot.loads)`. Currently it appears to admit such candidates.
+
+The LLM path's action-grammar rules (`TRIP_PLANNING_SYSTEM_SUFFIX` lines 183-186) explicitly call this out — "DELIVER requires a prior PICKUP in the same stop sequence, OR the load must already be in your CURRENT PLAN carried loads." The deterministic path needs the same constraint enforced in code, not in prompt instruction.
+
+## Fix shape
+
+### Step 1 — Validate snapshot sync at trip-planner invocation
+
+Before `DeterministicTripPlanner.planTripDeterministic` (or the LLM path equivalent) runs, assert:
+```ts
+// snapshot.bot.loads must reflect what is actually carried after all prior
+// in-turn actions (including any deliver that just fired during MovementPhase A1).
+// If snapshot is stale, every downstream candidate-generation decision is wrong.
+```
+
+Audit the call path between `TurnExecutor.handleDeliverLoad` and the next `TripPlanner.planTrip` invocation in the same turn. If the snapshot mirror in `handleDeliverLoad` (around `snapshot.bot.loads = snapshot.bot.loads.filter(l => l !== loadType)`) does not run before the post-delivery replan, we have a stale-loads bug.
+
+### Step 2 — Add a candidate-validator invariant
+
+In `DeterministicTripPlanner.scoreCandidate` (or wherever final route shapes are validated), reject any candidate failing this invariant:
+
+```ts
+function isCandidateGrammaticallyValid(
+  candidate: CandidateRoute,
+  carriedLoads: string[],
+): boolean {
+  const carriedAtStart = new Set(carriedLoads);
+  const pickedUpInRoute = new Set<string>();
+
+  for (const stop of candidate.stops) {
+    if (stop.action === 'pickup') {
+      pickedUpInRoute.add(stop.loadType);
+    } else if (stop.action === 'deliver') {
+      if (!carriedAtStart.has(stop.loadType) && !pickedUpInRoute.has(stop.loadType)) {
+        return false; // deliver-without-pickup, candidate is malformed
+      }
+    }
+  }
+  return true;
+}
+```
+
+Reject malformed candidates at score time; never let them become the active route.
+
+### Step 3 — Add a defensive runtime guard
+
+`MovementPhasePlanner` should detect "bot at delivery city but lacks the load" and trigger a replan instead of emitting PassTurn. If the planner's grammar check at Step 2 fails to catch a malformed route in some edge case, runtime should not silently waste a turn. Set `terminationReason = 'arrived_for_deliver_but_load_not_carried'` and trigger an immediate `TripPlanner` replan.
+
+## Acceptance from behavioral
+
+- **AC1** Unit test on `DeterministicTripPlanner.planTripDeterministic`: fixture with `bot.loads = []`, demand `Wine → Praha (supply Frankfurt)`. Assert: returned route contains a `pickup(Wine@Frankfurt)` stop preceding the deliver, OR does not reference Wine at all.
+- **AC2** Unit test on candidate validator: pass a hand-crafted malformed candidate (deliver without pickup, load not in `carriedLoads`). Assert: validator returns false / candidate is filtered out of the scored set.
+- **AC3** Integration test replaying T14→T15 hand turnover: simulate Wine→Warszawa delivery + Wine→Praha card draw + immediate planner re-invocation. Assert: bot's T15 active route is grammatically valid OR replanner detects malformation and re-runs.
+- **AC4** Runtime guard test: simulate the malformed-route case (bot at Praha, route stop = deliver Wine, loads empty). Assert: planner emits `terminationReason = 'arrived_for_deliver_but_load_not_carried'` and re-invokes TripPlanner instead of PassTurn.
+
+## Not in scope
+
+- Changing the LLM prompt (the prompt already states this constraint, line 183-186 of `systemPrompts.ts`); the fix is in the deterministic candidate generator + validator.
+- Reworking the demand-hand turnover logic.
+- Phase 4 event-card draw effects on hand turnover.
+
+## Validation hooks to inspect during fix
+
+- The transition `bot.loads` between T14 (carrying Wine) and T15 (after Warszawa delivery, before Praha card draw). If `snapshot.bot.loads` at the T15 planner invocation still contains Wine, the snapshot mirror is the bug, not the candidate generator.
+- The `actionableDemands` filter at `TripPlanner.ts:145-166` — does it correctly recognize `Wine → Praha` as a fresh (not carried) demand when the bot has just delivered Wine→Warszawa in the same turn?
+- The candidate's `validation` output — what does `validCandidates[0]` look like at T15? Confirm whether the malformed candidate is at index 0, or whether it's only being chosen after filtering eliminated others.

--- a/docs/ai/done/jira-250-corridorPickupMissedSecondFish-behavioral.md
+++ b/docs/ai/done/jira-250-corridorPickupMissedSecondFish-behavioral.md
@@ -1,0 +1,63 @@
+# JIRA-250 — Planner fails to pick up a second load at the same supply city when two demands share the supply and the corridor (behavioral)
+
+In game `75c6afc8-8d99-49b0-b878-e5e19512478d`, player Sonnet at T45 picks up one Fish load at Oslo for delivery to Zurich. Between T45 and T46 the demand hand turns over and the bot now holds **two** Fish demands: `Fish → Zurich` and `Fish → Milano`. Both demand cards have `supplyCity = null`, indicating the planner treats them as matched to the load already on the train (the single Fish picked up at T45).
+
+The bot has cargo capacity for at least one more load (Freight=2 slots, Heavy Freight/Superfreight=3). Fish is still available at Oslo (the bot just picked one up; the load chip count for Fish is 4 in the standard rules). **Zurich lies geographically on the corridor from Oslo to Milano** — the user's observation matches the map: Oslo → south through central Europe → Zurich → Milano is a natural single-trip path.
+
+At T46, the new route is `pickup(Fish@Oslo) → deliver(Fish@Milano)`. The planner:
+
+1. Did not include a `deliver(Fish@Zurich)` stop — even though the corridor would make it a near-free side delivery.
+2. Did not include a second `pickup(Fish@Oslo)` stop — even though the bot is at Oslo (or close), Fish is still available there, and the bot has the slot.
+3. Treated both `Fish` demands as if the single carried Fish satisfies both, which it does not — each delivery requires its own load.
+
+The bot follows this single-delivery route across T46–T50 (MoveTrain every turn, no replans). By T51 the route changes to a completely different Wine trip and Fish→Zurich is back in hand with `supplyCity = Oslo` (no longer null), suggesting the Fish→Milano delivery happened around T50→T51 and the Zurich demand reverted to "fresh" — meaning the bot will eventually have to detour back to Oslo for the Zurich Fish in a future trip.
+
+Net cost: the planner missed a free corridor optimization. The bot will need to make a second Oslo trip later for what should have been a single Oslo → Zurich → Milano run.
+
+## Source
+
+`logs/game-75c6afc8-8d99-49b0-b878-e5e19512478d.ndjson`, player Sonnet, T45 → T46 replan boundary.
+
+## Observed trace (Sonnet T43–T52)
+
+| Turn | Action     | Loads picked up    | Route stops                                                            | Fish demands |
+|------|------------|---------------------|------------------------------------------------------------------------|--------------|
+| T43  | BuildTrack | —                  | `pickup(Tourists@Ruhr), deliver(Tourists@Oslo), pickup(Fish@Oslo), deliver(Fish@Zurich)` | Fish→Zurich/from Oslo |
+| T44  | MoveTrain  | —                  | (same)                                                                 | Fish→Zurich/from Oslo |
+| T45  | MoveTrain  | **`Fish@Oslo`**    | (empty — route just completed Tourists leg)                            | **Two Fish demands now: Fish→Zurich/null + Fish→Milano/null** |
+| T46  | MoveTrain  | —                  | **`pickup(Fish@Oslo), deliver(Fish@Milano)`** — Zurich omitted          | Fish→Zurich/null + Fish→Milano/null |
+| T47–50 | MoveTrain | —                  | (same Milano-only route)                                                | (same) |
+| T51  | MoveTrain  | —                  | `pickup(Wine@Frankfurt), deliver(Wine@Napoli)` — Fish trip complete    | Fish→Zurich/**from Oslo** (no longer carried — needs detour) |
+
+The smoking gun is the T46 route. The bot is at Oslo (or nearby), carrying one Fish. Two Fish demands sit in the hand. The planner sees both demands but constructs a route that satisfies only one delivery, ignoring the corridor.
+
+## Expected behavior
+
+When the planner is invoked with:
+1. ≥1 demand cards of the same load type,
+2. The same supply city for both,
+3. At least one delivery city on the path between the current position and the other delivery city,
+4. Available cargo capacity,
+5. Load chips available at the supply city,
+
+…the planner MUST emit a route that picks up the additional load and delivers along the corridor. The trip-planning system prompt already calls this out as rule #1 of TRIP RULES (`COMBINE CORRIDORS: Two deliveries on one route beat two separate routes`, `WORKED EXAMPLE — Cardiff×2 Hops → Holland + Ruhr`). The deterministic candidate generator must enforce the same heuristic in code.
+
+What must NOT happen: a single-delivery route is selected over a two-delivery same-corridor route when the corridor delivery is geometrically free or cheap.
+
+## Acceptance
+
+- **AC1** — Replicate T45/T46 snapshot: bot at Oslo, `loads = ['Fish']`, demand hand contains `Fish → Zurich (supplyCity=null)` and `Fish → Milano (supplyCity=null)`, Fish available at Oslo, capacity ≥ 2 free slots. Invoke trip planner. Assert: returned route includes a stop sequence equivalent to `[pickup(Fish@Oslo), deliver(Fish@Zurich), deliver(Fish@Milano)]` OR provides a per-stop reasoning that explains why the Zurich detour was rejected (e.g. specific build cost > corridor savings).
+- **AC2** — Same fixture, but Zurich is NOT on the Oslo→Milano corridor (e.g. swap Zurich for an arbitrary off-path city). Assert: planner is free to choose either single-delivery or two-delivery; no constraint violation.
+- **AC3** — Same fixture, but capacity = 1 (Slow Freight). Assert: planner correctly chooses one delivery, with reasoning citing capacity.
+- **AC4** — Same fixture, but Fish chip count at Oslo is exhausted (no more Fish available). Assert: planner correctly chooses one delivery and notes the load-chip exhaustion in reasoning.
+- **AC5** — Demand-card matching invariant: when two demand cards reference the same load type and the bot carries one matching load, the planner must NOT treat the carried load as satisfying both demands. Each delivery requires its own load chip.
+
+## Not in scope
+
+- Re-tuning corridor detection thresholds (separate ticket if the heuristic needs sharpening).
+- Multi-corridor optimization (3+ loads sharing partial paths) — this ticket is about the simpler 2-load case where the second delivery is *on* the first's path.
+- The demand-hand turnover that produced the second Fish card at T45 — orthogonal.
+
+## Relationship to JIRA-248
+
+JIRA-248 describes a similar pattern: the planner drops a carried-load delivery from its route. JIRA-250 is a sibling case where the carried Fish satisfies one demand, but a second matching demand card sits in the hand and the planner doesn't trigger the same-supply-corridor pickup. The fix sites likely overlap: both call out the candidate generator's failure to account for available carried loads + matching demands. If JIRA-248's fix correctly enumerates carried-deliverable corridors, this ticket may be partially closed by it. Verify in regression.

--- a/docs/ai/done/jira-250-corridorPickupMissedSecondFish-technical.md
+++ b/docs/ai/done/jira-250-corridorPickupMissedSecondFish-technical.md
@@ -1,0 +1,96 @@
+# JIRA-250 — Candidate generator must enumerate "same supply, same load, multiple demands" corridor pickups (technical)
+
+Companion to `jira-250-corridorPickupMissedSecondFish-behavioral.md`.
+
+## Defect locus (provisional — needs log validation)
+
+The deterministic candidate generator at `src/server/services/ai/DeterministicTripPlanner.ts` enumerates routes via pair/triple combinations of demand cards. When two demand cards have:
+
+- Same `loadType`
+- Same `supplyCity`
+- Different `deliveryCity`
+
+…the generator should emit a candidate of shape `[pickup(L@supply), pickup(L@supply), deliver(L@city1), deliver(L@city2)]` where the deliver order is chosen by network distance from the supply. The user's observed T46 behavior suggests this enumeration is either:
+
+1. Not happening at all (the generator doesn't produce two-pickup-same-city candidates), OR
+2. Happening but being filtered out by an affordability or simulation gate.
+
+## Suspect: the carried-load demand matching collapses both demands into one
+
+When the bot picked up Fish at T45, `bot.loads = ['Fish']`. The demand-context builder (`DemandEngine.scoreDemand` or equivalent) marks any Fish demand as `isLoadOnTrain = true` and sets `supplyCity = null` ("matched to carry"). At T46 both `Fish→Zurich` and `Fish→Milano` demands have `supplyCity = null`.
+
+The candidate generator then treats both as "carried-delivery candidates" — *each* demand looks like a free delivery using the one Fish on board. But the bot has only ONE Fish chip. The generator may be computing the candidate `[deliver(Fish@Zurich), deliver(Fish@Milano)]` and scoring it as if both deliveries succeed (double payout, single load). Whichever scoring step is supposed to detect "you can only deliver one Fish" is missing.
+
+When the scorer or executor rejects the double-delivery candidate (because the bot would arrive at Milano with no Fish remaining after delivering at Zurich), the planner falls back to a single-delivery candidate. It picks `Fish→Milano` (perhaps because it has the higher payout or is the new card) and discards the Fish→Zurich consideration entirely — instead of stepping back and recognizing "I should pick up a second Fish at Oslo to satisfy both demands."
+
+## Fix shape
+
+Three layers; layer 2 is the meat of the fix.
+
+### Layer 1 — Demand-context builder: distinguish "carried satisfies" from "fresh"
+
+In `src/server/services/ai/context/DemandEngine.ts` (or wherever `DemandContext.supplyCity` is set), if `loadType` is in `bot.loads`, the matched demand gets `supplyCity = null`. BUT if there are **more demand cards matching the same loadType than carried load chips**, only the first N (where N = carried count) should have `supplyCity = null`; the rest must retain their original `supplyCity` so the planner knows they require a fresh pickup.
+
+Currently:
+- `bot.loads = ['Fish']`, demands match `Fish→Zurich` + `Fish→Milano` → BOTH get `supplyCity = null`. **Wrong.**
+
+Correct:
+- Same scenario → ONE demand (e.g. the one with the closer deliveryCity) gets `supplyCity = null`; the OTHER retains `supplyCity = 'Oslo'`.
+
+This makes the second demand visible to the candidate generator as a fresh pickup opportunity.
+
+### Layer 2 — Candidate generator: emit "same supply, same load, ≥2 demands" candidates
+
+In `DeterministicTripPlanner.enumerateCandidates`, add a generation rule:
+
+```ts
+// Group demands by (loadType, supplyCity); for each group with size ≥ 2 AND
+// supplyCity !== null AND capacity allows multiple pickups, emit a candidate
+// route with N pickups + N deliveries in network-distance order from supply.
+for (const [(load, supply), demands] of groupBy(demands, d => [d.loadType, d.supplyCity])) {
+  if (demands.length < 2 || supply === null) continue;
+  if (carriedCount(load) + demands.length > capacity) continue;
+  if (!loadChipAvailable(load, supply, demands.length)) continue;
+
+  const deliveryOrder = orderByNetworkDistance(supply, demands.map(d => d.deliveryCity));
+  const candidate = {
+    stops: [
+      ...Array(demands.length).fill(null).map(() => ({ action: 'pickup', loadType: load, city: supply })),
+      ...deliveryOrder.map(city => ({ action: 'deliver', loadType: load, city, ... })),
+    ],
+  };
+  yield candidate;
+}
+```
+
+This matches the prompt-side `WORKED EXAMPLE — Cardiff×2 Hops` constraint (separate pickup stops, one per load unit), which currently lives only in `TRIP_PLANNING_SYSTEM_SUFFIX` for the LLM path.
+
+### Layer 3 — Scorer: penalize "carry already matched" double-counting
+
+Cross-check: when a candidate has two `deliver(L@x)` and `deliver(L@y)` stops without two preceding pickups (or two carried loads), reject the candidate as malformed. This is essentially the same invariant as JIRA-249's grammar check (`deliver` requires `pickup` OR `carriedLoads`), extended to handle the multiplicity case: each `deliver(L)` consumes one `L` from `carriedLoads ∪ pickupsSoFar`.
+
+## Acceptance from behavioral
+
+- **AC1** Unit test on `DeterministicTripPlanner.enumerateCandidates`: fixture matching T45 (bot at Oslo, loads=['Fish'], demands include both Fish→Zurich and Fish→Milano, capacity=2). Assert: candidate set includes a route shaped `[pickup(Fish@Oslo), deliver(Fish@Zurich), deliver(Fish@Milano)]` (note: starts with 1 pickup because bot already carries 1).
+- **AC2** Unit test on demand-context builder: fixture with `bot.loads = ['Fish']` + 2 Fish demands. Assert: exactly ONE demand has `supplyCity = null`; the other retains its original supply city.
+- **AC3** Unit test on candidate-grammar validator: a candidate with `[deliver(Fish@A), deliver(Fish@B)]` and `carriedLoads = ['Fish']` (only ONE Fish on train) is rejected as malformed.
+- **AC4** Integration test replaying T45 snapshot: planner returns the corridor route, bot completes Oslo → Zurich → Milano without a second Oslo trip.
+- **AC5** Reuse JIRA-250-AC2/AC3/AC4 from the behavioral spec (off-corridor, capacity limit, chip exhaustion variants).
+
+## Not in scope
+
+- N-way corridor optimization (3+ deliveries sharing partial paths).
+- LLM-path corridor handling (the prompt already specifies the rule; this fix is for the deterministic path).
+- Re-tuning candidate count cap if the new candidates blow up the enumeration size — separate JIRA if perf regresses.
+
+## Validation hooks to inspect during fix
+
+- `composition.a1.opportunitiesFound` at T45 — does Phase A1 (opportunistic pickup) notice the second Fish demand and the slot availability? If yes, A1 should have fired the second pickup before the planner re-ran. If A1 didn't notice, that's a co-occurring bug.
+- `demandRanking[*]` at T46 — both Fish demands should appear; check their `supplyCity` values and `score`s.
+- The trip planner's selected `route.reasoning` — does the LLM/deterministic logic mention the dropped Zurich delivery, or is the omission silent?
+
+## Relationship to JIRA-248 and JIRA-249
+
+- JIRA-248: replan drops carried-load delivery entirely. JIRA-250 is a related case where the carried load matches one demand but the second matching demand (requiring a fresh pickup at the same supply) is dropped.
+- JIRA-249: malformed route emits deliver without prior pickup. JIRA-250's Layer 3 (grammar invariant for multiplicity) is the same family of check.
+- All three should be fixed in coordination — they're symptoms of the same candidate-generator weakness around carried-load + matching-demand semantics.

--- a/src/server/__tests__/ai/DemandEngine.test.ts
+++ b/src/server/__tests__/ai/DemandEngine.test.ts
@@ -517,3 +517,217 @@ describe('JIRA-231: Feasibility producer — supply city saturated', () => {
     }
   });
 });
+
+// ── JIRA-250 Layer 1: Multiplicity-aware carry-load detection ─────────────────
+
+describe('JIRA-250 Layer 1: computeAllDemandContexts — multiplicity-aware carry-load assignment', () => {
+  /**
+   * Unit Test 1: bot.loads = ['Labor'], 2 Labor demands.
+   * Expected: exactly one demand gets supplyCity=null (carried), the other gets a real supplyCity.
+   */
+  it('UT1: one carried Labor + two Labor demands → exactly one demand gets supplyCity=null', () => {
+    const snapshot: WorldSnapshot = {
+      ...makeSnapshot({ loads: ['Labor'] }),
+      bot: {
+        ...makeSnapshot({ loads: ['Labor'] }).bot,
+        loads: ['Labor'],
+        resolvedDemands: [
+          {
+            cardId: 1,
+            demands: [{ city: 'Berlin', loadType: 'Labor', payment: 15 }],
+          },
+          {
+            cardId: 2,
+            demands: [{ city: 'Hamburg', loadType: 'Labor', payment: 12 }],
+          },
+        ],
+      },
+    };
+
+    const gridPoints: GridPoint[] = [
+      makeCityPoint(5, 5, 'Warsaw', ['Labor']),   // supply city
+      makeCityPoint(10, 10, 'Berlin'),
+      makeCityPoint(15, 15, 'Hamburg'),
+    ];
+
+    mockEstimateGraphPathCost.mockReturnValue({
+      reachable: true, buildCost: 0, pathLength: 18, estimatedTurns: 2,
+    });
+
+    const contexts = computeAllDemandContexts(
+      snapshot,
+      null,
+      gridPoints,
+      ['Warsaw', 'Berlin', 'Hamburg'],
+      ['Warsaw', 'Berlin', 'Hamburg'],
+      [],
+    );
+
+    expect(contexts).toHaveLength(2);
+    const nullSupplyCities = contexts.filter(c => c.supplyCity === null);
+    const realSupplyCities = contexts.filter(c => c.supplyCity !== null && c.supplyCity !== 'NoSupply');
+    expect(nullSupplyCities).toHaveLength(1);
+    expect(realSupplyCities).toHaveLength(1);
+    expect(realSupplyCities[0].supplyCity).toBe('Warsaw');
+  });
+
+  /**
+   * Unit Test 2: bot.loads = ['Fish', 'Fish'], 1 Fish demand.
+   * Expected: that demand gets supplyCity=null (carried).
+   */
+  it('UT2: two carried Fish + one Fish demand → demand gets supplyCity=null', () => {
+    const snapshot: WorldSnapshot = {
+      ...makeSnapshot({ loads: ['Fish', 'Fish'] }),
+      bot: {
+        ...makeSnapshot({ loads: ['Fish', 'Fish'] }).bot,
+        loads: ['Fish', 'Fish'],
+        resolvedDemands: [
+          {
+            cardId: 1,
+            demands: [{ city: 'Marseille', loadType: 'Fish', payment: 18 }],
+          },
+        ],
+      },
+    };
+
+    const gridPoints: GridPoint[] = [
+      makeCityPoint(3, 3, 'Oslo', ['Fish']),    // supply city
+      makeCityPoint(10, 10, 'Marseille'),
+    ];
+
+    mockEstimateGraphPathCost.mockReturnValue({
+      reachable: true, buildCost: 0, pathLength: 18, estimatedTurns: 2,
+    });
+
+    const contexts = computeAllDemandContexts(
+      snapshot,
+      null,
+      gridPoints,
+      ['Oslo', 'Marseille'],
+      ['Oslo', 'Marseille'],
+      [],
+    );
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].supplyCity).toBeNull();
+    expect(contexts[0].isLoadOnTrain).toBe(true);
+  });
+
+  /**
+   * Unit Test 3: bot.loads = [], Wine demands.
+   * Expected: all Wine demands retain their original supplyCity.
+   */
+  it('UT3: empty loads + two Wine demands → both demands retain real supplyCity', () => {
+    const snapshot: WorldSnapshot = {
+      ...makeSnapshot({ loads: [] }),
+      bot: {
+        ...makeSnapshot({ loads: [] }).bot,
+        loads: [],
+        resolvedDemands: [
+          {
+            cardId: 1,
+            demands: [{ city: 'London', loadType: 'Wine', payment: 20 }],
+          },
+          {
+            cardId: 2,
+            demands: [{ city: 'Berlin', loadType: 'Wine', payment: 16 }],
+          },
+        ],
+      },
+    };
+
+    const gridPoints: GridPoint[] = [
+      makeCityPoint(3, 3, 'Bordeaux', ['Wine']),  // supply city
+      makeCityPoint(10, 10, 'London'),
+      makeCityPoint(15, 15, 'Berlin'),
+    ];
+
+    mockEstimateGraphPathCost.mockReturnValue({
+      reachable: true, buildCost: 0, pathLength: 18, estimatedTurns: 2,
+    });
+
+    const contexts = computeAllDemandContexts(
+      snapshot,
+      null,
+      gridPoints,
+      ['Bordeaux', 'London', 'Berlin'],
+      ['Bordeaux', 'London', 'Berlin'],
+      [],
+    );
+
+    expect(contexts).toHaveLength(2);
+    for (const ctx of contexts) {
+      expect(ctx.supplyCity).not.toBeNull();
+      expect(ctx.supplyCity).not.toBe('NoSupply');
+      expect(ctx.isLoadOnTrain).toBe(false);
+    }
+  });
+
+  /**
+   * Unit Test 4: Multiple load types with varying counts.
+   * bot.loads = ['Fish', 'Coal'], demands = [Fish→Berlin, Fish→London, Coal→Paris].
+   * Expected: one Fish demand gets supplyCity=null, the other retains its supplyCity.
+   * Coal demand gets supplyCity=null.
+   */
+  it('UT4: mixed loads with multiple types → correct multiplicity-aware assignment across types', () => {
+    const snapshot: WorldSnapshot = {
+      ...makeSnapshot({ loads: ['Fish', 'Coal'] }),
+      bot: {
+        ...makeSnapshot({ loads: ['Fish', 'Coal'] }).bot,
+        loads: ['Fish', 'Coal'],
+        resolvedDemands: [
+          {
+            cardId: 1,
+            demands: [{ city: 'Berlin', loadType: 'Fish', payment: 20 }],
+          },
+          {
+            cardId: 2,
+            demands: [{ city: 'London', loadType: 'Fish', payment: 18 }],
+          },
+          {
+            cardId: 3,
+            demands: [{ city: 'Paris', loadType: 'Coal', payment: 14 }],
+          },
+        ],
+      },
+    };
+
+    const gridPoints: GridPoint[] = [
+      makeCityPoint(3, 3, 'Oslo', ['Fish']),       // Fish supply city
+      makeCityPoint(4, 4, 'Hamburg', ['Coal']),    // Coal supply city
+      makeCityPoint(10, 10, 'Berlin'),
+      makeCityPoint(15, 15, 'London'),
+      makeCityPoint(12, 12, 'Paris'),
+    ];
+
+    mockEstimateGraphPathCost.mockReturnValue({
+      reachable: true, buildCost: 0, pathLength: 18, estimatedTurns: 2,
+    });
+
+    const contexts = computeAllDemandContexts(
+      snapshot,
+      null,
+      gridPoints,
+      ['Oslo', 'Hamburg', 'Berlin', 'London', 'Paris'],
+      ['Oslo', 'Hamburg', 'Berlin', 'London', 'Paris'],
+      [],
+    );
+
+    expect(contexts).toHaveLength(3);
+
+    const fishContexts = contexts.filter(c => c.loadType === 'Fish');
+    const coalContexts = contexts.filter(c => c.loadType === 'Coal');
+
+    // Exactly one Fish demand should be carried (supplyCity=null)
+    const fishCarried = fishContexts.filter(c => c.supplyCity === null);
+    const fishFresh = fishContexts.filter(c => c.supplyCity !== null && c.supplyCity !== 'NoSupply');
+    expect(fishCarried).toHaveLength(1);
+    expect(fishFresh).toHaveLength(1);
+    expect(fishFresh[0].supplyCity).toBe('Oslo');
+
+    // The Coal demand should be carried (supplyCity=null)
+    expect(coalContexts).toHaveLength(1);
+    expect(coalContexts[0].supplyCity).toBeNull();
+    expect(coalContexts[0].isLoadOnTrain).toBe(true);
+  });
+});

--- a/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
+++ b/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
@@ -66,6 +66,9 @@ import {
   scoreCandidate,
   pickTop1,
   planTripDeterministic,
+  isCandidateGrammaticallyValid,
+  enumerateCarriedDeliveryFloor,
+  enumerateSameSupplyCorridorCandidates,
 } from '../../services/ai/DeterministicTripPlanner';
 import {
   WorldSnapshot,
@@ -2405,5 +2408,282 @@ describe('JIRA-242 expansion bonus (multi-delivery)', () => {
     });
     applyExpansionBonus(odd);
     expect(odd.aggregateScore).toBe(0.5);
+  });
+});
+
+// ── JIRA-249/250: Grammar validation & carried delivery floor ─────────
+
+type Row = { loadType: string; supplyCity: string | null; deliveryCity: string; payout: number; cardIndex: number; isCarry: boolean };
+
+function makeRow(overrides: Partial<Row> = {}): Row {
+  return {
+    loadType: 'Coal',
+    supplyCity: 'Essen',
+    deliveryCity: 'Berlin',
+    payout: 15,
+    cardIndex: 1,
+    isCarry: false,
+    ...overrides,
+  };
+}
+
+function makeCandidate(id: string, stops: RouteStop[], rows: Row[] = []): { id: string; rows: Row[]; stops: RouteStop[]; payout: number } {
+  return { id, rows, stops, payout: rows.reduce((s, r) => s + r.payout, 0) };
+}
+
+describe('isCandidateGrammaticallyValid', () => {
+  /**
+   * UT1 (Grammar - Deliver without Pickup):
+   * Candidate [deliver(Wine@Praha)] with carriedLoads=[] → rejected with deliver_without_pickup.
+   */
+  it('UT1: rejects deliver(Wine@Praha) when carriedLoads=[] with reason=deliver_without_pickup', () => {
+    const candidate = makeCandidate('test:1', [
+      { action: 'deliver', loadType: 'Wine', city: 'Praha', demandCardId: 1, payment: 20 },
+    ], [makeRow({ loadType: 'Wine', deliveryCity: 'Praha', payout: 20 })]);
+
+    const result = isCandidateGrammaticallyValid(candidate, []);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.rejection.reason).toBe('deliver_without_pickup');
+      expect(result.rejection.loadType).toBe('Wine');
+      expect(result.rejection.offendingStopIndex).toBe(0);
+    }
+  });
+
+  /**
+   * UT2 (Grammar - Deliver Exceeds Carried):
+   * Candidate [deliver(Fish@Zurich), deliver(Fish@Milano)] with carriedLoads=['Fish']
+   * → rejected with deliver_exceeds_carried (only one Fish, but two deliveries).
+   */
+  it('UT2: rejects [deliver(Fish@Zurich), deliver(Fish@Milano)] with one carried Fish with reason=deliver_exceeds_carried', () => {
+    const candidate = makeCandidate('test:2', [
+      { action: 'deliver', loadType: 'Fish', city: 'Zurich', demandCardId: 1, payment: 20 },
+      { action: 'deliver', loadType: 'Fish', city: 'Milano', demandCardId: 2, payment: 18 },
+    ], [
+      makeRow({ loadType: 'Fish', deliveryCity: 'Zurich', cardIndex: 1, payout: 20 }),
+      makeRow({ loadType: 'Fish', deliveryCity: 'Milano', cardIndex: 2, payout: 18 }),
+    ]);
+
+    const result = isCandidateGrammaticallyValid(candidate, ['Fish']);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.rejection.reason).toBe('deliver_exceeds_carried');
+      expect(result.rejection.loadType).toBe('Fish');
+      expect(result.rejection.offendingStopIndex).toBe(1); // second deliver fails
+    }
+  });
+
+  it('accepts valid candidate: pickup(Fish) then deliver(Fish)', () => {
+    const candidate = makeCandidate('test:3', [
+      { action: 'pickup', loadType: 'Fish', city: 'Oslo' },
+      { action: 'deliver', loadType: 'Fish', city: 'Zurich', demandCardId: 1, payment: 20 },
+    ]);
+
+    const result = isCandidateGrammaticallyValid(candidate, []);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts valid candidate: two pickups then two deliveries', () => {
+    const candidate = makeCandidate('test:4', [
+      { action: 'pickup', loadType: 'Fish', city: 'Oslo' },
+      { action: 'pickup', loadType: 'Fish', city: 'Oslo' },
+      { action: 'deliver', loadType: 'Fish', city: 'Zurich', demandCardId: 1, payment: 20 },
+      { action: 'deliver', loadType: 'Fish', city: 'Milano', demandCardId: 2, payment: 18 },
+    ]);
+
+    const result = isCandidateGrammaticallyValid(candidate, []);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts carry-only candidate: deliver(Labor@Bern) with carriedLoads=[Labor]', () => {
+    const candidate = makeCandidate('test:5', [
+      { action: 'deliver', loadType: 'Labor', city: 'Bern', demandCardId: 1, payment: 12 },
+    ]);
+
+    const result = isCandidateGrammaticallyValid(candidate, ['Labor']);
+    expect(result.ok).toBe(true);
+  });
+
+  it('provides carriedAtStart and pickupsBeforeOffender in rejection context', () => {
+    const candidate = makeCandidate('test:6', [
+      { action: 'pickup', loadType: 'Coal', city: 'Essen' },
+      { action: 'deliver', loadType: 'Coal', city: 'Berlin', demandCardId: 1, payment: 15 },
+      // Extra deliver with no Coal left
+      { action: 'deliver', loadType: 'Coal', city: 'Warszawa', demandCardId: 2, payment: 10 },
+    ]);
+
+    const result = isCandidateGrammaticallyValid(candidate, []);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.rejection.context.carriedAtStart).toEqual([]);
+      expect(result.rejection.context.pickupsBeforeOffender).toContain('Coal');
+      expect(result.rejection.reason).toBe('deliver_exceeds_carried');
+    }
+  });
+});
+
+describe('enumerateCarriedDeliveryFloor', () => {
+  /**
+   * UT3 (Carried Delivery Floor):
+   * When bot.loads=['Labor'] and Labor is deliverable to Bern,
+   * enumerateCandidates must include a candidate with deliver(Labor@Bern).
+   */
+  it('UT3: generates a floor candidate with deliver(Labor@Bern) when one Labor carried', () => {
+    const rows: Row[] = [
+      makeRow({ loadType: 'Labor', deliveryCity: 'Bern', cardIndex: 1, payout: 12, isCarry: true, supplyCity: null }),
+    ];
+
+    const floor = enumerateCarriedDeliveryFloor(rows);
+
+    expect(floor).not.toBeNull();
+    expect(floor!.stops).toHaveLength(1);
+    expect(floor!.stops[0]).toMatchObject({ action: 'deliver', loadType: 'Labor', city: 'Bern' });
+    expect(floor!.id).toContain('carry-floor');
+  });
+
+  it('returns null when no carried rows exist', () => {
+    const rows: Row[] = [
+      makeRow({ loadType: 'Coal', deliveryCity: 'Berlin', cardIndex: 1, isCarry: false }),
+    ];
+
+    const floor = enumerateCarriedDeliveryFloor(rows);
+    expect(floor).toBeNull();
+  });
+
+  it('includes all carried rows in the floor candidate', () => {
+    const rows: Row[] = [
+      makeRow({ loadType: 'Fish', deliveryCity: 'Zurich', cardIndex: 1, payout: 20, isCarry: true, supplyCity: null }),
+      makeRow({ loadType: 'Coal', deliveryCity: 'Berlin', cardIndex: 2, payout: 15, isCarry: true, supplyCity: null }),
+      makeRow({ loadType: 'Wine', deliveryCity: 'London', cardIndex: 3, payout: 18, isCarry: false }),
+    ];
+
+    const floor = enumerateCarriedDeliveryFloor(rows);
+
+    expect(floor).not.toBeNull();
+    expect(floor!.stops).toHaveLength(2); // only the 2 carry rows
+    const loadTypes = floor!.stops.map(s => s.loadType);
+    expect(loadTypes).toContain('Fish');
+    expect(loadTypes).toContain('Coal');
+  });
+});
+
+describe('enumerateSameSupplyCorridorCandidates', () => {
+  /**
+   * UT4 (Corridor Enumeration):
+   * T46 scenario: bot at Oslo, two Fish demands (Fish→Zurich, Fish→Milano), capacity=2.
+   * Expected: candidate [pickup(Fish@Oslo), pickup(Fish@Oslo), deliver(Fish@Zurich), deliver(Fish@Milano)].
+   */
+  it('UT4: generates corridor candidate for T46-like scenario [pickup(Fish@Oslo)×2, deliver(Fish@Zurich), deliver(Fish@Milano)]', () => {
+    const rows: Row[] = [
+      makeRow({ loadType: 'Fish', supplyCity: 'Oslo', deliveryCity: 'Zurich', cardIndex: 1, payout: 20, isCarry: false }),
+      makeRow({ loadType: 'Fish', supplyCity: 'Oslo', deliveryCity: 'Milano', cardIndex: 2, payout: 18, isCarry: false }),
+    ];
+    const carriedCount = new Map<string, number>();
+
+    const candidates = enumerateSameSupplyCorridorCandidates(rows, 2, carriedCount);
+
+    expect(candidates.length).toBeGreaterThan(0);
+    // Find a candidate that has two pickups at Oslo and delivers to both cities
+    const corridorCandidate = candidates.find(c =>
+      c.stops.filter(s => s.action === 'pickup' && s.city === 'Oslo').length === 2 &&
+      c.stops.some(s => s.action === 'deliver' && s.city === 'Zurich') &&
+      c.stops.some(s => s.action === 'deliver' && s.city === 'Milano'),
+    );
+    expect(corridorCandidate).toBeDefined();
+    expect(corridorCandidate!.id).toContain('corridor:');
+  });
+
+  it('does not generate corridor candidates when only one demand shares the supply city', () => {
+    const rows: Row[] = [
+      makeRow({ loadType: 'Fish', supplyCity: 'Oslo', deliveryCity: 'Zurich', cardIndex: 1, payout: 20, isCarry: false }),
+      makeRow({ loadType: 'Fish', supplyCity: 'Bergen', deliveryCity: 'Milano', cardIndex: 2, payout: 18, isCarry: false }),
+    ];
+    const carriedCount = new Map<string, number>();
+
+    const candidates = enumerateSameSupplyCorridorCandidates(rows, 2, carriedCount);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('does not generate corridor candidates when capacity would be exceeded', () => {
+    // Bot already carries 2 Fish, cap=2 → can't pick up 2 more
+    const rows: Row[] = [
+      makeRow({ loadType: 'Fish', supplyCity: 'Oslo', deliveryCity: 'Zurich', cardIndex: 1, payout: 20, isCarry: false }),
+      makeRow({ loadType: 'Fish', supplyCity: 'Oslo', deliveryCity: 'Milano', cardIndex: 2, payout: 18, isCarry: false }),
+    ];
+    const carriedCount = new Map<string, number>([['Fish', 2]]);
+
+    const candidates = enumerateSameSupplyCorridorCandidates(rows, 2, carriedCount);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it('skips carry rows (isCarry=true) for corridor grouping', () => {
+    const rows: Row[] = [
+      makeRow({ loadType: 'Fish', supplyCity: null, deliveryCity: 'Zurich', cardIndex: 1, payout: 20, isCarry: true }),
+      makeRow({ loadType: 'Fish', supplyCity: 'Oslo', deliveryCity: 'Milano', cardIndex: 2, payout: 18, isCarry: false }),
+    ];
+    const carriedCount = new Map<string, number>();
+
+    const candidates = enumerateSameSupplyCorridorCandidates(rows, 2, carriedCount);
+    expect(candidates).toHaveLength(0);
+  });
+});
+
+describe('JIRA-249/250: Rejection logging in planTripDeterministic', () => {
+  /**
+   * UT5 (Rejection Logging): When a survivor candidate is grammatically invalid,
+   * planTripDeterministic should populate candidateRejections with a structured record.
+   *
+   * We cannot easily inject a malformed candidate into the pipeline via normal row
+   * setup (the generators produce valid grammar). Instead we verify the field exists
+   * and is undefined when no rejections occur (the happy path — field absent).
+   * A direct grammar-rejection scenario is tested via isCandidateGrammaticallyValid.
+   */
+  it('UT5: candidateRejections is absent (undefined) when all survivors pass grammar', () => {
+    mockSimulateTrip.mockReturnValue({ turnsToComplete: 2, totalBuildCost: 5, feasible: true, minCashRelative: 0, finalCashRelative: 0, builtSegments: [] });
+    mockEstimateGraphPathCost.mockReturnValue({ reachable: true, buildCost: 5, estimatedTurns: 2, pathLength: 20 });
+
+    const demands = [
+      makeDemand({ cardIndex: 1, loadType: 'Coal', deliveryCity: 'Berlin', payout: 15 }),
+    ];
+    const snapshot = makeSnapshot();
+    const context = makeContext(demands);
+    const memory = makeMemory();
+
+    const result = planTripDeterministic(snapshot, context, memory);
+
+    expect(result.outcome).toBe('success');
+    // No malformed candidates in normal flow → rejections absent
+    expect(result.candidateRejections).toBeUndefined();
+  });
+});
+
+describe('JIRA-249/250: enumerateCandidates includes carry floor and corridor candidates', () => {
+  it('UT5: enumerateCandidates includes carry-floor candidate when bot carries Labor', () => {
+    const rows: Row[] = [
+      makeRow({ loadType: 'Labor', deliveryCity: 'Bern', cardIndex: 1, payout: 12, isCarry: true, supplyCity: null }),
+      makeRow({ loadType: 'Coal', deliveryCity: 'Berlin', cardIndex: 2, payout: 15, isCarry: false }),
+    ];
+
+    const candidates = enumerateCandidates(rows, 2);
+
+    // Should have a carry-floor candidate
+    const floorCandidates = candidates.filter(c => c.id.startsWith('carry-floor:'));
+    expect(floorCandidates).toHaveLength(1);
+    expect(floorCandidates[0].stops[0]).toMatchObject({ action: 'deliver', loadType: 'Labor', city: 'Bern' });
+  });
+
+  it('UT5b: enumerateCandidates includes corridor candidates for same-supply, same-load pair', () => {
+    const rows: Row[] = [
+      makeRow({ loadType: 'Fish', supplyCity: 'Oslo', deliveryCity: 'Zurich', cardIndex: 1, payout: 20, isCarry: false }),
+      makeRow({ loadType: 'Fish', supplyCity: 'Oslo', deliveryCity: 'Milano', cardIndex: 2, payout: 18, isCarry: false }),
+    ];
+
+    const candidates = enumerateCandidates(rows, 2);
+
+    const corridorCandidates = candidates.filter(c => c.id.startsWith('corridor:'));
+    expect(corridorCandidates.length).toBeGreaterThan(0);
   });
 });

--- a/src/server/__tests__/ai/MovementPhasePlanner.test.ts
+++ b/src/server/__tests__/ai/MovementPhasePlanner.test.ts
@@ -426,6 +426,7 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
     });
     const context = makeContext({
       position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'], // JIRA-249 L3: guard requires load present before deliver
     });
 
     mockExecuteStopAction.mockResolvedValue({
@@ -463,6 +464,7 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
     });
     const context = makeContext({
       position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'], // JIRA-249 L3: guard requires load present before deliver
     });
 
     mockExecuteStopAction.mockResolvedValue({
@@ -526,6 +528,7 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
       position: { row: 1, col: 1, city: 'Paris' },
       citiesOnNetwork: ['Berlin'],
       speed: 9,
+      loads: ['Wine'], // JIRA-249 L3: guard requires load present before deliver
     });
     const snapshot = makeSnapshot();
 
@@ -678,6 +681,7 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
       position: { row: 1, col: 1, city: 'Paris' },
       citiesOnNetwork: ['Berlin', 'Wien'],
       speed: 9,
+      loads: ['Wine'], // JIRA-249 L3: guard requires load present before deliver
     });
     const snapshot = makeSnapshot();
 
@@ -809,6 +813,7 @@ describe('MovementPhasePlanner.run — PhaseAResult fields', () => {
     });
     const context = makeContext({
       position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'], // JIRA-249 L3: guard requires load present before deliver
     });
 
     mockExecuteStopAction.mockResolvedValue({
@@ -868,6 +873,7 @@ describe('JIRA-202: arrival on last milepost executes stop action', () => {
       position: { row: 1, col: 1, city: 'Paris' },
       citiesOnNetwork: ['Berlin'],
       speed: 9,
+      loads: ['Wine'], // JIRA-249 L3: guard requires load present before deliver
     });
     const snapshot = makeSnapshot();
 
@@ -1935,6 +1941,98 @@ describe('JIRA-244 AC3: A3 empty-result — a3_target_already_reachable via paid
     // Secondary assertion: MovementPhasePlanner did NOT produce a PassTurn plan
     // (PassTurn is only added by TurnExecutorPlanner from an empty accumulatedPlans;
     // what we verify here is that A3 did not emit it from this branch)
+    expect(result.accumulatedPlans.some(p => p.type === AIActionType.PassTurn)).toBe(false);
+  });
+});
+
+// ── JIRA-249 Layer 3: Runtime arrival guard ───────────────────────────────────
+
+describe('JIRA-249 Layer 3: MovementPhasePlanner runtime arrival guard', () => {
+  /**
+   * UT1: Bot arrives at Praha with route.next = deliver(Wine@Praha) but bot.loads
+   * does NOT contain 'Wine'. Guard should fire: return with terminationReason
+   * 'arrived_for_deliver_but_load_not_carried' and NOT call executeStopAction.
+   */
+  it('UT1: guard fires when arrived at deliver city but load is not in context.loads', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    const route = makeRoute({
+      stops: [{ action: 'deliver', city: 'Praha', loadType: 'Wine', demandCardId: 1, payment: 20 }],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Praha' },
+      loads: [], // Wine NOT in loads — guard should fire
+    });
+
+    const trace = makeTrace();
+    const result = await MovementPhasePlanner.run(route, makeSnapshot(), context, trace);
+
+    // Guard fired: terminationReason set
+    expect(trace.a2.terminationReason).toBe('arrived_for_deliver_but_load_not_carried');
+    // executeStopAction was NOT called (guard intercepted before it)
+    expect(mockExecuteStopAction).not.toHaveBeenCalled();
+    // No delivery recorded
+    expect(result.hasDelivery).toBe(false);
+    // No PassTurn emitted
+    expect(result.accumulatedPlans.some(p => p.type === AIActionType.PassTurn)).toBe(false);
+  });
+
+  /**
+   * UT2: Bot arrives at Praha with route.next = deliver(Wine@Praha) and bot.loads
+   * DOES contain 'Wine'. Guard should NOT fire — normal delivery proceeds.
+   */
+  it('UT2: guard does NOT fire when load is present in context.loads', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    const route = makeRoute({
+      stops: [{ action: 'deliver', city: 'Praha', loadType: 'Wine', demandCardId: 1, payment: 20 }],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Praha' },
+      loads: ['Wine'], // Wine IS in loads — guard should not fire
+    });
+
+    mockExecuteStopAction.mockResolvedValue({
+      success: true,
+      plan: { type: AIActionType.DeliverLoad, load: 'Wine', city: 'Praha' },
+    });
+
+    mockPostDeliveryReplan.mockResolvedValue({
+      route: makeRoute({ stops: [], currentStopIndex: 0 }),
+      moveTargetInvalidated: true,
+    });
+
+    const trace = makeTrace();
+    await MovementPhasePlanner.run(route, makeSnapshot(), context, trace);
+
+    // Guard did NOT fire: terminationReason is not the guard reason
+    expect(trace.a2.terminationReason).not.toBe('arrived_for_deliver_but_load_not_carried');
+    // executeStopAction WAS called — normal delivery flow
+    expect(mockExecuteStopAction).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * UT3: Guard fires (load missing) → no PassTurn emitted. The result's
+   * accumulatedPlans should not contain a PassTurn action.
+   */
+  it('UT3: PassTurn is not emitted when arrival guard triggers a skip', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    const route = makeRoute({
+      stops: [{ action: 'deliver', city: 'Berlin', loadType: 'Coal', demandCardId: 2, payment: 15 }],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Berlin' },
+      loads: [], // Coal NOT in loads
+    });
+
+    const trace = makeTrace();
+    const result = await MovementPhasePlanner.run(route, makeSnapshot(), context, trace);
+
+    expect(trace.a2.terminationReason).toBe('arrived_for_deliver_but_load_not_carried');
     expect(result.accumulatedPlans.some(p => p.type === AIActionType.PassTurn)).toBe(false);
   });
 });

--- a/src/server/__tests__/ai/TripPlanner.test.ts
+++ b/src/server/__tests__/ai/TripPlanner.test.ts
@@ -2929,6 +2929,124 @@ describe('JIRA-207B: TripPlanner pre-LLM short-circuit (R10c)', () => {
   });
 });
 
+// ── JIRA-248 Layer 2: Affordability gate bypass for carried-load demands ──────
+
+describe('JIRA-248 Layer 2: TripPlanner affordability gate bypass for carried-load demands', () => {
+  let RouteValidatorMock: jest.MockedObject<typeof import('../../services/ai/RouteValidator').RouteValidator>;
+
+  beforeAll(() => {
+    RouteValidatorMock = jest.requireMock('../../services/ai/RouteValidator').RouteValidator;
+    RouteValidatorMock.validate.mockReturnValue({ valid: true, errors: [] });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    RouteValidatorMock.validate.mockReturnValue({ valid: true, errors: [] });
+  });
+
+  /**
+   * UT1: bot has low money → all fresh demands are isAffordable=false.
+   * One carried-load demand has isLoadOnTrain=true && isDeliveryReachable=true.
+   * Expected: actionableDemands is NOT empty — carried-load demand bypasses gate.
+   * The planner should NOT return no_actionable_options.
+   */
+  it('UT1: unaffordable fresh demands + carried-load demand → carried-load bypasses gate (not no_actionable_options)', async () => {
+    const { brain, chatFn } = makeMockBrain();
+
+    const context = makeContext({
+      loads: ['Fish'],
+      demands: [
+        // Carried load — not affordable (high track cost) but isLoadOnTrain=true
+        makeDemand({
+          cardIndex: 1, loadType: 'Fish', supplyCity: null, deliveryCity: 'Zurich',
+          payout: 20, isAffordable: false, isLoadOnTrain: true, isDeliveryReachable: true,
+        }),
+        // Fresh demand — also not affordable
+        makeDemand({
+          cardIndex: 2, loadType: 'Coal', supplyCity: 'Essen', deliveryCity: 'Berlin',
+          payout: 15, isAffordable: false, isLoadOnTrain: false, isDeliveryReachable: true,
+        }),
+      ],
+    });
+
+    const memory = makeMemory({ activeRoute: null });
+    const planner = new TripPlanner(brain);
+    const result = await planner.planTrip(makeSnapshot(), context, [], memory);
+
+    // Must NOT return no_actionable_options — carried-load bypasses gate
+    expect(result.selection?.fallbackReason).not.toBe('no_actionable_options');
+    // LLM not called (single-option short-circuit fires for the one actionable carried-load demand)
+    expect(chatFn).not.toHaveBeenCalled();
+    // A route should be returned (single_option_shortcircuit)
+    expect(result.selection?.fallbackReason).toBe('single_option_shortcircuit');
+  });
+
+  /**
+   * UT2: no carried loads, all fresh demands are isAffordable=false.
+   * Expected: no_actionable_options (existing behavior preserved).
+   */
+  it('UT2: no carried loads + all fresh demands unaffordable → no_actionable_options (existing behavior preserved)', async () => {
+    const { brain, chatFn } = makeMockBrain();
+
+    const context = makeContext({
+      loads: [],
+      demands: [
+        makeDemand({ cardIndex: 1, loadType: 'Coal', supplyCity: 'Essen', deliveryCity: 'Berlin', payout: 15, isAffordable: false, isLoadOnTrain: false }),
+        makeDemand({ cardIndex: 2, loadType: 'Wine', supplyCity: 'Bordeaux', deliveryCity: 'Paris', payout: 12, isAffordable: false, isLoadOnTrain: false }),
+      ],
+    });
+
+    const memory = makeMemory({ activeRoute: null });
+    const planner = new TripPlanner(brain);
+    const result = await planner.planTrip(makeSnapshot(), context, [], memory);
+
+    expect(result.selection?.fallbackReason).toBe('no_actionable_options');
+    expect(chatFn).not.toHaveBeenCalled();
+  });
+
+  /**
+   * UT3: both affordable fresh demands AND carried-load demands are present.
+   * Expected: actionableDemands contains both → LLM is called (≥2 actionable).
+   */
+  it('UT3: affordable fresh demand + carried-load demand → both in actionable set, LLM called', async () => {
+    const { brain, chatFn } = makeMockBrain();
+
+    const llmResponse = buildLlmResponse([
+      {
+        stops: [
+          { action: 'deliver', load: 'Fish', city: 'Zurich', demandCardId: 1, payment: 20 },
+        ],
+        reasoning: 'deliver carried Fish',
+      },
+    ], 0);
+    chatFn.mockResolvedValue({ text: llmResponse, usage: { input: 50, output: 30 } });
+
+    const context = makeContext({
+      loads: ['Fish'],
+      demands: [
+        // Carried load demand
+        makeDemand({
+          cardIndex: 1, loadType: 'Fish', supplyCity: null, deliveryCity: 'Zurich',
+          payout: 20, isAffordable: false, isLoadOnTrain: true, isDeliveryReachable: true,
+        }),
+        // Affordable fresh demand
+        makeDemand({
+          cardIndex: 2, loadType: 'Coal', supplyCity: 'Essen', deliveryCity: 'Berlin',
+          payout: 15, isAffordable: true, isLoadOnTrain: false, isDeliveryReachable: true,
+        }),
+      ],
+    });
+
+    const memory = makeMemory({ activeRoute: null });
+    const planner = new TripPlanner(brain);
+    const result = await planner.planTrip(makeSnapshot(), context, [], memory);
+
+    // With 2 actionable demands (1 carried + 1 affordable), LLM is called
+    expect(chatFn).toHaveBeenCalledTimes(1);
+    expect(result.route).not.toBeNull();
+  });
+});
+
 // ── TEST-002: Game 5302ee21 reproduction tests (AC22, AC23) ─────────────────
 
 describe('JIRA-207B: Game 5302ee21 reproduction tests (TEST-002)', () => {

--- a/src/server/__tests__/ai/TurnExecutorPlanner.test.ts
+++ b/src/server/__tests__/ai/TurnExecutorPlanner.test.ts
@@ -735,7 +735,7 @@ describe('TurnExecutorPlanner.execute — delivery at current city', () => {
       stops: [makeStop('deliver', 'Berlin', 'Coal')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
 
     const result = await TurnExecutorPlanner.execute(route, snapshot, context);
@@ -760,7 +760,7 @@ describe('TurnExecutorPlanner.execute — delivery at current city', () => {
       stops: [makeStop('deliver', 'Berlin', 'Coal')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
 
     const result = await TurnExecutorPlanner.execute(route, snapshot, context);
@@ -782,7 +782,7 @@ describe('TurnExecutorPlanner.execute — delivery at current city', () => {
       stops: [makeStop('deliver', 'Berlin', 'Coal')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
 
     const result = await TurnExecutorPlanner.execute(route, snapshot, context);
@@ -1358,7 +1358,7 @@ describe('TurnExecutorPlanner.execute — post-delivery replan', () => {
       stops: [makeStop('deliver', 'Berlin', 'Coal')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
     const fakeBrain = {} as any;
     const fakeGridPoints = [{ row: 1, col: 1, name: 'TestCity' }] as any;
@@ -1391,7 +1391,7 @@ describe('TurnExecutorPlanner.execute — post-delivery replan', () => {
       stops: [makeStop('deliver', 'Berlin', 'Coal')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
     const fakeBrain = {} as any;
     const fakeGridPoints = [{ row: 1, col: 1, name: 'TestCity' }] as any;
@@ -1419,7 +1419,7 @@ describe('TurnExecutorPlanner.execute — post-delivery replan', () => {
       stops: [makeStop('deliver', 'Berlin', 'Coal')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
     const fakeBrain = {} as any;
     const fakeGridPoints = [{ row: 1, col: 1, name: 'TestCity' }] as any;
@@ -1446,7 +1446,7 @@ describe('TurnExecutorPlanner.execute — post-delivery replan', () => {
       stops: [makeStop('deliver', 'Berlin', 'Coal')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
 
     // No brain passed → no TripPlanner
@@ -1495,6 +1495,7 @@ describe('TurnExecutorPlanner.execute — post-delivery replan', () => {
     // context.demands includes the Beer→Beograd demand that is about to be fulfilled
     const context = makeContext({
       position: { city: 'Beograd', row: 3, col: 3 },
+      loads: ['Beer'], // JIRA-249 L3: guard requires load present before deliver
       demands: [
         {
           cardIndex: 0,
@@ -1621,7 +1622,7 @@ describe('TurnExecutorPlanner.execute — post-delivery replan', () => {
       stops: [{ action: 'deliver', city: 'Beograd', loadType: 'Beer', demandCardId: 10 }],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Beograd', row: 3, col: 3 } });
+    const context = makeContext({ position: { city: 'Beograd', row: 3, col: 3 }, loads: ['Beer'] }); // JIRA-249 L3
     const snapshot = {
       ...makeSnapshot(),
       bot: {
@@ -1803,7 +1804,7 @@ describe('TurnExecutorPlanner.execute — JIRA-194 reset move target after post-
       stops: [makeStop('deliver', 'Berlin', 'Coal'), makeStop('pickup', 'Paris', 'Wine')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
     const fakeBrain = {} as any;
     const fakeGridPoints = [] as any;
@@ -1836,7 +1837,7 @@ describe('TurnExecutorPlanner.execute — JIRA-194 reset move target after post-
       stops: [makeStop('deliver', 'Berlin', 'Coal'), makeStop('pickup', 'Paris', 'Wine')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
     const fakeBrain = {} as any;
     const fakeGridPoints = [] as any;
@@ -1866,7 +1867,7 @@ describe('TurnExecutorPlanner.execute — JIRA-194 reset move target after post-
       stops: [makeStop('deliver', 'Berlin', 'Coal'), makeStop('pickup', 'Paris', 'Wine')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 } });
+    const context = makeContext({ position: { city: 'Berlin', row: 2, col: 2 }, loads: ['Coal'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
 
     // No brain → no TripPlanner → no-brain branch
@@ -3874,7 +3875,7 @@ describe('TurnExecutorPlanner.execute — JIRA-185 post-delivery context sync', 
       stops: [makeStop('deliver', 'Paris', 'Wine')],
       currentStopIndex: 0,
     });
-    const context = makeContext({ position: { city: 'Paris', row: 1, col: 1 }, money: 100 });
+    const context = makeContext({ position: { city: 'Paris', row: 1, col: 1 }, money: 100, loads: ['Wine'] }); // JIRA-249 L3
     const snapshot = makeSnapshot();
     const fakeBrain = {} as any;
     const fakeGridPoints = [{ row: 1, col: 1, name: 'TestCity' }] as any;

--- a/src/server/__tests__/ai/integration/test_jira156_e2e.test.ts
+++ b/src/server/__tests__/ai/integration/test_jira156_e2e.test.ts
@@ -610,6 +610,7 @@ describe('JIRA-156 mid-turn replan: delivery triggers TripPlanner + RouteEnrichm
     const context = makeContext({
       position: { city: 'Berlin', row: 2, col: 2 },
       citiesOnNetwork: ['Berlin', 'Lyon', 'Madrid'],
+      loads: ['Coal'], // JIRA-249 L3: guard requires load present before deliver
     });
     const snapshot = makeSnapshot({ botCity: 'Berlin', botRow: 2, botCol: 2 });
 

--- a/src/server/services/ai/DeterministicTripPlanner.ts
+++ b/src/server/services/ai/DeterministicTripPlanner.ts
@@ -126,6 +126,8 @@ export interface DeterministicTripPlanResult {
   reasoning: string;
   outcome: 'success' | 'no_feasible_candidates';
   synthesizedAttempt: LlmAttempt;
+  /** JIRA-249/250: Structured records of candidates rejected by the grammar validator. */
+  candidateRejections?: CandidateRejection[];
 }
 
 // ── Internal types ─────────────────────────────────────────────────────
@@ -183,6 +185,30 @@ interface ScoredCandidate extends Candidate {
 interface GridCoord {
   row: number;
   col: number;
+}
+
+// ── Candidate grammar validation types (JIRA-249 Layer 2 / JIRA-250 Layer 3) ──
+
+/**
+ * Reasons a candidate route may fail grammar validation.
+ *
+ * - `deliver_without_pickup`: a deliver stop has no prior pickup and the load
+ *   is not in the bot's carried loads at trip start.
+ * - `deliver_exceeds_carried`: a deliver(L) would consume more L than the bot
+ *   has available (carried + picked up so far in the candidate).
+ */
+export type CandidateRejectionReason = 'deliver_without_pickup' | 'deliver_exceeds_carried';
+
+/** Structured record of a single grammar-rule violation for a rejected candidate. */
+export interface CandidateRejection {
+  candidateId: string;
+  reason: CandidateRejectionReason;
+  offendingStopIndex: number;
+  loadType: string;
+  context: {
+    carriedAtStart: string[];
+    pickupsBeforeOffender: string[];
+  };
 }
 
 interface ResolvedOptions {
@@ -679,6 +705,187 @@ const EMPTY_SNAPSHOT: WorldSnapshot = {
   loadAvailability: {},
 };
 
+// ── Grammar validation (JIRA-249 Layer 2 / JIRA-250 Layer 3) ──────────
+
+/**
+ * Validate a candidate's stop sequence against the action grammar rules.
+ *
+ * Each `deliver(L)` stop MUST be preceded by either:
+ *   a) a `pickup(L)` earlier in the same candidate, OR
+ *   b) L present in `carriedAtStart` (bot already carries it at trip start).
+ *
+ * Multiplicity is enforced: each `deliver(L)` consumes one unit from the
+ * running pool (carriedAtStart + pickupsSoFar), so two `deliver(Fish)` stops
+ * require either two Fish in the pool or one carried + one picked up.
+ *
+ * Returns `{ ok: true }` when the candidate is valid.
+ * Returns `{ ok: false, ... }` with structured rejection details when invalid.
+ */
+export function isCandidateGrammaticallyValid(
+  candidate: Candidate,
+  carriedAtStart: string[],
+): { ok: true } | { ok: false; rejection: CandidateRejection } {
+  // Build a mutable count map from carriedAtStart (supports duplicates).
+  const available = new Map<string, number>();
+  for (const load of carriedAtStart) {
+    available.set(load, (available.get(load) ?? 0) + 1);
+  }
+
+  const pickupsBeforeOffender: string[] = [];
+
+  for (let i = 0; i < candidate.stops.length; i++) {
+    const stop = candidate.stops[i];
+    if (stop.action === 'pickup') {
+      // Pickups add to the available pool.
+      available.set(stop.loadType, (available.get(stop.loadType) ?? 0) + 1);
+      pickupsBeforeOffender.push(stop.loadType);
+    } else if (stop.action === 'deliver') {
+      const count = available.get(stop.loadType) ?? 0;
+      if (count <= 0) {
+        // No unit available: either never picked up and not carried, or already consumed.
+        const hadInitialCarry = carriedAtStart.includes(stop.loadType);
+        const hadPickup = candidate.stops.slice(0, i).some(
+          s => s.action === 'pickup' && s.loadType === stop.loadType,
+        );
+        const reason: CandidateRejectionReason = hadInitialCarry || hadPickup
+          ? 'deliver_exceeds_carried'
+          : 'deliver_without_pickup';
+        return {
+          ok: false,
+          rejection: {
+            candidateId: candidate.id,
+            reason,
+            offendingStopIndex: i,
+            loadType: stop.loadType,
+            context: {
+              carriedAtStart: [...carriedAtStart],
+              pickupsBeforeOffender: [...pickupsBeforeOffender],
+            },
+          },
+        };
+      }
+      // Consume one unit.
+      available.set(stop.loadType, count - 1);
+    }
+  }
+
+  return { ok: true };
+}
+
+// ── Carried delivery floor (JIRA-248 Layer 1) ─────────────────────────
+
+/**
+ * Generate a base candidate that delivers ALL currently-carried loads that have
+ * a reachable delivery demand. This is the "floor" of the candidate space —
+ * the bot should always be able to deliver what it's already carrying.
+ *
+ * Returns null when no carried demands are deliverable.
+ */
+export function enumerateCarriedDeliveryFloor(
+  rows: NormalizedDemandRow[],
+): Candidate | null {
+  const carryRows = rows.filter(r => r.isCarry);
+  if (carryRows.length === 0) return null;
+
+  const stops: RouteStop[] = carryRows.map(r => ({
+    action: 'deliver',
+    loadType: r.loadType,
+    city: r.deliveryCity,
+    demandCardId: r.cardIndex,
+    payment: r.payout,
+  }));
+
+  const payout = carryRows.reduce((sum, r) => sum + r.payout, 0);
+  const idParts = carryRows.map(r => `${r.cardIndex}:${r.loadType}`).join('+');
+
+  return {
+    id: `carry-floor:${idParts}`,
+    rows: carryRows,
+    stops,
+    payout,
+  };
+}
+
+// ── Same-supply corridor enumeration (JIRA-250 Layer 2) ───────────────
+
+/**
+ * Generate corridor candidates for groups of demands where:
+ *   - Same `loadType` AND same `supplyCity`
+ *   - Group size ≥ 2
+ *   - `supplyCity !== null` (not a carry — fresh pickup)
+ *   - Picking up (groupSize) units fits within available capacity
+ *
+ * Emits one candidate per group: `[pickup(L@supply), ..., deliver(L@city1), deliver(L@city2), ...]`
+ * The number of pickup stops equals the number of demands in the group (one per unit).
+ * Delivery order is the same as demand array order (network-distance ordering is
+ * applied by the downstream spatial prune / simulator).
+ *
+ * Note: Currently handles exactly 2-demand groups (the observed JIRA-250 case).
+ * N-way (3+) corridor optimization is deferred per the spec ("Not in scope").
+ */
+export function enumerateSameSupplyCorridorCandidates(
+  rows: NormalizedDemandRow[],
+  cap: number,
+  carriedCount: Map<string, number>,
+): Candidate[] {
+  // Group non-carry rows by (loadType, supplyCity).
+  const groups = new Map<string, NormalizedDemandRow[]>();
+  for (const row of rows) {
+    if (row.isCarry || row.supplyCity === null) continue;
+    const key = `${row.loadType}|${row.supplyCity}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(row);
+  }
+
+  const candidates: Candidate[] = [];
+
+  for (const [key, groupRows] of groups) {
+    if (groupRows.length < 2) continue;
+
+    const { loadType, supplyCity } = groupRows[0];
+    if (supplyCity === null) continue;
+
+    // Check capacity: carried of this type + groupSize must not exceed cap.
+    const alreadyCarried = carriedCount.get(loadType) ?? 0;
+    if (alreadyCarried + groupRows.length > cap) continue;
+
+    // Only handle pairs for now (N-way deferred).
+    const pairs = groupRows.slice(0, 2);
+    const [a, b] = pairs;
+
+    // Stops: one pickup per unit, then deliver in demand order.
+    const pickupStop: RouteStop = { action: 'pickup', loadType, city: supplyCity };
+    const deliverA: RouteStop = {
+      action: 'deliver', loadType, city: a.deliveryCity,
+      demandCardId: a.cardIndex, payment: a.payout,
+    };
+    const deliverB: RouteStop = {
+      action: 'deliver', loadType, city: b.deliveryCity,
+      demandCardId: b.cardIndex, payment: b.payout,
+    };
+
+    // Two pickup stops (one per load unit) + two deliver stops.
+    const stopsAB: RouteStop[] = [pickupStop, pickupStop, deliverA, deliverB];
+    const stopsBA: RouteStop[] = [pickupStop, pickupStop, deliverB, deliverA];
+    const supSuffix = `-sup:${supplyCity}`;
+
+    candidates.push({
+      id: `corridor:${a.cardIndex}-${loadType}+${b.cardIndex}-${loadType}:AB${supSuffix}`,
+      rows: pairs,
+      stops: stopsAB,
+      payout: a.payout + b.payout,
+    });
+    candidates.push({
+      id: `corridor:${a.cardIndex}-${loadType}+${b.cardIndex}-${loadType}:BA${supSuffix}`,
+      rows: pairs,
+      stops: stopsBA,
+      payout: a.payout + b.payout,
+    });
+  }
+
+  return candidates;
+}
+
 /**
  * Enumerate all single, pair, and triple demand-fulfillment candidates.
  * JIRA-230 BE-002: supply-aware — one candidate per (route shape × supply choice).
@@ -694,11 +901,32 @@ export function enumerateCandidates(
 ): Candidate[] {
   const snap = snapshot ?? EMPTY_SNAPSHOT;
   const spd = speed ?? 9;
-  return [
+
+  const base = [
     ...genSingles(rows, snap, spd),
     ...genPairs(rows, cap, snap, spd),
     ...genTriples(rows, cap, snap, spd),
   ];
+
+  // JIRA-248 Layer 1: Ensure the "carried delivery floor" candidate is always
+  // present so the planner cannot drop a carried-load delivery.
+  const floor = enumerateCarriedDeliveryFloor(rows);
+  if (floor !== null) {
+    base.push(floor);
+  }
+
+  // JIRA-250 Layer 2: Emit corridor candidates for same-supply, same-load
+  // demand groups (two pickups at same city for different deliveries).
+  const carriedCount = new Map<string, number>();
+  for (const row of rows) {
+    if (row.isCarry) {
+      carriedCount.set(row.loadType, (carriedCount.get(row.loadType) ?? 0) + 1);
+    }
+  }
+  const corridorCandidates = enumerateSameSupplyCorridorCandidates(rows, cap, carriedCount);
+  base.push(...corridorCandidates);
+
+  return base;
 }
 
 // ── Spatial prune (R5) ─────────────────────────────────────────────────
@@ -1484,9 +1712,27 @@ export function planTripDeterministic(
     };
   }
 
-  // Simulate survivors (R6)
+  // Simulate survivors (R6), with grammar validation gate (JIRA-249 L2 / JIRA-250 L3)
+  // Build carriedAtStart from the authoritative `carried` map (which merges all
+  // carry-detection signals) rather than raw snapshot.bot.loads — the latter may
+  // be missing isLoadOnTrain-flagged loads in legacy/test contexts.
+  const carriedAtStart: string[] = [];
+  for (const [loadType, count] of carried) {
+    for (let i = 0; i < count; i++) carriedAtStart.push(loadType);
+  }
+  const candidateRejections: CandidateRejection[] = [];
   const feasible: ScoredCandidate[] = [];
   for (const cand of survivors) {
+    const grammarCheck = isCandidateGrammaticallyValid(cand, carriedAtStart);
+    if (!grammarCheck.ok) {
+      // Log structured rejection to candidateRejections for diagnostics.
+      candidateRejections.push(grammarCheck.rejection);
+      console.warn(
+        `[DeterministicTripPlanner] Grammar violation — rejecting candidate id=${cand.id} ` +
+        `reason=${grammarCheck.rejection.reason} load=${grammarCheck.rejection.loadType}`,
+      );
+      continue;
+    }
     const scored = scoreCandidate(cand, startPos, snapshot, opts, undefined, memory);
     if (scored.feasible) feasible.push(scored);
   }
@@ -1503,6 +1749,7 @@ export function planTripDeterministic(
       reasoning,
       outcome: 'no_feasible_candidates',
       synthesizedAttempt: synthesizeLlmAttempt(null, latencyMs),
+      candidateRejections: candidateRejections.length > 0 ? candidateRejections : undefined,
     };
   }
 
@@ -1598,5 +1845,6 @@ export function planTripDeterministic(
     reasoning,
     outcome: 'success',
     synthesizedAttempt: synthesizeLlmAttempt(top1, latencyMs),
+    candidateRejections: candidateRejections.length > 0 ? candidateRejections : undefined,
   };
 }

--- a/src/server/services/ai/MovementPhasePlanner.ts
+++ b/src/server/services/ai/MovementPhasePlanner.ts
@@ -179,6 +179,31 @@ export class MovementPhasePlanner {
           }
         }
 
+        // JIRA-249 Layer 3: Runtime arrival guard — verify load is present before deliver.
+        // If the bot arrived at a delivery city but the load is not in context.loads,
+        // the route is stale/malformed. Abandon the current stop and trigger a replan
+        // rather than emitting PassTurn or a failed deliver action.
+        if (
+          currentStop.action === 'deliver' &&
+          !context.loads.includes(currentStop.loadType)
+        ) {
+          console.warn(
+            `${tag} arrived_for_deliver_but_load_not_carried: ` +
+            `loadType=${currentStop.loadType} city=${targetCity} ` +
+            `context.loads=[${context.loads.join(',')}] — abandoning stop, triggering replan.`,
+          );
+          trace.a2.terminationReason = 'arrived_for_deliver_but_load_not_carried';
+          trace.outputPlan = plans.map(p => p.type);
+          // Advance past the malformed stop so the route does not loop on it.
+          activeRoute = { ...activeRoute, currentStopIndex: activeRoute.currentStopIndex + 1 };
+          return MovementPhasePlanner.makeResult(
+            activeRoute, plans, hasDelivery, lastMoveTargetCity, deliveriesThisTurn,
+            snapshot, context, false, false,
+            replanLlmLog, replanSystemPrompt, replanUserPrompt,
+            pendingUpgradeAction, upgradeSuppressionReason,
+          );
+        }
+
         const _stopActionStart = Date.now();
         const actionResult = await TurnExecutorPlanner.executeStopAction(
           currentStop,

--- a/src/server/services/ai/TripPlanner.ts
+++ b/src/server/services/ai/TripPlanner.ts
@@ -150,7 +150,15 @@ export class TripPlanner {
       const hasRemainingStops = activeRoute != null && activeRoute.currentStopIndex < activeRoute.stops.length;
       // A carry-load demand is only a "commitment" when an active route is already delivering it.
       // Without a route, the carry-load is an undischarged obligation that needs a fresh plan.
-      const actionableDemands = context.demands.filter(d => d.isAffordable && (!d.isLoadOnTrain || !hasRemainingStops));
+      //
+      // JIRA-248 Layer 2: Carried-load demands (isLoadOnTrain && isDeliveryReachable) require no
+      // track spend — they must bypass the affordability gate to prevent the planner from
+      // short-circuiting to DiscardHand when the bot is one move from delivering a load it carries.
+      const isDeliverableCarriedLoad = (d: typeof context.demands[0]) =>
+        d.isLoadOnTrain && d.isDeliveryReachable && !hasRemainingStops;
+      const actionableDemands = context.demands.filter(
+        d => isDeliverableCarriedLoad(d) || (d.isAffordable && (!d.isLoadOnTrain || !hasRemainingStops)),
+      );
       const hasNewOptions = actionableDemands.length > 0;
       if (!hasNewOptions) {
         const hasCarriedLoads = context.loads.length > 0;

--- a/src/server/services/ai/TurnExecutorPlanner.ts
+++ b/src/server/services/ai/TurnExecutorPlanner.ts
@@ -117,6 +117,12 @@ export interface CompositionTrace {
     stopActionMs: number;
     stopActionCount: number;
   };
+  /**
+   * JIRA-249/250: Structured records of candidates rejected by the grammar
+   * validator (isCandidateGrammaticallyValid) before scoring. Optional —
+   * only populated when the deterministic planner is active and rejections occur.
+   */
+  candidateRejections?: import('./DeterministicTripPlanner').CandidateRejection[];
   /** JIRA-179: Build Route Resolver candidate comparison — only present when ENABLE_BUILD_RESOLVER=true */
   buildResolver?: {
     enabled: true;

--- a/src/server/services/ai/context/DemandEngine.ts
+++ b/src/server/services/ai/context/DemandEngine.ts
@@ -791,6 +791,18 @@ export function computeBestDemandContext(
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
+/**
+ * Build a count map of how many times each loadType appears in bot.loads.
+ * Used by computeAllDemandContexts to track multiplicity-aware carry assignment.
+ */
+function buildCarriedLoadCounts(loads: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const load of loads) {
+    counts.set(load, (counts.get(load) ?? 0) + 1);
+  }
+  return counts;
+}
+
 export function computeAllDemandContexts(
   snapshot: WorldSnapshot,
   network: ReturnType<typeof buildTrackNetwork> | null,
@@ -800,12 +812,42 @@ export function computeAllDemandContexts(
   connectedMajorCities: string[],
   saturatedCityKeys?: Set<string>,
 ): DemandContext[] {
+  // Track remaining carried-load "slots" per loadType. When a demand matches
+  // a loadType the bot is carrying, we consume one slot and mark that demand
+  // as already-on-train (supplyCity = null). Once all slots for a loadType
+  // are consumed, remaining matching demands are treated as fresh pickups.
+  const remainingCarriedCounts = buildCarriedLoadCounts(snapshot.bot.loads);
+
   const contexts: DemandContext[] = [];
   for (const resolved of snapshot.bot.resolvedDemands) {
     for (const demand of resolved.demands) {
-      contexts.push(
-        computeBestDemandContext(resolved.cardId, demand, snapshot, network, gridPoints, reachableCities, citiesOnNetwork, connectedMajorCities, saturatedCityKeys),
-      );
+      const remaining = remainingCarriedCounts.get(demand.loadType) ?? 0;
+      if (remaining > 0) {
+        // Consume one carried slot: treat this demand as already-on-train.
+        // Use the original snapshot — loads already contains this loadType.
+        remainingCarriedCounts.set(demand.loadType, remaining - 1);
+        contexts.push(
+          computeBestDemandContext(
+            resolved.cardId, demand, snapshot, network, gridPoints,
+            reachableCities, citiesOnNetwork, connectedMajorCities, saturatedCityKeys,
+          ),
+        );
+      } else {
+        // No carried slot available for this loadType: demand requires a fresh pickup.
+        // Strip this loadType entirely from loads so computeBestDemandContext does not
+        // treat it as already-on-train and assigns a real supplyCity.
+        const loadsWithoutThisType = snapshot.bot.loads.filter(l => l !== demand.loadType);
+        const freshSnapshot: WorldSnapshot = {
+          ...snapshot,
+          bot: { ...snapshot.bot, loads: loadsWithoutThisType },
+        };
+        contexts.push(
+          computeBestDemandContext(
+            resolved.cardId, demand, freshSnapshot, network, gridPoints,
+            reachableCities, citiesOnNetwork, connectedMajorCities, saturatedCityKeys,
+          ),
+        );
+      }
     }
   }
   return contexts;


### PR DESCRIPTION
## Summary — combined PR per boss approval

**Three JIRAs in one PR by design.** The original commits on `matt/may-29` (`1f911d3`) co-fixed three tickets in a single planner change because the changes are logically inseparable: multiplicity-aware carry detection (JIRA-250) feeds the carry-floor logic (JIRA-248) which is enforced by the corridor enumerator (JIRA-249). Splitting the commit retroactively would have required surgical history rewrite — boss approved keeping them combined with explicit per-JIRA call-outs below.

## Tickets covered

| JIRA | What | Files |
|---|---|---|
| **JIRA-248** | Replan drops carried-load delivery | `TripPlanner.ts` (affordability bypass), `DeterministicTripPlanner.ts` (carry-floor + grammar) |
| **JIRA-249** | Route omits pickup for new demand | `DeterministicTripPlanner.ts` (corridor enumeration), `MovementPhasePlanner.ts` (deliver-without-load arrival guard) |
| **JIRA-250** | Corridor pickup missed second Fish | `DemandEngine.ts` (multiplicity-aware carry detection) |

## Commits (4)

1. `76bbdbb` — multiplicity-aware carry-load detection in DemandEngine (JIRA-250 Layer 1)
2. `b0e72a7` — bypass affordability gate for carried-load demands in TripPlanner (JIRA-248 Layer 2)
3. `907ac42` — grammar validation, carry floor, and corridor enumeration in DeterministicTripPlanner (**JIRA-248 L1 + JIRA-249 L2 + JIRA-250 L2/L3** — the entangled one)
4. `8e29f4f` — runtime arrival guard in MovementPhasePlanner for deliver-without-load (JIRA-249 Layer 3)

Plus one combined docs commit (6 files).

## Per-ticket docs
- `docs/ai/done/jira-248-replanDropsCarriedLoadDelivery-{behavioral,technical}.md`
- `docs/ai/done/jira-249-routeOmitsPickupForNewDemand-{behavioral,technical}.md`
- `docs/ai/done/jira-250-corridorPickupMissedSecondFish-{behavioral,technical}.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full suite green: **3842 pass, 24 skipped, 0 fail**

**Base**: `main`. Independent of the JIRA-256 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)