### PR TITLE
feat(ai): JIRA-255 — end-game phase logic + cash-completion route boost (5 layers)

### DIFF
--- a/docs/ai/done/jira-255-endGamePhaseLogicNotWired-behavioral.md
+++ b/docs/ai/done/jira-255-endGamePhaseLogicNotWired-behavioral.md
@@ -1,0 +1,57 @@
+# JIRA-255 — End-game routing must optimize for fewest turns to victory, not income velocity (behavioral)
+
+## Symptom
+
+In game `6033c903-7ab8-40e8-b073-acd82e2e3c9e`, player Sonnet at **T76** with cash **$227M**, `cmc = ['Milano', 'Ruhr', 'Wien']` (3 of 7), train capacity 3 (Heavy Freight). Hand contains three Hops-from-Cardiff demand cards:
+
+| Card | Demand | Payout |
+|------|--------|--------|
+| 66   | Hops Cardiff → Munchen | $29M |
+| 83   | Hops Cardiff → Leipzig | $25M |
+| 120  | Hops Cardiff → Lodz    | $35M |
+
+A triple-pickup at Cardiff delivers all three: payout `$89M`, build `$22M` (one ferry trip), NET `~$67M`. End cash `$227M + $67M = $294M`. After ~$30M of track to connect the 4 remaining major cities: `$264M ≥ $250M`. **This route wins the game.**
+
+Planner picks instead `single Potatoes Lodz → Bern` (NET $18M, 6 turns) on `aggregateScore = 2.17 M/turn`. The triple-Hops candidate is enumerated by `genTriples` but discarded by the `PRUNE_MAX_TURNS = 12` filter (T76 log: `Discarded by prune: 831 (turns > 12)`). Bot ends T81 at $245M — close to cash threshold, nowhere near closing the city-connection budget — then enters another multi-route cycle.
+
+## Win cost
+
+Bot wins by reaching:
+- `$250M` cash, AND
+- 7 connected major cities — which costs `sum(estimatedCost for cheapest (7 − cmc) unconnected majors)`, retrievable from existing `NetworkContext.computeUnconnectedMajorCities`.
+
+**Full win cost** = `$250M + costToConnectRemainingMajors`.
+
+A candidate is **win-completing** when `(currentCash + candidate.net) ≥ fullWinCost`.
+
+## End-game state lock
+
+When bot cash crosses **$200M**, the planner enters end-game state. The state is **sticky** — it does not unlock if cash dips below $200M from a build. In this state:
+
+1. **Route candidates are filtered to win-completers** (when at least one exists).
+2. **Ranking is by fewest turns to victory**, not income velocity.
+3. The `PRUNE_MAX_TURNS = 12` filter does not apply to win-completers — a long-turn winning route beats a short-turn non-winning one.
+
+When no win-completer exists in the candidate set, fall through to the normal `aggregateScore` ranking — but the state stays end-game (re-enter the win-completer filter on the next replan).
+
+## Caveat — turn counting is suspect
+
+Triple Hops-Cardiff is currently estimated at ~14-18 turns (and pruned). The actual game time, accounting for Heavy Freight 9 mp/turn movement, one ferry crossing, and the 22M build (over 2 turns with the 20M Phase B cap), looks closer to **9 turns**, not 16. Fixing the turn-count estimator is **out of scope here** — but the discrepancy strengthens the case for the prune carve-out: even if turn counts are inflated, win-completers must not be silently dropped.
+
+## Acceptance
+
+- **AC1** End-game state activates at `cash > $200M` and remains sticky across the rest of the game.
+- **AC2** In end-game state, triple-Hops-Cardiff (the only win-completer in the T76 candidate set) survives pruning regardless of estimated turn count.
+- **AC3** In end-game state, among win-completers, ranking is by ascending turns. The triple-Hops candidate beats any equally-completing slower alternative.
+- **AC4** Outside end-game state, ranking is unchanged (`aggregateScore = net / turns`).
+- **AC5** Replay Sonnet T76 snapshot from game `6033c903`: top-1 is the triple-Hops-Cardiff candidate (or another win-completer with fewer turns to victory). Single-Potatoes-Lodz is not top-1.
+
+## Source
+
+`logs/game-6033c903-7ab8-40e8-b073-acd82e2e3c9e.ndjson`, Sonnet T76 entry — reasoning string, demandRanking, victoryCheck, gameState.
+
+## Relationship to existing JIRAs
+
+- **JIRA-229** introduced `aggregateScore` for mid-game velocity ranking. This ticket adds a phase override.
+- **JIRA-253** removed an A3 abandon predicate that killed multi-turn builds. With 253 in place, a long-build win-completer can actually execute.
+- **JIRA-252** addresses post-delivery replan ordering — sibling timing concern.

--- a/docs/ai/done/jira-255-endGamePhaseLogicNotWired-technical.md
+++ b/docs/ai/done/jira-255-endGamePhaseLogicNotWired-technical.md
@@ -1,0 +1,167 @@
+# JIRA-255 — End-game state lock + fewest-turns-to-victory ranking (technical)
+
+Companion to `jira-255-endGamePhaseLogicNotWired-behavioral.md`.
+
+## Defect loci
+
+### 1. `classifyGamePhase` is dead code
+
+`src/server/services/ai/DeterministicTripPlanner.ts:68` — `classifyGamePhase(turn, deliveries, citiesConnected): 'early' | 'mid' | 'late'`. Defined, exported, has its own test suite. `grep -r classifyGamePhase src/` shows zero production callers.
+
+### 2. `NetworkContext.computePhase` feeds the log/LLM only
+
+`src/server/services/ai/context/NetworkContext.ts:259-269` produces the `gamePhase` log field. Not consumed by `DeterministicTripPlanner.scoreCandidate` or `computeAggregateScore`. The deterministic planner has no phase awareness.
+
+### 3. `aggregateScore` is pure income velocity
+
+`DeterministicTripPlanner.ts:1086` (`scoreCandidate`) and `1182-1184` (`computeAggregateScore`):
+
+```ts
+aggregateScore: net / Math.max(turns, 1),
+// chained:
+const aggregate = (c1.net + c2ChainedNet) / Math.max(c1.turns + c2Chained.turnsToComplete, 1);
+```
+
+No notion of "this candidate funds the full win cost."
+
+### 4. `PRUNE_MAX_TURNS = 12` drops win-completers
+
+`DeterministicTripPlanner.ts:78` — applied before scoring. The T76 log records `Discarded by prune: 831 (turns > 12)`. The only win-completing candidate at T76 (triple-Hops-Cardiff) is in this bucket.
+
+### 5. `NetworkContext.computeUnconnectedMajorCities` is unused by the planner
+
+`NetworkContext.ts:272-288` returns `{cityName, estimatedCost}[]` for unconnected majors, sorted cheapest-first. The data the planner needs to compute `fullWinCost` already exists; it just isn't read.
+
+## Fix shape
+
+Four layers. All required.
+
+### Layer 0 — Fix same-city phantom turn in cheapPrune estimator
+
+`PathCostEstimator.ts:188` hardcodes `estimatedTurns: 1` for trivial same-point legs:
+
+```ts
+if (fromCoord.row === toCoord.row && fromCoord.col === toCoord.col) {
+  const trivial: PathCost = { buildCost: 0, pathLength: 1, estimatedTurns: 1, reachable: true, newSegments: [] };
+```
+
+A leg from a city back to itself (e.g. multi-pickup at one city) costs zero turns — game rule: pickups/deliveries do not consume movement. Change to `estimatedTurns: 0`. Triple-Hops-Cardiff's two same-city pickup-to-pickup transitions drop the cheapPrune estimate from 13 turns to 11, surviving the `PRUNE_MAX_TURNS = 12` cut even without Layer A's carve-out. Layer A still required for genuinely long win-completers.
+
+This is the surgical estimator fix; the broader estimator overhaul (per-leg `ceil` inflation, no continuous-movement model) is out of scope and tracked separately.
+
+### Layer A — End-game state lock
+
+Add a sticky flag on bot memory:
+
+```ts
+// extend BotMemoryState:
+endGameLocked: boolean; // once true, stays true for the rest of the game
+```
+
+Set in the planner entry point (e.g. `AIStrategyEngine` or `DeterministicTripPlanner.planTrip`):
+
+```ts
+if (snapshot.bot.money > 200 && !memory.endGameLocked) {
+  memory.endGameLocked = true;
+  await updateMemory(gameId, playerId, { endGameLocked: true });
+}
+```
+
+The lock is one-way. Once active, end-game routing rules apply on every subsequent replan — even if cash temporarily drops below $200M from a build.
+
+### Layer B — Pre-prune carve-out + win-completer filter
+
+New helper (e.g. `src/server/services/ai/winCompletion.ts`):
+
+```ts
+export const CASH_WIN_THRESHOLD_M = 250;
+
+export function fullWinCost(
+  unconnectedMajors: Array<{ cityName: string; estimatedCost: number }>,
+  cmcCount: number,
+): number {
+  const remaining = Math.max(0, 7 - cmcCount);
+  const cityCost = unconnectedMajors.slice(0, remaining)
+    .reduce((sum, c) => sum + c.estimatedCost, 0);
+  return CASH_WIN_THRESHOLD_M + cityCost;
+}
+
+export function isWinCompleting(
+  currentCash: number,
+  candidateNet: number,
+  unconnectedMajors: Array<{ cityName: string; estimatedCost: number }>,
+  cmcCount: number,
+): boolean {
+  return currentCash + candidateNet >= fullWinCost(unconnectedMajors, cmcCount);
+}
+```
+
+In the prune pass — skip the `turns > PRUNE_MAX_TURNS` discard when the candidate is a win-completer and the bot is in end-game state:
+
+```ts
+if (candidate.turns > PRUNE_MAX_TURNS) {
+  if (memory.endGameLocked && isWinCompleting(cash, candidate.net, unconnectedMajors, cmcCount)) {
+    // keep — long-turn winners survive in end-game
+  } else {
+    continue;
+  }
+}
+```
+
+### Layer C — Fewest-turns-to-victory ranking in end-game
+
+In end-game state, replace `aggregateScore` ranking with a two-tier sort:
+
+```ts
+function endGameRankKey(c: ScoredCandidate, ctx: WinContext): [number, number] {
+  const completing = isWinCompleting(ctx.cash, c.net, ctx.unconnectedMajors, ctx.cmcCount);
+  // Primary: completers (0) sort before non-completers (1).
+  // Secondary: ascending turns. Among completers, fewer turns = better.
+  //            Among non-completers, fall back to velocity.
+  return [completing ? 0 : 1, completing ? c.turns : -c.aggregateScore];
+}
+```
+
+If no completer exists in the candidate set, the second tier (`-aggregateScore` on non-completers) is the ranker — same as today.
+
+Outside end-game state, ranking is unchanged.
+
+### Layer D — Wire `classifyGamePhase` (housekeeping)
+
+The dead `classifyGamePhase` becomes the gate on Layers B/C alongside the `endGameLocked` flag. Either:
+- Use `classifyGamePhase(turn, deliveries, cmc) === 'late'` as an alternate trigger for setting `endGameLocked` (in addition to `cash > 200`), OR
+- Delete `classifyGamePhase` and its tests if `endGameLocked` covers all the cases.
+
+Recommend the first option — phase-and-cash both rotating the lock catches more cases (e.g. games where `cmc` reaches 5 before cash reaches $200M).
+
+## Out of scope
+
+- **Broader turn-estimator overhaul.** Both `cheapPrune` and `simulateTrip` sum per-leg `ceil(mp/speed)` instead of running a continuous-movement simulator. This inflates multi-stop candidates systematically. Layer 0 fixes only the same-city phantom-turn case (the most common over-counter for triple-pickup candidates). The per-leg ceiling drift, no-cross-leg-movement-carry, and partial ferry-rate modeling are tracked in a separate ticket. Layer A's carve-out keeps win-completers in scope regardless of remaining estimator drift.
+- LLM-path scoring. The deterministic planner is the entry here (`[deterministic-top-1]` in the T76 reasoning).
+- Replacing `aggregateScore` outside end-game state. Pre-end-game ranking is unchanged.
+
+## Acceptance from behavioral
+
+- **AC0** Unit test on `estimateGraphPathCost`: same-coord input (`from === to`) returns `estimatedTurns: 0`. Pre-fix returns `1`.
+- **AC1** Unit test: bot snapshot `cash = 205M`, `endGameLocked = false`. After one replan tick, `memory.endGameLocked === true`. Persist via `updateMemory`.
+- **AC2** Unit test: `endGameLocked = true`, then a build drops `cash` to $180M. Lock remains true; end-game ranking still applies.
+- **AC3** Unit test on the prune pass: `endGameLocked = true`, candidate `{ net: 67, turns: 16 }`, `fullWinCost = $280M`, `cash = $227M`. Assert candidate survives. With `endGameLocked = false`, candidate is discarded by `turns > 12`.
+- **AC4** Unit test on ranking: `endGameLocked = true`, candidate A `{ net: 67, turns: 16, win-completing }`, candidate B `{ net: 18, turns: 6, not win-completing }`. Assert A ranks above B.
+- **AC5** Unit test on ranking: `endGameLocked = true`, both candidates win-completing, A `{ turns: 9 }`, B `{ turns: 16 }`. Assert A ranks above B (fewest turns wins).
+- **AC6** Unit test on ranking: `endGameLocked = true`, no win-completer in the candidate set. Assert ranking falls back to `-aggregateScore` (i.e. existing velocity ranking).
+- **AC7** Unit test outside end-game: `endGameLocked = false`, cash $80M. Assert ranking is unchanged from today's behavior.
+- **AC8** Game replay on Sonnet T76 snapshot, game `6033c903`. Assert top-1 is the triple-Hops-Cardiff candidate.
+- **AC9** `grep -rn "classifyGamePhase" src/` shows at least one non-test usage in the planner pipeline.
+
+## Validation hooks
+
+- New log fields per turn: `endGameLocked: boolean`, `fullWinCost: number`, `winCompleterCount: number`.
+- Reasoning string for the picked candidate, when in end-game: `Picked: triple-3fresh — payout 89M, NET 67M, 16 turns. End-game: win-completer (projected $294M cash, full win cost $280M), ranked by fewest turns.`
+- Prune log line in end-game: `Discarded by prune: 829 (turns > 12, 2 win-completing kept).`
+
+## Relationship to existing JIRAs
+
+- **JIRA-229** introduced `aggregateScore`. This ticket adds a phase override that does not modify mid-game ranking.
+- **JIRA-242** added flat additive bonuses on `aggregateScore` for multi-delivery candidates — different pattern (additive bonus) than this ticket (rank-key override) but in the same scoring path.
+- **JIRA-253** narrowed the A3 partial-path abandon predicate, allowing multi-turn builds to execute. Required for any long-turn win-completer surfaced by Layer B to actually run.
+- **JIRA-252** addresses post-delivery replan ordering — sibling timing concern.

--- a/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
+++ b/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
@@ -2812,12 +2812,11 @@ describe('JIRA-255 Layer A: end-game lock in planTripDeterministic', () => {
     // Default simulateTrip: feasible result
     mockSimulateTrip.mockReturnValue({
       feasible: true,
-      net: 20,
-      turns: 3,
+      finalCashRelative: 20,
+      turnsToComplete: 3,
+      totalBuildCost: 0,
       builtSegments: [],
-      endCity: 'DeliveryCity',
       minCashRelative: 0,
-      reasoning: 'ok',
     });
   });
 
@@ -3012,7 +3011,7 @@ describe('JIRA-255 Layer C: end-game ranking in planTripDeterministic', () => {
     const demandB = makeDemand({ cardIndex: 1, loadType: 'Hops', deliveryCity: 'Paris', payout: 67 });
 
     mockSimulateTrip.mockReturnValue({
-      feasible: true, net: 67, turns: 16, builtSegments: [], endCity: 'Paris', minCashRelative: 0, reasoning: 'B',
+      feasible: true, finalCashRelative: 67, turnsToComplete: 16, totalBuildCost: 0, builtSegments: [], minCashRelative: 0,
     });
 
     const memory = makeMemory({ endGameLocked: true });
@@ -3068,7 +3067,7 @@ describe('JIRA-255 Layer C: end-game ranking in planTripDeterministic', () => {
     const demandA = makeDemand({ cardIndex: 0, loadType: 'Coal', deliveryCity: 'Berlin', payout: 10 });
 
     mockSimulateTrip.mockReturnValue({
-      feasible: true, net: 10, turns: 3, builtSegments: [], endCity: 'Berlin', minCashRelative: 0, reasoning: 'A',
+      feasible: true, finalCashRelative: 10, turnsToComplete: 3, totalBuildCost: 0, builtSegments: [], minCashRelative: 0,
     });
 
     const memory = makeMemory({ endGameLocked: true });
@@ -3089,7 +3088,7 @@ describe('JIRA-255 Layer C: end-game ranking in planTripDeterministic', () => {
     const demandA = makeDemand({ cardIndex: 0, loadType: 'Coal', deliveryCity: 'Berlin', payout: 10 });
 
     mockSimulateTrip.mockReturnValue({
-      feasible: true, net: 10, turns: 3, builtSegments: [], endCity: 'Berlin', minCashRelative: 0, reasoning: 'A',
+      feasible: true, finalCashRelative: 10, turnsToComplete: 3, totalBuildCost: 0, builtSegments: [], minCashRelative: 0,
     });
 
     const memory = makeMemory({ endGameLocked: false });

--- a/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
+++ b/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
@@ -36,6 +36,12 @@ jest.mock('../../services/ai/PathCostEstimator', () => ({
   clearPathCostCache: jest.fn(),
 }));
 
+// Mock BotMemory so updateMemory (called by end-game lock hook) doesn't hit the DB
+const mockUpdateMemory = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../services/ai/BotMemory', () => ({
+  updateMemory: mockUpdateMemory,
+}));
+
 // Mock MapTopology to control grid + city lookup
 // Using Map<string, any> since the mock grid is just for test fixtures
 const mockGrid = new Map<string, { row: number; col: number; terrain: number; name?: string }>();
@@ -2790,5 +2796,99 @@ describe('JIRA-249/250: enumerateCandidates includes carry floor and corridor ca
 
     const corridorCandidates = candidates.filter(c => c.id.startsWith('corridor:'));
     expect(corridorCandidates.length).toBeGreaterThan(0);
+  });
+});
+
+// ── JIRA-255 Layer A: End-game lock mechanism ──────────────────────────
+
+describe('JIRA-255 Layer A: end-game lock in planTripDeterministic', () => {
+  beforeEach(() => {
+    mockUpdateMemory.mockClear();
+    // Default cheapPrune: always keep
+    mockEstimateGraphPathCost.mockReturnValue({
+      buildCost: 0, pathLength: 1, estimatedTurns: 1, reachable: true, newSegments: [],
+    });
+    // Default simulateTrip: feasible result
+    mockSimulateTrip.mockReturnValue({
+      feasible: true,
+      net: 20,
+      turns: 3,
+      builtSegments: [],
+      endCity: 'DeliveryCity',
+      minCashRelative: 0,
+      reasoning: 'ok',
+    });
+  });
+
+  /** A demand that cheapPrune keeps and simulateTrip scores as feasible */
+  function makeSingleDemand(): DemandContext {
+    return makeDemand({ cardIndex: 0, loadType: 'Coal', deliveryCity: 'Paris', payout: 25 });
+  }
+
+  it('sets endGameLocked=true when cash > 200 and lock was false', () => {
+    const memory = makeMemory({ endGameLocked: false });
+    const snap = makeSnapshot({ money: 205 });
+    const ctx = makeContext([makeSingleDemand()]);
+
+    planTripDeterministic(snap, ctx, memory);
+
+    expect(memory.endGameLocked).toBe(true);
+    expect(mockUpdateMemory).toHaveBeenCalledWith('test-game', 'bot-1', { endGameLocked: true });
+  });
+
+  it('sets endGameLocked=true when classifyGamePhase returns late (turn >= 80)', () => {
+    const memory = makeMemory({ endGameLocked: false, deliveryCount: 5 });
+    // money <= 200 but turn=80 → late
+    const snap: WorldSnapshot = {
+      ...makeSnapshot({ money: 100 }),
+      turnNumber: 80,
+    };
+    const ctx = makeContext([makeSingleDemand()]);
+
+    planTripDeterministic(snap, ctx, memory);
+
+    expect(memory.endGameLocked).toBe(true);
+    expect(mockUpdateMemory).toHaveBeenCalledWith('test-game', 'bot-1', { endGameLocked: true });
+  });
+
+  it('does not set endGameLocked when cash <= 200 and phase is not late', () => {
+    const memory = makeMemory({ deliveryCount: 1 });
+    // money=100, turn=10 (default in makeSnapshot), deliveries=1, cmc=0 → early phase
+    const snap = makeSnapshot({ money: 100 });
+    const ctx = makeContext([makeSingleDemand()]);
+
+    planTripDeterministic(snap, ctx, memory);
+
+    // Lock was not set — remains absent (undefined)
+    expect(memory.endGameLocked).toBeFalsy();
+    expect(mockUpdateMemory).not.toHaveBeenCalledWith('test-game', 'bot-1', { endGameLocked: true });
+  });
+
+  it('endGameLocked remains true when already set (sticky, not re-set on cash dip)', () => {
+    const memory = makeMemory({ endGameLocked: true });
+    // money now only 150 (post-build dip) — lock should stay
+    const snap = makeSnapshot({ money: 150 });
+    const ctx = makeContext([makeSingleDemand()]);
+
+    mockUpdateMemory.mockClear();
+    planTripDeterministic(snap, ctx, memory);
+
+    expect(memory.endGameLocked).toBe(true);
+    // updateMemory should NOT be called again since lock was already set
+    expect(mockUpdateMemory).not.toHaveBeenCalledWith('test-game', 'bot-1', { endGameLocked: true });
+  });
+
+  it('sets endGameLocked=true when citiesConnected >= 5 (late via classifyGamePhase)', () => {
+    const memory = makeMemory({ endGameLocked: false, deliveryCount: 10 });
+    // money=50 but 5 cities connected → late phase
+    const snap = makeSnapshot({ money: 50 });
+    const ctx = makeContext([makeSingleDemand()], {
+      connectedMajorCities: ['A', 'B', 'C', 'D', 'E'],
+    });
+
+    planTripDeterministic(snap, ctx, memory);
+
+    expect(memory.endGameLocked).toBe(true);
+    expect(mockUpdateMemory).toHaveBeenCalledWith('test-game', 'bot-1', { endGameLocked: true });
   });
 });

--- a/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
+++ b/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
@@ -64,6 +64,7 @@ import {
   PRUNE_MAX_BUILD_M,
   HOP_AVG_COST_M,
   AFFORDABILITY_FLOOR_M,
+  WIN_COMPLETING_MAX_TURNS,
   classifyGamePhase,
   detectCarriedLoads,
   normalizeRows,
@@ -2890,5 +2891,214 @@ describe('JIRA-255 Layer A: end-game lock in planTripDeterministic', () => {
 
     expect(memory.endGameLocked).toBe(true);
     expect(mockUpdateMemory).toHaveBeenCalledWith('test-game', 'bot-1', { endGameLocked: true });
+  });
+});
+
+// ── JIRA-255 Layer B: cheapPrune end-game carve-out ────────────────────
+
+describe('JIRA-255 Layer B: cheapPrune end-game carve-out', () => {
+  const defaultOpts = {
+    pruneMaxTurns: PRUNE_MAX_TURNS,
+    pruneMaxBuildM: PRUNE_MAX_BUILD_M,
+    hopAvgCostM: HOP_AVG_COST_M,
+  };
+
+  beforeEach(() => {
+    mockEstimateGraphPathCost.mockReset();
+  });
+
+  /** Candidate worth payout=67, buildCost=0 → net=67 */
+  function makeWinCandidate() {
+    return {
+      id: 'win-candidate',
+      rows: [],
+      stops: [
+        { action: 'pickup' as const, loadType: 'Hops', city: 'Cardiff' },
+        { action: 'deliver' as const, loadType: 'Hops', city: 'Paris' },
+      ],
+      payout: 67,
+    };
+  }
+
+  it('keeps win-completing candidate with turns=16 when endGameLocked=true (exceeds PRUNE_MAX_TURNS)', () => {
+    // estTurns=16 > PRUNE_MAX_TURNS(12), but win-completing → keep
+    mockEstimateGraphPathCost
+      .mockReturnValueOnce({ reachable: true, buildCost: 0, pathLength: 72, estimatedTurns: 8 })
+      .mockReturnValueOnce({ reachable: true, buildCost: 0, pathLength: 72, estimatedTurns: 8 });
+
+    const memory = { endGameLocked: true };
+    // cash=227, payout=67, estBuild=0 → candidateNet=67 → 227+67=294 >= 280 (fullWinCost with 30M track)
+    const snap = makeSnapshot({ money: 227 });
+    const ctx = {
+      unconnectedMajorCities: [
+        { cityName: 'A', estimatedCost: 5 },
+        { cityName: 'B', estimatedCost: 7 },
+        { cityName: 'C', estimatedCost: 9 },
+        { cityName: 'D', estimatedCost: 9 },
+      ],
+      connectedMajorCities: ['X', 'Y', 'Z'],
+    };
+
+    const result = cheapPrune(makeWinCandidate(), { row: 5, col: 5 }, 9, defaultOpts, snap, memory, ctx);
+    expect(result.keep).toBe(true);
+    expect(result.estTurns).toBe(16);
+  });
+
+  it('prunes win-completing candidate with turns=30 (exceeds WIN_COMPLETING_MAX_TURNS)', () => {
+    // estTurns=30 > WIN_COMPLETING_MAX_TURNS(25) → always pruned
+    mockEstimateGraphPathCost
+      .mockReturnValueOnce({ reachable: true, buildCost: 0, pathLength: 135, estimatedTurns: 15 })
+      .mockReturnValueOnce({ reachable: true, buildCost: 0, pathLength: 135, estimatedTurns: 15 });
+
+    const memory = { endGameLocked: true };
+    const snap = makeSnapshot({ money: 227 });
+    const ctx = {
+      unconnectedMajorCities: [{ cityName: 'A', estimatedCost: 5 }],
+      connectedMajorCities: ['X', 'Y', 'Z', 'W', 'V', 'U'],
+    };
+
+    const result = cheapPrune(makeWinCandidate(), { row: 5, col: 5 }, 9, defaultOpts, snap, memory, ctx);
+    expect(result.keep).toBe(false);
+    expect(result.estTurns).toBe(30);
+  });
+
+  it('prunes a candidate with turns=16 when endGameLocked=false (standard rule applies)', () => {
+    mockEstimateGraphPathCost
+      .mockReturnValueOnce({ reachable: true, buildCost: 0, pathLength: 72, estimatedTurns: 8 })
+      .mockReturnValueOnce({ reachable: true, buildCost: 0, pathLength: 72, estimatedTurns: 8 });
+
+    const memory = { endGameLocked: false };
+    const snap = makeSnapshot({ money: 227 });
+    const result = cheapPrune(makeWinCandidate(), { row: 5, col: 5 }, 9, defaultOpts, snap, memory);
+    expect(result.keep).toBe(false);
+    expect(result.estTurns).toBe(16);
+  });
+
+  it('prunes a non-win-completing candidate even if turns<=WIN_COMPLETING_MAX_TURNS and endGameLocked=true', () => {
+    // turns=16, but net=1 → 227+1=228 < 280 → not win-completing → pruned
+    mockEstimateGraphPathCost
+      .mockReturnValueOnce({ reachable: true, buildCost: 0, pathLength: 72, estimatedTurns: 8 })
+      .mockReturnValueOnce({ reachable: true, buildCost: 0, pathLength: 72, estimatedTurns: 8 });
+
+    const memory = { endGameLocked: true };
+    const snap = makeSnapshot({ money: 227 });
+    const ctx = {
+      unconnectedMajorCities: [
+        { cityName: 'A', estimatedCost: 5 }, { cityName: 'B', estimatedCost: 7 },
+        { cityName: 'C', estimatedCost: 9 }, { cityName: 'D', estimatedCost: 9 },
+      ],
+      connectedMajorCities: ['X', 'Y', 'Z'],
+    };
+    const lowPayoutCandidate = { ...makeWinCandidate(), payout: 1 };
+
+    const result = cheapPrune(lowPayoutCandidate, { row: 5, col: 5 }, 9, defaultOpts, snap, memory, ctx);
+    expect(result.keep).toBe(false);
+  });
+});
+
+// ── JIRA-255 Layer C: end-game two-tier ranking via planTripDeterministic ─
+
+describe('JIRA-255 Layer C: end-game ranking in planTripDeterministic', () => {
+  beforeEach(() => {
+    mockUpdateMemory.mockClear();
+    mockEstimateGraphPathCost.mockReturnValue({
+      buildCost: 0, pathLength: 1, estimatedTurns: 1, reachable: true, newSegments: [],
+    });
+  });
+
+  it('win-completing candidate ranks above non-completing high-velocity candidate when endGameLocked', () => {
+    // Only one demand card — payout=67. With cash=227+67=294 >= 250 → win-completing.
+    // When endGameLocked=true, win-completer always wins.
+    const demandB = makeDemand({ cardIndex: 1, loadType: 'Hops', deliveryCity: 'Paris', payout: 67 });
+
+    mockSimulateTrip.mockReturnValue({
+      feasible: true, net: 67, turns: 16, builtSegments: [], endCity: 'Paris', minCashRelative: 0, reasoning: 'B',
+    });
+
+    const memory = makeMemory({ endGameLocked: true });
+    const snap = makeSnapshot({ money: 227 }); // 227+67=294 >= 250 → win-completing
+    const ctx = makeContext([demandB], {
+      unconnectedMajorCities: [],
+      connectedMajorCities: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+    });
+
+    const result = planTripDeterministic(snap, ctx, memory);
+    expect(result.route).not.toBeNull();
+    const firstDeliver = result.route?.stops.find(s => s.action === 'deliver');
+    expect(firstDeliver?.city).toBe('Paris');
+  });
+
+  it('among win-completing candidates, fewest-turns wins (ranker test via sorted array)', () => {
+    // We test the sort logic directly on two ScoredCandidates to verify two-tier ranking.
+    // This avoids the complexity of mocking the full planTripDeterministic pipeline
+    // with multiple candidates producing different turn counts.
+    //
+    // Synthetic feasible set: A (turns=16, win-completing), B (turns=9, win-completing)
+    // Expected: B ranks first (fewest turns among completers)
+    const feasibleA = {
+      id: 'A', rows: [], stops: [{ action: 'deliver' as const, loadType: 'Coal', city: 'Berlin' }],
+      payout: 70, buildCost: 0, turns: 16, net: 70, feasible: true,
+      aggregateScore: 70 / 16, aggregateFollowup: null, aggregateEmptyLegTurns: 0,
+      builtSegments: [], endCity: 'Berlin', reasoning: 'A', minCashRelative: 0,
+    };
+    const feasibleB = {
+      id: 'B', rows: [], stops: [{ action: 'deliver' as const, loadType: 'Hops', city: 'Paris' }],
+      payout: 70, buildCost: 0, turns: 9, net: 70, feasible: true,
+      aggregateScore: 70 / 9, aggregateFollowup: null, aggregateEmptyLegTurns: 0,
+      builtSegments: [], endCity: 'Paris', reasoning: 'B', minCashRelative: 0,
+    };
+
+    // Both are win-completing (cash=200, net=70 → 270 >= 250 with no unconnected)
+    const unconnectedMajors: Array<{ cityName: string; estimatedCost: number }> = [];
+    const cmcCount = 7; // all connected → fullWinCost=250
+    const cash = 200;
+
+    // Sort using the Layer C logic manually
+    const { isWinCompleting: winCheck } = require('../../services/ai/winCompletion');
+    const completers = [feasibleA, feasibleB].filter(c => winCheck(cash, c.net, unconnectedMajors, cmcCount));
+    completers.sort((a: typeof feasibleA, b: typeof feasibleB) => a.turns !== b.turns ? a.turns - b.turns : a.id.localeCompare(b.id));
+
+    expect(completers).toHaveLength(2);
+    expect(completers[0].id).toBe('B'); // 9 turns < 16 turns
+    expect(completers[1].id).toBe('A');
+  });
+
+  it('falls back to aggregateScore when endGameLocked=true but no win-completers (single candidate)', () => {
+    // Single demand, no win-completing (cash=50, payout=10 → 60 < 250)
+    const demandA = makeDemand({ cardIndex: 0, loadType: 'Coal', deliveryCity: 'Berlin', payout: 10 });
+
+    mockSimulateTrip.mockReturnValue({
+      feasible: true, net: 10, turns: 3, builtSegments: [], endCity: 'Berlin', minCashRelative: 0, reasoning: 'A',
+    });
+
+    const memory = makeMemory({ endGameLocked: true });
+    const snap = makeSnapshot({ money: 50 }); // 50+10=60 << 250 — not win-completing
+    const ctx = makeContext([demandA], {
+      unconnectedMajorCities: [],
+      connectedMajorCities: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+    });
+
+    const result = planTripDeterministic(snap, ctx, memory);
+    // Should still return a route via velocity fallback
+    expect(result.route).not.toBeNull();
+    const firstDeliver = result.route?.stops.find(s => s.action === 'deliver');
+    expect(firstDeliver?.city).toBe('Berlin');
+  });
+
+  it('uses velocity ranking when endGameLocked=false (single candidate test)', () => {
+    const demandA = makeDemand({ cardIndex: 0, loadType: 'Coal', deliveryCity: 'Berlin', payout: 10 });
+
+    mockSimulateTrip.mockReturnValue({
+      feasible: true, net: 10, turns: 3, builtSegments: [], endCity: 'Berlin', minCashRelative: 0, reasoning: 'A',
+    });
+
+    const memory = makeMemory({ endGameLocked: false });
+    const snap = makeSnapshot({ money: 50 });
+    const ctx = makeContext([demandA]);
+
+    const result = planTripDeterministic(snap, ctx, memory);
+    expect(result.route).not.toBeNull();
+    const firstDeliver = result.route?.stops.find(s => s.action === 'deliver');
+    expect(firstDeliver?.city).toBe('Berlin');
   });
 });

--- a/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
+++ b/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
@@ -3102,3 +3102,76 @@ describe('JIRA-255 Layer C: end-game ranking in planTripDeterministic', () => {
     expect(firstDeliver?.city).toBe('Berlin');
   });
 });
+
+// ── JIRA-255 Layer D: diagnostic logging in reasoning strings ──────────
+
+describe('JIRA-255 Layer D: end-game diagnostic logging in reasoning strings', () => {
+  beforeEach(() => {
+    mockUpdateMemory.mockClear();
+    mockEstimateGraphPathCost.mockReturnValue({
+      buildCost: 0, pathLength: 1, estimatedTurns: 1, reachable: true, newSegments: [],
+    });
+  });
+
+  it('reasoning includes win-completer annotation when endGameLocked=true and candidate wins', () => {
+    // cash=227, payout=67, buildCost=0 → net=67 → 227+67=294 >= 250 → win-completing
+    const demand = makeDemand({ cardIndex: 0, loadType: 'Hops', deliveryCity: 'Paris', payout: 67 });
+
+    // Use correct TripSimulation shape: turnsToComplete + totalBuildCost
+    mockSimulateTrip.mockReturnValue({
+      feasible: true, turnsToComplete: 5, totalBuildCost: 0,
+      builtSegments: [], minCashRelative: 0, finalCashRelative: 67,
+    });
+
+    const memory = makeMemory({ endGameLocked: true });
+    const snap = makeSnapshot({ money: 227 });
+    const ctx = makeContext([demand], {
+      unconnectedMajorCities: [],
+      connectedMajorCities: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+    });
+
+    const result = planTripDeterministic(snap, ctx, memory);
+    expect(result.reasoning).toContain('win-completer');
+    expect(result.reasoning).toContain('projected $294');
+    expect(result.reasoning).toContain('full win cost $250');
+  });
+
+  it('reasoning includes locked-but-no-completers annotation when endGameLocked=true but not win-completing', () => {
+    // cash=50, payout=10, buildCost=0 → net=10 → 60 < 250 → not win-completing
+    const demand = makeDemand({ cardIndex: 0, loadType: 'Coal', deliveryCity: 'Berlin', payout: 10 });
+
+    mockSimulateTrip.mockReturnValue({
+      feasible: true, turnsToComplete: 3, totalBuildCost: 0,
+      builtSegments: [], minCashRelative: 0, finalCashRelative: 10,
+    });
+
+    const memory = makeMemory({ endGameLocked: true });
+    const snap = makeSnapshot({ money: 50 });
+    const ctx = makeContext([demand], {
+      unconnectedMajorCities: [],
+      connectedMajorCities: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+    });
+
+    const result = planTripDeterministic(snap, ctx, memory);
+    expect(result.reasoning).toContain('End-game: locked');
+    expect(result.reasoning).toContain('no win-completers in set');
+    expect(result.reasoning).toContain('velocity ranking applied');
+  });
+
+  it('reasoning does NOT contain end-game annotation when endGameLocked=false', () => {
+    const demand = makeDemand({ cardIndex: 0, loadType: 'Coal', deliveryCity: 'Berlin', payout: 10 });
+
+    mockSimulateTrip.mockReturnValue({
+      feasible: true, turnsToComplete: 3, totalBuildCost: 0,
+      builtSegments: [], minCashRelative: 0, finalCashRelative: 10,
+    });
+
+    const memory = makeMemory({ endGameLocked: false });
+    const snap = makeSnapshot({ money: 50 });
+    const ctx = makeContext([demand]);
+
+    const result = planTripDeterministic(snap, ctx, memory);
+    expect(result.reasoning).not.toContain('End-game:');
+    expect(result.reasoning).not.toContain('win-completer');
+  });
+});

--- a/src/server/__tests__/ai/PathCostEstimator.test.ts
+++ b/src/server/__tests__/ai/PathCostEstimator.test.ts
@@ -406,7 +406,8 @@ describe('estimateGraphPathCost', () => {
     expect(result.reachable).toBe(true);
     expect(result.buildCost).toBe(0);
     expect(result.pathLength).toBe(1);
-    expect(result.estimatedTurns).toBe(1);
+    // JIRA-255 Layer 0 fix: same-city pickups consume 0 turns (train is already there)
+    expect(result.estimatedTurns).toBe(0);
     expect(mockEstimateRouteSegment).not.toHaveBeenCalled();
   });
 

--- a/src/server/__tests__/ai/winCompletion.test.ts
+++ b/src/server/__tests__/ai/winCompletion.test.ts
@@ -1,0 +1,143 @@
+/**
+ * winCompletion.test.ts
+ *
+ * Unit tests for the winCompletion helper module (JIRA-255 BE-001).
+ *
+ * Covers:
+ *  - CASH_WIN_THRESHOLD_M constant
+ *  - fullWinCost: various cmcCount and unconnectedMajors combinations
+ *  - isWinCompleting: boundary conditions, true/false cases
+ */
+
+import {
+  CASH_WIN_THRESHOLD_M,
+  fullWinCost,
+  isWinCompleting,
+} from '../../services/ai/winCompletion';
+
+// ── CASH_WIN_THRESHOLD_M ───────────────────────────────────────────────
+
+describe('CASH_WIN_THRESHOLD_M', () => {
+  it('equals 250', () => {
+    expect(CASH_WIN_THRESHOLD_M).toBe(250);
+  });
+});
+
+// ── fullWinCost ────────────────────────────────────────────────────────
+
+describe('fullWinCost', () => {
+  it('returns 250 when cmcCount is 7 (all connected)', () => {
+    const result = fullWinCost([], 7);
+    expect(result).toBe(250);
+  });
+
+  it('returns 250 when unconnectedMajors is empty and cmcCount < 7', () => {
+    // No known connection costs available — returns only the cash threshold
+    const result = fullWinCost([], 3);
+    expect(result).toBe(250);
+  });
+
+  it('sums the cheapest (7 - cmcCount) costs for cmcCount = 3', () => {
+    // remaining = 4; cheapest 4 from [5, 7, 9, 11, 13, 15] are 5+7+9+11 = 32
+    const unconnected = [
+      { cityName: 'A', estimatedCost: 5 },
+      { cityName: 'B', estimatedCost: 7 },
+      { cityName: 'C', estimatedCost: 9 },
+      { cityName: 'D', estimatedCost: 11 },
+      { cityName: 'E', estimatedCost: 13 },
+      { cityName: 'F', estimatedCost: 15 },
+    ];
+    const result = fullWinCost(unconnected, 3);
+    expect(result).toBe(250 + 5 + 7 + 9 + 11); // 282
+  });
+
+  it('picks cheapest entries even when array is not sorted', () => {
+    const unconnected = [
+      { cityName: 'A', estimatedCost: 15 },
+      { cityName: 'B', estimatedCost: 5 },
+      { cityName: 'C', estimatedCost: 9 },
+    ];
+    // cmcCount = 5 → remaining = 2 → cheapest 2: 5+9 = 14
+    const result = fullWinCost(unconnected, 5);
+    expect(result).toBe(250 + 5 + 9); // 264
+  });
+
+  it('handles cmcCount = 6 (one city left to connect)', () => {
+    const unconnected = [
+      { cityName: 'X', estimatedCost: 20 },
+      { cityName: 'Y', estimatedCost: 8 },
+    ];
+    // remaining = 1 → take only the cheapest: 8
+    const result = fullWinCost(unconnected, 6);
+    expect(result).toBe(250 + 8); // 258
+  });
+
+  it('returns 250 when remaining cities exceeds unconnected array length (capped)', () => {
+    // cmcCount = 0, remaining = 7, but only 2 cities available
+    const unconnected = [
+      { cityName: 'A', estimatedCost: 10 },
+      { cityName: 'B', estimatedCost: 20 },
+    ];
+    const result = fullWinCost(unconnected, 0);
+    // Can only slice 2 entries → 250 + 10 + 20 = 280
+    expect(result).toBe(250 + 10 + 20); // 280
+  });
+
+  it('does not mutate the original unconnectedMajors array', () => {
+    const unconnected = [
+      { cityName: 'A', estimatedCost: 15 },
+      { cityName: 'B', estimatedCost: 5 },
+    ];
+    const original = [...unconnected];
+    fullWinCost(unconnected, 5);
+    expect(unconnected).toEqual(original);
+  });
+});
+
+// ── isWinCompleting ────────────────────────────────────────────────────
+
+describe('isWinCompleting', () => {
+  // Shared fixture: 3 cities connected, unconnected sum of cheapest 4 = 30M
+  // (5+7+9+9 — see below), fullWinCost = 280
+  const majors = [
+    { cityName: 'A', estimatedCost: 5 },
+    { cityName: 'B', estimatedCost: 7 },
+    { cityName: 'C', estimatedCost: 9 },
+    { cityName: 'D', estimatedCost: 9 },
+    { cityName: 'E', estimatedCost: 12 },
+  ];
+  const cmcCount = 3; // remaining = 4; cheapest 4: 5+7+9+9 = 30 → fullWinCost = 280
+
+  it('returns true when currentCash + candidateNet >= fullWinCost', () => {
+    // 227 + 67 = 294 >= 280
+    expect(isWinCompleting(227, 67, majors, cmcCount)).toBe(true);
+  });
+
+  it('returns false when currentCash + candidateNet < fullWinCost', () => {
+    // 227 + 32 = 259 < 280
+    expect(isWinCompleting(227, 32, majors, cmcCount)).toBe(false);
+  });
+
+  it('returns true when sum exactly equals fullWinCost (boundary)', () => {
+    // 227 + 53 = 280 == 280 → true
+    expect(isWinCompleting(227, 53, majors, cmcCount)).toBe(true);
+  });
+
+  it('returns false when candidateNet subtracts track cost bringing total below threshold', () => {
+    // fullWinCost with cmcCount=3, sum $30 = 280; cash=260, net=10
+    // 260 + 10 = 270 < 280 → false
+    expect(isWinCompleting(260, 10, majors, cmcCount)).toBe(false);
+  });
+
+  it('returns true when all 7 cities connected (fullWinCost = 250)', () => {
+    // No track cost needed; just need cash >= 250
+    expect(isWinCompleting(240, 15, [], 7)).toBe(true);  // 255 >= 250
+    expect(isWinCompleting(240, 9, [], 7)).toBe(false);  // 249 < 250
+  });
+
+  it('handles zero candidateNet correctly', () => {
+    // Just re-checking cash position without a new delivery
+    expect(isWinCompleting(280, 0, [], 7)).toBe(true);   // 280 >= 250
+    expect(isWinCompleting(249, 0, [], 7)).toBe(false);  // 249 < 250
+  });
+});

--- a/src/server/services/ai/DeterministicTripPlanner.ts
+++ b/src/server/services/ai/DeterministicTripPlanner.ts
@@ -37,6 +37,7 @@ import {
 import { cheapestUnconnectedMajorConnectorCost } from './victoryRules';
 import { getCityMilepointKey, isPickupDeliveryBlocked } from '../restrictionPredicates';
 import { updateMemory } from './BotMemory';
+import { isWinCompleting } from './winCompletion';
 
 // ── Tunables ───────────────────────────────────────────────────────────
 
@@ -80,6 +81,15 @@ export function classifyGamePhase(
 export const PRUNE_MAX_TURNS = 12;
 export const PRUNE_MAX_BUILD_M = 130;
 export const HOP_AVG_COST_M = 1.3;
+
+/**
+ * JIRA-255 Layer B: Hard ceiling on turn count for win-completing candidates
+ * exempted from the standard PRUNE_MAX_TURNS gate when endGameLocked is true.
+ * Guards against pathological estimates (e.g., 50-turn candidates that the
+ * estimator overestimates due to ferry half-rate or alpine rerouting).
+ * Value 25: covers realistic 14-18 turn win-completers with headroom.
+ */
+export const WIN_COMPLETING_MAX_TURNS = 25;
 
 /**
  * Cap on chained-follow-up search per c1 in computeAggregateScore.
@@ -944,6 +954,11 @@ export function enumerateCandidates(
  * Graph-aware spatial prune: compute turn + build estimates using PathCostEstimator.
  * Returns keep=false if either threshold is exceeded or any leg is unreachable.
  * JIRA-230 BE-003: replaced hex-distance sum with iterated estimateGraphPathCost calls.
+ *
+ * JIRA-255 Layer B: When memory.endGameLocked is true, candidates that exceed
+ * pruneMaxTurns are NOT discarded if they are win-completing and their estimated
+ * turns are within WIN_COMPLETING_MAX_TURNS. This allows the bot to consider
+ * longer routes when a single delivery would lock in a win.
  */
 export function cheapPrune(
   candidate: Candidate,
@@ -951,6 +966,8 @@ export function cheapPrune(
   speed: number,
   opts: ResolvedOptions,
   snapshot: WorldSnapshot,
+  memory?: Pick<BotMemoryState, 'endGameLocked'>,
+  context?: Pick<GameContext, 'unconnectedMajorCities' | 'connectedMajorCities'>,
 ): { keep: boolean; estTurns: number; estBuild: number } {
   let totalBuild = 0;
   let totalTurns = 0;
@@ -975,8 +992,27 @@ export function cheapPrune(
   }
   const estTurns = Math.max(1, totalTurns);
   const estBuild = totalBuild;
-  const keep = estTurns <= opts.pruneMaxTurns && estBuild <= opts.pruneMaxBuildM;
-  return { keep, estTurns, estBuild };
+
+  // Standard gate: drop anything exceeding turn or build threshold.
+  if (estTurns <= opts.pruneMaxTurns && estBuild <= opts.pruneMaxBuildM) {
+    return { keep: true, estTurns, estBuild };
+  }
+
+  // JIRA-255 Layer B: end-game carve-out for win-completing candidates.
+  // Only active when endGameLocked=true and the turn count is under the hard ceiling.
+  if (
+    memory?.endGameLocked &&
+    estTurns <= WIN_COMPLETING_MAX_TURNS
+  ) {
+    const unconnectedMajors = context?.unconnectedMajorCities ?? [];
+    const cmcCount = context?.connectedMajorCities?.length ?? 0;
+    const candidateNet = candidate.payout - estBuild;
+    if (isWinCompleting(snapshot.bot.money, candidateNet, unconnectedMajors, cmcCount)) {
+      return { keep: true, estTurns, estBuild };
+    }
+  }
+
+  return { keep: false, estTurns, estBuild };
 }
 
 // ── Simulation scoring (R6, R7) ────────────────────────────────────────
@@ -1691,7 +1727,7 @@ export function planTripDeterministic(
         }
       }
     }
-    const { keep, estTurns, estBuild } = cheapPrune(cand, startPos, speed, opts, snapshot);
+    const { keep, estTurns, estBuild } = cheapPrune(cand, startPos, speed, opts, snapshot, memory, context);
     if (keep) {
       survivors.push(cand);
     } else {
@@ -1832,12 +1868,46 @@ export function planTripDeterministic(
     }
   }
 
-  // Sort by aggregate score (rank key per JIRA-229) and pick top-1
-  const sorted = [...feasible].sort((a, b) => {
-    if (b.aggregateScore !== a.aggregateScore) return b.aggregateScore - a.aggregateScore;
-    if (b.net !== a.net) return b.net - a.net;
-    return a.id.localeCompare(b.id);
-  });
+  // JIRA-255 Layer C: end-game two-tier ranking override.
+  // When endGameLocked=true, sort win-completing candidates first (by fewest turns),
+  // then non-completers (by velocity). If no completers exist, fall back to the
+  // standard aggregateScore ranking for all candidates.
+  let sorted: ScoredCandidate[];
+  if (memory.endGameLocked) {
+    const unconnectedMajors = context.unconnectedMajorCities ?? [];
+    const cmcCount = context.connectedMajorCities?.length ?? 0;
+    const completers = feasible.filter(
+      (c) => isWinCompleting(snapshot.bot.money, c.net, unconnectedMajors, cmcCount),
+    );
+    const nonCompleters = feasible.filter(
+      (c) => !isWinCompleting(snapshot.bot.money, c.net, unconnectedMajors, cmcCount),
+    );
+    if (completers.length > 0) {
+      // Among win-completers: fewest turns first (game-winning objective).
+      completers.sort((a, b) => a.turns !== b.turns ? a.turns - b.turns : a.id.localeCompare(b.id));
+      // Non-completers follow, ranked by velocity (existing rule).
+      nonCompleters.sort((a, b) => {
+        if (b.aggregateScore !== a.aggregateScore) return b.aggregateScore - a.aggregateScore;
+        if (b.net !== a.net) return b.net - a.net;
+        return a.id.localeCompare(b.id);
+      });
+      sorted = [...completers, ...nonCompleters];
+    } else {
+      // No win-completers in this candidate set — fall back to velocity ranking.
+      sorted = [...feasible].sort((a, b) => {
+        if (b.aggregateScore !== a.aggregateScore) return b.aggregateScore - a.aggregateScore;
+        if (b.net !== a.net) return b.net - a.net;
+        return a.id.localeCompare(b.id);
+      });
+    }
+  } else {
+    // Standard sort by aggregate score (rank key per JIRA-229)
+    sorted = [...feasible].sort((a, b) => {
+      if (b.aggregateScore !== a.aggregateScore) return b.aggregateScore - a.aggregateScore;
+      if (b.net !== a.net) return b.net - a.net;
+      return a.id.localeCompare(b.id);
+    });
+  }
   const top1 = pickTop1(sorted)!;
 
   // JIRA-232 Defect B: emit predicted build cost for post-game diff against actual.

--- a/src/server/services/ai/DeterministicTripPlanner.ts
+++ b/src/server/services/ai/DeterministicTripPlanner.ts
@@ -37,7 +37,7 @@ import {
 import { cheapestUnconnectedMajorConnectorCost } from './victoryRules';
 import { getCityMilepointKey, isPickupDeliveryBlocked } from '../restrictionPredicates';
 import { updateMemory } from './BotMemory';
-import { isWinCompleting } from './winCompletion';
+import { isWinCompleting, fullWinCost } from './winCompletion';
 
 // ── Tunables ───────────────────────────────────────────────────────────
 
@@ -1410,6 +1410,13 @@ function synthesizeReasoning(
   opts: ResolvedOptions,
   supplyDiffLines?: string[],
   enumerationMs?: number,
+  endGameContext?: {
+    endGameLocked: boolean;
+    fullWinCostM: number;
+    isTop1WinCompleting: boolean;
+    projectedCash: number;
+    winCompleterCount: number;
+  },
 ): string {
   const pattern = inferPatternLabel(top1);
   const stopsStr = top1.stops
@@ -1435,6 +1442,15 @@ function synthesizeReasoning(
   }
   reasoning += `  Stops: ${stopsStr}\n`;
   reasoning += `  Rationale: ${patternExplanation}\n`;
+
+  // JIRA-255 Layer D: end-game annotation — only emit when active to avoid log noise.
+  if (endGameContext?.endGameLocked) {
+    if (endGameContext.isTop1WinCompleting) {
+      reasoning += `  End-game: win-completer (projected $${endGameContext.projectedCash.toFixed(0)}M cash, full win cost $${endGameContext.fullWinCostM.toFixed(0)}M); ranked by fewest turns.\n`;
+    } else {
+      reasoning += `  End-game: locked (full win cost $${endGameContext.fullWinCostM.toFixed(0)}M); no win-completers in set (${endGameContext.winCompleterCount}); velocity ranking applied.\n`;
+    }
+  }
 
   // JIRA-230 BE-003: chosen-supply surface lines
   if (supplyDiffLines && supplyDiffLines.length > 0) {
@@ -1945,13 +1961,33 @@ export function planTripDeterministic(
     }
   }
 
+  // JIRA-255 Layer D: compute end-game context for diagnostic emit.
+  // Only when endGameLocked to avoid computing fullWinCost on every non-end-game turn.
+  let endGameContext: Parameters<typeof synthesizeReasoning>[6] | undefined;
+  if (memory.endGameLocked) {
+    const egUnconnected = context.unconnectedMajorCities ?? [];
+    const egCmcCount = context.connectedMajorCities?.length ?? 0;
+    const egFullWinCostM = fullWinCost(egUnconnected, egCmcCount);
+    const egWinCompleterCount = feasible.filter(
+      (c) => isWinCompleting(snapshot.bot.money, c.net, egUnconnected, egCmcCount),
+    ).length;
+    const egIsTop1Completing = isWinCompleting(snapshot.bot.money, top1.net, egUnconnected, egCmcCount);
+    endGameContext = {
+      endGameLocked: true,
+      fullWinCostM: egFullWinCostM,
+      isTop1WinCompleting: egIsTop1Completing,
+      projectedCash: snapshot.bot.money + top1.net,
+      winCompleterCount: egWinCompleterCount,
+    };
+  }
+
   const latencyMs = Date.now() - startMs;
   const upgradeNote = upgradeOnRoute
     ? `\n  Upgrade emitted: ${upgradeOnRoute} (cost ${UPGRADE_COST_M}M, cash ${snapshot.bot.money}M, build ${top1.buildCost}M).`
     : upgradeDecision.gateReason
       ? `\n  Upgrade skipped: ${upgradeDecision.gateReason}.`
       : '';
-  const reasoning = synthesizeReasoning(top1, sorted, stats, opts, supplyDiffLines, enumerationMs) + upgradeNote;
+  const reasoning = synthesizeReasoning(top1, sorted, stats, opts, supplyDiffLines, enumerationMs, endGameContext) + upgradeNote;
   const route = buildStrategicRoute(top1, snapshot.turnNumber, reasoning, upgradeOnRoute);
 
   return {

--- a/src/server/services/ai/DeterministicTripPlanner.ts
+++ b/src/server/services/ai/DeterministicTripPlanner.ts
@@ -36,6 +36,7 @@ import {
 } from '../../../shared/types/GameTypes';
 import { cheapestUnconnectedMajorConnectorCost } from './victoryRules';
 import { getCityMilepointKey, isPickupDeliveryBlocked } from '../restrictionPredicates';
+import { updateMemory } from './BotMemory';
 
 // ── Tunables ───────────────────────────────────────────────────────────
 
@@ -1605,6 +1606,26 @@ export function planTripDeterministic(
     hopAvgCostM: options?.hopAvgCostM ?? HOP_AVG_COST_M,
     excludeRouteSignatures: new Set(options?.excludeRouteSignatures ?? []),
   };
+
+  // JIRA-255 Layer A: End-game lock hook.
+  // Once set, endGameLocked is sticky (one-way) — it never reverts even after
+  // temporary cash dips from track building. Whichever condition fires first
+  // sets the lock for the remainder of the game.
+  if (!memory.endGameLocked) {
+    const cmcCount = context.connectedMajorCities?.length ?? 0;
+    const phase = classifyGamePhase(
+      snapshot.turnNumber,
+      memory.deliveryCount,
+      cmcCount,
+    );
+    if (snapshot.bot.money > 200 || phase === 'late') {
+      memory.endGameLocked = true;
+      // Persist asynchronously — in-memory mutation is authoritative for this turn.
+      updateMemory(snapshot.gameId, snapshot.bot.playerId, { endGameLocked: true }).catch(
+        (err: unknown) => console.warn('[planTripDeterministic] Failed to persist endGameLocked:', err),
+      );
+    }
+  }
 
   // Empty hand check (R8)
   if (!context.demands || context.demands.length === 0) {

--- a/src/server/services/ai/GameLogger.ts
+++ b/src/server/services/ai/GameLogger.ts
@@ -176,6 +176,15 @@ export interface GameTurnLogEntry {
   // Populated on every bot turn that runs checkBotVictory; omitted when check was skipped.
   victoryCheck?: VictoryCheckResult;
 
+  // JIRA-255: End-game routing diagnostics.
+  // Only populated when end-game routing is active (endGameLocked=true) to prevent log noise.
+  /** True when the end-game lock is active for this turn; absent when not engaged. */
+  endGameLocked?: boolean;
+  /** Minimum cash required to win (ECU millions) including cheapest unconnected major city connections. */
+  fullWinCost?: number;
+  /** Number of candidates in the feasible set that would complete the win condition. */
+  winCompleterCount?: number;
+
   // Execution Results
   success: boolean;
   error?: string;

--- a/src/server/services/ai/PathCostEstimator.ts
+++ b/src/server/services/ai/PathCostEstimator.ts
@@ -183,9 +183,11 @@ function computePathCost(
 
   for (const fromCoord of fromCoords) {
     for (const toCoord of toCoords) {
-      // Skip trivial same-point case early
+      // Skip trivial same-point case early.
+      // Same-city pickups/deliveries consume zero turns per game rules — the
+      // train is already at the location, so no movement is required.
       if (fromCoord.row === toCoord.row && fromCoord.col === toCoord.col) {
-        const trivial: PathCost = { buildCost: 0, pathLength: 1, estimatedTurns: 1, reachable: true, newSegments: [] };
+        const trivial: PathCost = { buildCost: 0, pathLength: 1, estimatedTurns: 0, reachable: true, newSegments: [] };
         if (bestResult === null || trivial.pathLength < bestResult.pathLength) {
           bestResult = trivial;
         }

--- a/src/server/services/ai/winCompletion.ts
+++ b/src/server/services/ai/winCompletion.ts
@@ -1,0 +1,90 @@
+/**
+ * winCompletion.ts
+ *
+ * Pure-function helper module for end-game win-completion math.
+ * Centralises the win-cost calculation and the win-completer predicate
+ * so they can be reused by cheapPrune (carve-out gate) and the rank
+ * pass (two-tier sort key) without duplicating logic.
+ *
+ * The lock that activates end-game routing is one-way (sticky): once
+ * endGameLocked is set on BotMemoryState it never unsets, even if
+ * the bot temporarily dips below the threshold due to track builds.
+ * This module contains no I/O and no state — it is pure math.
+ */
+
+/**
+ * Cash threshold in ECU millions required to win the game.
+ * A bot must hold at least this much cash AND have a continuous line
+ * of track connecting 7 major cities to declare victory.
+ */
+export const CASH_WIN_THRESHOLD_M = 250;
+
+/**
+ * Calculate the total cash a bot needs in order to win the game,
+ * taking into account the track still needed to connect the remaining
+ * major cities.
+ *
+ * Algorithm:
+ *  1. Determine how many more major cities still need to be connected:
+ *     `remaining = 7 - cmcCount`.
+ *  2. If `remaining <= 0` (all 7 already connected), no track cost is
+ *     required — return `CASH_WIN_THRESHOLD_M`.
+ *  3. Otherwise, sort `unconnectedMajors` by `estimatedCost` ascending
+ *     and sum the cheapest `remaining` entries.
+ *  4. Return `CASH_WIN_THRESHOLD_M + sumOfCheapestRemainingCosts`.
+ *
+ * @param unconnectedMajors - Array of major cities not yet on the bot's
+ *   network, each with an `estimatedCost` in ECU millions (from
+ *   `NetworkContext.computeUnconnectedMajorCities`).
+ * @param cmcCount - Number of major cities currently connected to the
+ *   bot's network.
+ * @returns The minimum cash (ECU millions) the bot needs to pay both the
+ *   cash win threshold and all remaining track connection costs.
+ */
+export function fullWinCost(
+  unconnectedMajors: Array<{ cityName: string; estimatedCost: number }>,
+  cmcCount: number,
+): number {
+  const remaining = Math.max(0, 7 - cmcCount);
+  if (remaining === 0 || unconnectedMajors.length === 0) {
+    return CASH_WIN_THRESHOLD_M;
+  }
+
+  // Sort ascending by estimatedCost so we take the cheapest connections first.
+  const sorted = [...unconnectedMajors].sort((a, b) => a.estimatedCost - b.estimatedCost);
+  const slice = sorted.slice(0, remaining);
+  const trackCost = slice.reduce((sum, m) => sum + m.estimatedCost, 0);
+
+  return CASH_WIN_THRESHOLD_M + trackCost;
+}
+
+/**
+ * Determine whether a candidate route would complete the win condition
+ * if executed — i.e., would the bot have enough cash after collecting
+ * the payout AND spending on remaining track connections?
+ *
+ * Formula:
+ *   `(currentCash + candidateNet) >= fullWinCost(unconnectedMajors, cmcCount)`
+ *
+ * Note: `candidateNet` must already account for track building costs
+ * along the route itself. The `fullWinCost` tracks only the connection
+ * costs for major cities not yet reachable via the candidate route.
+ *
+ * @param currentCash - Bot's current cash balance in ECU millions.
+ * @param candidateNet - Net income from the candidate route (payout minus
+ *   estimated build costs along the route) in ECU millions.
+ * @param unconnectedMajors - Major cities not yet connected, each with an
+ *   `estimatedCost` (from `NetworkContext.computeUnconnectedMajorCities`).
+ * @param cmcCount - Number of major cities currently connected.
+ * @returns `true` if executing this candidate would leave the bot with
+ *   enough resources to win; `false` otherwise.
+ */
+export function isWinCompleting(
+  currentCash: number,
+  candidateNet: number,
+  unconnectedMajors: Array<{ cityName: string; estimatedCost: number }>,
+  cmcCount: number,
+): boolean {
+  const required = fullWinCost(unconnectedMajors, cmcCount);
+  return currentCash + candidateNet >= required;
+}

--- a/src/shared/types/GameTypes.ts
+++ b/src/shared/types/GameTypes.ts
@@ -610,6 +610,13 @@ export interface BotMemoryState {
      * Format: Array<{ key: string; abandonedAtTurn: number }>
      */
     recentlyAbandonedRouteKeys?: Array<{ key: string; abandonedAtTurn: number }>;
+    /**
+     * JIRA-255: Sticky end-game routing flag. Once set true (cash > 200M OR classifyGamePhase
+     * returns 'late'), never reverts — even after temporary cash dips from track building.
+     * When true, the trip planner switches from per-turn velocity ranking to fewest-turns-
+     * to-victory ranking for win-completing candidates.
+     */
+    endGameLocked?: boolean;
 }
 
 /** Simplified option summary for decision logging */


### PR DESCRIPTION
## Summary

**Stacked on PR #256** (JIRA-253) because JIRA-255's `TripPlanner.ts` / `routeHelpers.ts` / `PathCostEstimator.ts` changes were authored on top of JIRA-253's livelock fixes. Cherry-picked clean off `fix/jira-248-253-carried-load-bot`.

When the bot's cash crossed the end-game threshold (~$200M+) but the route scoring still ranked by ECU-per-turn, the planner would chase another delivery cycle instead of completing the city-connection track needed for victory. This PR adds five layers:

| Layer | What |
|---|---|
| **BE-001** | New `winCompletion` helper module — predicts whether a remaining-route plan can clinch victory given current cash + connected major cities |
| **BE-002** | Wire end-game lock mechanism in planner — once latched, planner restricts to win-completion-aware candidates |
| **BE-003** | End-game prune carve-out + two-tier ranking in `cheapPrune` — route candidates that complete the win are floated above pure ECU-per-turn winners |
| **BE-004** | Correct same-point `estimatedTurns` to 0 in `PathCostEstimator` (Layer 0 — same-city phantom turn no longer inflates win-route estimates) |
| **BE-005** | End-game diagnostic logging in `reasoning` strings — so post-mortems show why the win-completion ranking fired |

Plus a test mock alignment (`166e6a4`) for `simulateTrip`'s current `TripSimulation` shape.

## Per-ticket docs
- `docs/ai/done/jira-255-endGamePhaseLogicNotWired-behavioral.md`
- `docs/ai/done/jira-255-endGamePhaseLogicNotWired-technical.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full suite green: **3898 pass, 24 skipped, 0 fail**
- [ ] Once PR #255 and PR #256 merge, retarget base to `main`

**Base**: `pr/jira-253` (PR #256). Stacked: PR-9 → PR-10 → PR-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)