### PR TITLE
feat(ai): JIRA-265 — end-game state per-turn visibility + lock-engagement fix (3 layers)

### DIFF
--- a/docs/ai/done/jira-265-endGameStateNoPerTurnVisibilityAndLockNotEngaged-behavioral.md
+++ b/docs/ai/done/jira-265-endGameStateNoPerTurnVisibilityAndLockNotEngaged-behavioral.md
@@ -1,0 +1,80 @@
+# JIRA-265 — End-game state has no per-turn NDJSON visibility; the `memory.endGameLocked` ranking carve-out doesn't appear to engage during execution turns; in game 086fa2ce s1, `gameState=end` correctly latched at T61 but the bot took 18 more turns to win, with no observable end-game logic firing for 6 of the 7 final turns (behavioral)
+
+In game `086fa2ce-a6c9-4a88-b91a-9653fc7fdcf9` (all-bot Haiku match), player s1 (superfreight) reached cash > $200M at T61 and `gameState=end` correctly latched. From that turn through T79 (the winning turn), the per-turn NDJSON log surfaces almost no information about (a) what the bot needs to win, (b) what its plan is to get there, or (c) whether the existing end-game ranking carve-out (`memory.endGameLocked` per JIRA-255) is engaged. The displayed `gamePhase` field continues to show `Mid Game` even at cash $255M because the display computation is dominated by major-city count rather than the latched end-game state. Between T72 (7 majors connected, cash $218M, gap of $32M to win) and T79 (cash $259M, declared), the bot executed a `[route-executor]` route for 6 turns with no end-game-specific replan visible — and the one winning replan at T79 chose a `triple-3fresh` with **NET aggregate score of −0.33 M/turn over 17 turns**, which is the antithesis of "win the game quickly".
+
+## Source
+
+`logs/game-086fa2ce-a6c9-4a88-b91a-9653fc7fdcf9.ndjson`, player s1 turns T60–T79. Discovered 2026-05-25 — user-reported.
+
+## End-game phase concepts in this codebase
+
+There are **three independent "end-game" mechanisms** and they don't align. Understanding which one fires when is a prerequisite for any end-game diagnosis.
+
+| Mechanism | Source file:fn | Trigger | What it gates |
+|---|---|---|---|
+| `context.gameState: 'end'` | `ContextBuilder.computeGameState` (via `victoryRules.ts:57`) | cash > $200M (latches forever) OR turn ≥ 26 (mid) / ≥ 4 (early) | `findFinalVictoryRoute` call at `AIStrategyEngine.ts:302`; `applyEndStateScoring` entry condition at `DeterministicTripPlanner.ts:1886` |
+| `context.gamePhase: 'Mid Game'/'Late Game'/'Victory Imminent'` | `NetworkContext.computePhase` | Hybrid majors+cash thresholds: 6+ majors AND $230, or 5+ AND $250, or 5+ AND $150, or 3+ majors / $80M | Display only (NDJSON `.gamePhase` field, LLM prompt text) |
+| `memory.endGameLocked: boolean` | `DeterministicTripPlanner.ts:1671-1684` (inside `planTripDeterministic`) | cash > $200M OR `classifyGamePhase==='late'` (5+ majors OR turn ≥ 80) | `cheapPrune` turn-cap exemption (`:1009`); win-completer-first ranking (`:1897`); `endGameContext` reasoning annotation (`:1972`) |
+
+`gameState=end` and `endGameLocked` use the same `$200M` trigger but live in different objects and update at different times. `gamePhase` uses entirely different thresholds and is just a UI label.
+
+## Trace — s1, game 086fa2ce, T60–T79
+
+| Turn | cash | gameState | gamePhase | majors | victoryCheck | endGameLocked (NDJSON) | reasoning highlight |
+|------|------|-----------|-----------|--------|--------------|------------------------|---------------------|
+| T60 | 222 | mid | Mid Game | 4 (Milano, Ruhr, Berlin, London) | insufficient-funds | null | — |
+| T61 | 222 | **end** | Mid Game | 4 | insufficient-funds | null | `gameState` latched here |
+| T62–T64 | 222 | end | Mid Game | 4 | insufficient-funds | null | `[route-executor]` |
+| T65 | 255 | end | Mid Game | 4 | **too-few-cities** | null | cash crossed $250M; needs 3 majors |
+| T66–T67 | 255 | end | Mid Game | 4 | too-few-cities | null | `[route-executor]` |
+| T68 | 247 | end | Mid Game | 4 | insufficient-funds | null | BuildTrack — spent $8M |
+| T69 | 247 | end | Late Game | 5 (Paris connected) | insufficient-funds | null | — |
+| T70 | 240 | end | Late Game | 5 | insufficient-funds | null | BuildTrack — spent $7M |
+| T71 | 227 | end | Victory Imminent | 6 (Holland connected) | insufficient-funds | null | BuildTrack — spent $13M |
+| T72 | 218 | end | Late Game | 7 (Wien connected) | insufficient-funds | null | BuildTrack — spent $9M; **7 majors achieved, +$32M cash needed** |
+| T73 | 218 | end | Late Game | 7 | insufficient-funds | null | `[route-executor]` |
+| T74 | 218 | end | Late Game | 7 | insufficient-funds | null | `[route-executor]` |
+| T75 | 237 | end | Late Game | 7 | insufficient-funds | null | `[route-executor]` + replan: `[final-victory] Steel→Warszawa, Copper→Antwerpen, turns=15, build=30M, payout=38M, cash@victory=255M, majors@victory=7` — but routesMatch suppressed override (existing 4-stop route shared first stop) |
+| T76 | 228 | end | Victory Imminent | 7 | insufficient-funds | null | new route `[deliver:Cardiff(Copper)]` (post-delivery replan picked Copper→Cardiff over Copper→Antwerpen) |
+| T77 | 228 | end | Late Game | 7 | insufficient-funds | null | `[route-executor]` |
+| T78 | 228 | end | Late Game | 7 | insufficient-funds | null | `[route-executor]` |
+| T79 | 259 | end | Late Game | 7 | **declared** | null | delivered Copper@Cardiff (+$31M) → won. Post-delivery replan picked `triple:Imports+Cheese+Copper:3f-ABC`, **NET 36M over 17 turns, aggregate −0.33 M/turn** |
+
+## Observable problems
+
+1. **`endGameLocked` is null in every turn-log entry.** The flag is set inside `planTripDeterministic` (line 1679), which runs only on replan turns (`no-active-route` or post-delivery). For T60–T78 most turns are pure `[route-executor]` execution — no replan, no planTripDeterministic call, no chance to set the flag. `GameLogger` reads it from somewhere that's always seeing the pre-planner value. Either the lock latch is in the wrong place, or the log capture is in the wrong place, or both.
+
+2. **No per-turn visibility of `cashGap`, `majorsGap`, full win cost, or victory-route projection.** The `victoryCheck.outcome` field tells you the result (insufficient-funds / too-few-cities / declared) but not the deltas or the cost to close them. The only places the deltas appear in the NDJSON are:
+   - Inside `[final-victory]` reasoning strings, which only emit when `findFinalVictoryRoute` returns a non-null route AND the override applies.
+   - Inside `End-game: ...` reasoning annotations from `synthesizeReasoning`, which only emit when `endGameLocked=true` AND `planTripDeterministic` runs (per #1, rarely).
+
+   Result: from the NDJSON alone you cannot answer "at T73, how much cash and how many majors does the bot need, and what's its plan to get them?"
+
+3. **`gamePhase` display field disagrees with `gameState` at the relevant junctures.** At T65 cash=$255M (over victory threshold!) but gamePhase shows "Mid Game" because s1 only has 4 majors. The user sees `Mid Game | Cash: 255M` and reasonably concludes the bot doesn't understand the game state.
+
+4. **End-game ranking carve-out did not fire for T76–T78 turn-execution.** The Cardiff route was picked by a post-delivery replan at T75/T76. With endGameLocked engaged, win-completer ranking (line 1897) sorts cash-completing candidates first by fewest turns. The Cardiff route did complete the win ($228 + $31 = $259), so it WAS win-completing — but the bot then spent T76, T77, T78 traveling to Cardiff (3 turns of no payout) when there was already $228M cash and the closest delivery would have clinched. A win-completer ranking by **fewest turns to completion** would have preferred any deliverable load with a destination 1–2 turns away over a 3-turn trip to Cardiff. We can't tell from the log whether the win-completer ranking ran at all (endGameLocked null).
+
+5. **The T79 winning-turn replan picked a NEGATIVE-aggregate plan.** `triple:Imports+Cheese+Copper, NET 36M over 17 turns, aggregate −0.33 M/turn`. The plan starts with three pickup stops in Antwerpen, Bern, Wroclaw — geographically scattered. In normal play the scorer would never pick this. In end-game play (with endGameLocked engaged) the win-completer-first rule should have picked something different. Whatever fired here, it didn't optimize for victory. The fact that s1 won this turn is incidental — the planner's choice was a fall-back, not a deliberate victory plan.
+
+## Expected behavior
+
+For every turn where `gameState==='end'`, the NDJSON entry should expose a structured `endGame` object (or equivalent flat fields) with at minimum:
+
+- `endGameLocked: boolean` — current value of `memory.endGameLocked` (after this turn's update)
+- `cashGap: number` — `max(0, 250 - cash)` in ECU M
+- `majorsGap: number` — `max(0, 7 - connectedMajorCities.length)`
+- `cheapestConnectors: Array<{cityName, costM}>` — the cheapest `majorsGap` unconnected majors needed to win
+- `fullWinCostM: number` — `cashGap + sum(cheapestConnectors.costM)`
+- `victoryRouteProjection: { stops?, turns?, buildM?, payoutM?, cashAtVictory?, majorsAtVictory? } | { skipReason: 'no_demands' | 'victory_met' | 'no_feasible_demands' | 'no_route_covers_gap' }` — the per-turn output of `findFinalVictoryRoute`, whether or not the override fires
+- `activePlanProjection: { willClinch: boolean, projectedCash?, projectedMajors?, turnsRemaining? }` — whether the bot's current `activeRoute` (if any) will clinch on completion, and the projected end-state if so
+
+A reader of the NDJSON should be able to answer per turn: "is the bot in end-game state? what does it need? what's its plan to get there? is that plan actually going to win, and when?"
+
+Beyond visibility, two behavioral observations need root-cause work:
+
+- (5) above: the end-game ranking carve-out either didn't fire or didn't favor faster-clinch routes. With (1) fixed (visibility), the next investigation can answer "why".
+- The `gamePhase` display field should align with `gameState` once the latch fires. At minimum, `gamePhase` should never show "Mid Game" when `gameState==='end'`.
+
+## Not in scope (single-game observation; visibility-first)
+
+This is one observation in one game. No generalization beyond "the per-turn NDJSON lacks end-game visibility" and "`endGameLocked` doesn't visibly engage on execution turns". Broader scoring or ranking changes require corroborating observations across games after the visibility fix lands and the operator can see what's actually happening.

--- a/docs/ai/done/jira-265-endGameStateNoPerTurnVisibilityAndLockNotEngaged-technical.md
+++ b/docs/ai/done/jira-265-endGameStateNoPerTurnVisibilityAndLockNotEngaged-technical.md
@@ -1,0 +1,215 @@
+# JIRA-265 — Surface per-turn end-game state into NDJSON via a new `composition.endGame` field; move the `endGameLocked` latch from `planTripDeterministic` into `ContextBuilder` so it engages on every turn (not just replan turns); align `gamePhase` display with `gameState=end` (technical)
+
+Companion to `jira-265-endGameStateNoPerTurnVisibilityAndLockNotEngaged-behavioral.md`.
+
+Three coordinated changes. Layer 1 (visibility) is the must-have and unblocks future investigation. Layer 2 (latch placement) is the root-cause fix for "endGameLocked is null in every log entry". Layer 3 (display alignment) prevents the confusing "Mid Game | Cash: 255M" output.
+
+## Layer 1 — Per-turn `composition.endGame` field in NDJSON
+
+**Defect locus.** `src/server/services/ai/GameLogger.ts` (`GameTurnLogEntry` shape); `src/server/services/ai/AIStrategyEngine.ts` (turn-log build site around `:1019-1021`); `src/server/services/ai/victoryRules.ts` (`findFinalVictoryRoute` — return shape needs to expose skip reasons for the null path).
+
+### Step 1a — Change `findFinalVictoryRoute` return shape
+
+Currently returns `FinalVictoryRoute | null`. Change to a discriminated union:
+
+```ts
+// victoryRules.ts
+export type FinalVictoryOutcome =
+  | { outcome: 'fire'; route: FinalVictoryRoute }
+  | { outcome: 'skip'; reason: 'no_demands' | 'victory_met' | 'no_feasible_demands' | 'no_route_covers_gap'; cashGap?: number; connectorCost?: number; majorsGap?: number };
+
+export function findFinalVictoryRoute(...): FinalVictoryOutcome { ... }
+```
+
+The four `console.log('[final-victory] skip: ...')` lines (332, 344, 364, 461) become carried-through structured returns. The lines themselves can stay (cheap interactive debugging) but the caller now has the structured reason too.
+
+Caller at `AIStrategyEngine.ts:302` updates from `if (finalVictoryRoute) { ... }` to `if (result.outcome === 'fire') { ... }` etc.
+
+### Step 1b — Define `EndGameTrace` shape
+
+```ts
+// shared/types/GameTypes.ts (or a new endGameTrace.ts)
+export interface EndGameTrace {
+  /** True when context.gameState === 'end'. False otherwise; the rest of the fields may be omitted. */
+  inEndGame: boolean;
+  /** Current value of memory.endGameLocked (after this turn's mutation, if any). */
+  endGameLocked: boolean;
+  /** Cash gap to victory threshold ($250M): max(0, 250 - cash). */
+  cashGapM: number;
+  /** Major-city gap to victory (7 connected): max(0, 7 - connectedCount). */
+  majorsGap: number;
+  /** The cheapest majorsGap unconnected majors needed to close the city condition. Each entry's costM is estimateTrackCost from current network. */
+  cheapestConnectors: Array<{ cityName: string; costM: number }>;
+  /** cashGapM + sum(cheapestConnectors.costM) — the total build-and-earn required to win. */
+  fullWinCostM: number;
+  /** Per-turn output of findFinalVictoryRoute. fire = override candidate; skip = reason for not finding one. */
+  victoryRouteProjection:
+    | { outcome: 'fire'; stops: string[]; turns: number; buildM: number; payoutM: number; cashAtVictory: number; majorsAtVictory: number; appliedOverride: boolean }
+    | { outcome: 'skip'; reason: string };
+  /** Whether the bot's current activeRoute (if any) will clinch on completion. Computed from the route's projected cash + connector deliveries. */
+  activePlanProjection?: {
+    willClinch: boolean;
+    projectedCash: number;
+    projectedMajors: number;
+    turnsRemaining: number;
+  };
+}
+```
+
+### Step 1c — Populate per turn in `AIStrategyEngine`
+
+In `AIStrategyEngine.takeTurn` (or wherever the turn-log entry is constructed), compute `endGameTrace` once per turn:
+
+```ts
+const inEndGame = context.gameState === GameState.End;
+let endGameTrace: EndGameTrace | undefined;
+if (inEndGame) {
+  const cashGapM = Math.max(0, 250 - context.money);
+  const majorsGap = Math.max(0, 7 - context.connectedMajorCities.length);
+  const cheapestConnectors = context.unconnectedMajorCities
+    .slice(0, majorsGap)
+    .map(e => ({ cityName: e.cityName, costM: e.estimatedCost }));
+  const fullWinCostM = cashGapM + cheapestConnectors.reduce((s, c) => s + c.costM, 0);
+  const fvResult = findFinalVictoryRoute(snapshot, context, memory); // already called below; reuse
+  // Build projection from result; activePlanProjection from activeRoute if set.
+  endGameTrace = { inEndGame: true, endGameLocked: !!memory.endGameLocked, cashGapM, majorsGap, cheapestConnectors, fullWinCostM, victoryRouteProjection: ..., activePlanProjection: ... };
+}
+```
+
+Attach to the turn-log entry:
+
+```ts
+return {
+  ...existingTurnLogFields,
+  composition: { ...existingComposition, endGame: endGameTrace },
+};
+```
+
+After the fix, a reader can `jq -c 'select(.gameState=="end") | .composition.endGame' logs/game-<id>.ndjson` and see one structured object per turn.
+
+## Layer 2 — Move `endGameLocked` latch from `planTripDeterministic` to `ContextBuilder`
+
+**Defect locus.** `src/server/services/ai/DeterministicTripPlanner.ts:1671-1684` (current latch site, fires only on replan turns); `src/server/services/ai/ContextBuilder.ts` (target site, runs every turn alongside `computeGameState` for `gameState=end`).
+
+The current latch lives inside `planTripDeterministic`, which only runs on replan turns (no-active-route + post-delivery). On pure `[route-executor]` turns the latch never updates. For game 086fa2ce s1, planTripDeterministic ran on a handful of T68–T79 turns (build turns + T75 + T79); the other 15+ end-state turns never touched the lock.
+
+Move the latch to `ContextBuilder` — same place where `computeGameState` decides `gameState=end`:
+
+```ts
+// ContextBuilder.ts, right after computeGameState (~line 192)
+const gamePhase = computeGameState({ money, turnNumber }, memoryForPhase);
+const shouldLockEndGame = gamePhase === GameState.End ||
+  classifyGamePhase(turnNumber, deliveryCount, connectedMajorCities.length) === 'late';
+if (!memoryForPhase.endGameLocked && shouldLockEndGame) {
+  updateMemory(snapshot.gameId, snapshot.bot.playerId, { endGameLocked: true }).catch(...);
+  memoryForPhase.endGameLocked = true; // mutate in-place so downstream callers in this turn see true
+}
+```
+
+Then **remove the latch from `planTripDeterministic`** (lines 1671-1684) — it's redundant once ContextBuilder owns the source of truth. The downstream consumers (`cheapPrune`, `applyEndStateScoring`, win-completer ranking, reasoning annotation) all read `memory.endGameLocked` and will see the correct value regardless of whether planTripDeterministic runs.
+
+**Effect:** every turn in `gameState=end` (or `phase=late`) has `endGameLocked=true` from the moment ContextBuilder runs. The Layer 1 `endGameTrace.endGameLocked` field now reflects reality.
+
+Add a single ContextBuilder-emitted log line on the transition turn (similar to the existing `[game-state] ENTER End | ...` line in the local end-game logging branch — re-use that if it's already merged):
+
+```
+[end-game-lock] ENTER engaged at T<N>: cash=$<X>M, majors=<Y>/7, fullWinCost=$<Z>M
+```
+
+## Layer 3 — Align `gamePhase` display with `gameState=end`
+
+**Defect locus.** `src/server/services/ai/context/NetworkContext.ts:259-269` (`computePhase`).
+
+The display field never returns "End Game" — its ceiling is "Victory Imminent" (6+ majors AND $230, or 5+ AND $250). When `gameState=end` has latched at cash > $200M but the bot has only 3–4 majors, `gamePhase` rolls back down to "Mid Game" (3+ majors / $80M branch at line 267).
+
+Fix: when `gameState==='end'`, `gamePhase` should reflect that. Simplest change — pass `gameState` into `computePhase` (or compute display from a single source):
+
+```ts
+// NetworkContext.computePhase signature update
+static computePhase(snapshot: WorldSnapshot, connectedMajorCities: string[], gameState: GameState): string {
+  if (gameState === GameState.End) {
+    // Bot has reached end-game state (cash > $200M latched). Refine the display
+    // based on how close it actually is to victory.
+    if (connectedMajorCities.length >= 7 && snapshot.bot.money >= 250) return 'Victory Imminent';
+    if (connectedMajorCities.length >= 6 && snapshot.bot.money >= 230) return 'Victory Imminent';
+    return 'End Game';
+  }
+  // existing thresholds for Initial/Early/Mid/Late
+  ...
+}
+```
+
+Caller passes `gamePhase` from the already-computed `computeGameState` result. No new computation, just thread the value through.
+
+After this, the T65 log line in game 086fa2ce would read `End Game | Cash: 255M` instead of `Mid Game | Cash: 255M`, immediately telling a reader the bot is in end-state regardless of major count.
+
+## Acceptance criteria
+
+- **AC1 (Layer 1: trace populated)** Unit test on `AIStrategyEngine.takeTurn`: fixture with `context.gameState=GameState.End`, `cash=$210M`, `connectedMajorCities.length=4`, `unconnectedMajorCities=[Holland($20M), Paris($15M), Wien($25M), London($30M)]`. Assert the resulting turn-log entry has:
+  - `composition.endGame.inEndGame === true`
+  - `composition.endGame.cashGapM === 40`
+  - `composition.endGame.majorsGap === 3`
+  - `composition.endGame.cheapestConnectors` lists Paris/Holland/Wien (sorted ascending by cost), totaling $60M
+  - `composition.endGame.fullWinCostM === 100`
+
+- **AC2 (Layer 1: skip reason)** Unit test where `findFinalVictoryRoute` returns the `no_route_covers_gap` skip. Assert `composition.endGame.victoryRouteProjection === { outcome: 'skip', reason: 'no_route_covers_gap' }`.
+
+- **AC3 (Layer 1: fire path)** Unit test where `findFinalVictoryRoute` fires and the override applies. Assert `victoryRouteProjection.outcome === 'fire'` with all route fields populated and `appliedOverride === true`. (Also covered by JIRA-261 idempotency suppression path: `appliedOverride === false` when routesMatch suppresses.)
+
+- **AC4 (Layer 2: latch fires on execution-only turn)** Integration test: bot in `gameState=end` with no replan triggered (route-executor turn). Assert `memory.endGameLocked === true` after `ContextBuilder.build` returns, regardless of whether `planTripDeterministic` is called this turn.
+
+- **AC5 (Layer 2: latch sticky)** Same fixture as AC4 but starting with `memory.endGameLocked === true` and cash dipped to $150M (e.g., post-build dip). Assert `endGameLocked` remains `true` (sticky one-way).
+
+- **AC6 (Layer 3: display reflects end-game)** Unit test on `NetworkContext.computePhase` with `gameState=End`, 4 majors, cash $255M. Assert returns `'End Game'`. Same fixture with 7 majors + $250M → `'Victory Imminent'`. Same fixture with `gameState=Mid` → existing thresholds apply (Mid Game).
+
+- **AC7 (replay)** Replay s1 game 086fa2ce T60–T79. For each turn:
+  - T60: `endGame` undefined or `inEndGame=false`.
+  - T61–T79: `endGame.inEndGame === true`, `endGameLocked === true` (after Layer 2), `cashGapM` and `majorsGap` populated correctly.
+  - T75: `victoryRouteProjection.outcome === 'fire'` with `appliedOverride === false` (routesMatch suppresses; existing JIRA-261 behavior).
+  - T79: `endGame.activePlanProjection.willClinch === true` BEFORE the delivery completes.
+
+## Files touched
+
+- `src/server/services/ai/victoryRules.ts` — return-shape change for `findFinalVictoryRoute`; update callers.
+- `src/server/services/ai/ContextBuilder.ts` — add end-game-lock latch alongside `computeGameState`; thread `gamePhase` into the returned `GameContext`.
+- `src/server/services/ai/context/NetworkContext.ts` — `computePhase` takes `gameState` and returns `'End Game'` when latched.
+- `src/server/services/ai/AIStrategyEngine.ts` — construct `EndGameTrace` per turn; thread into turn-log composition.
+- `src/server/services/ai/DeterministicTripPlanner.ts` — remove the now-redundant latch block (lines 1671-1684); downstream consumers unchanged.
+- `src/server/services/ai/GameLogger.ts` — add `composition.endGame?: EndGameTrace` to `GameTurnLogEntry`.
+- `src/shared/types/GameTypes.ts` — declare `EndGameTrace` interface (or co-locate with victoryRules).
+- Tests: `src/server/__tests__/ai/AIStrategyEngine.endGameTrace.test.ts` (new), `src/server/__tests__/ai/ContextBuilder.endGameLock.test.ts` (new), and updates to existing `victoryRules.test.ts` for the return-shape change.
+
+## Diagnostic-value validation
+
+After the fix, the reader of any future game NDJSON can:
+
+```bash
+jq -c 'select(.gameState=="end") | {turn, cash, majors: (.connectedMajorCities|length), endGame: .composition.endGame}' \
+  logs/game-<id>.ndjson
+```
+
+and see one structured object per turn:
+
+```
+{"turn":61,"cash":222,"majors":4,"endGame":{"inEndGame":true,"endGameLocked":true,"cashGapM":28,"majorsGap":3,"cheapestConnectors":[...],"fullWinCostM":88,"victoryRouteProjection":{"outcome":"skip","reason":"no_route_covers_gap"},"activePlanProjection":{"willClinch":false,...}}}
+```
+
+The operator can then immediately spot:
+- Turns where the bot is in end-game but `victoryRouteProjection.outcome` is consistently `skip` — diagnostic for "why isn't `findFinalVictoryRoute` finding a route?"
+- Turns where `activePlanProjection.willClinch=false` — diagnostic for "the bot's current plan won't win; why hasn't it replanned?"
+- Turns where `endGameLocked=true` but the `[deterministic-top-1]` reasoning shows velocity-only ranking — diagnostic for "is the win-completer carve-out actually firing?"
+
+## Not in scope
+
+- Changes to the actual scoring/ranking math inside `applyEndStateScoring` or the win-completer comparator. The current ticket is visibility + latch placement. If post-fix logs show the carve-out is firing but picking suboptimal plans, that's a follow-up ticket with concrete evidence.
+- Surfacing `composition.endGame` into the debug UI overlay. Future work; this ticket adds the data only.
+- Backfill of past games. Going-forward only.
+- The `findFinalVictoryRoute` double-counting hypothesis from the previous draft of this ticket. The diagnostic test for that lives in this conversation but the bug exists in math that's hidden by the visibility gap; with Layer 1 in place, future investigation can confirm or refute on real game data. Not in scope for this ticket.
+
+## Cross-references
+
+- JIRA-241 — `gameState` latch in ContextBuilder. The new `endGameLocked` latch lives in the same place after Layer 2.
+- JIRA-245 — `findFinalVictoryRoute`. Return shape change (Layer 1) updates the caller contract.
+- JIRA-255 — `endGameLocked` was introduced inside `planTripDeterministic`. Layer 2 relocates it; the downstream consumers (`cheapPrune` carve-out, win-completer ranking, reasoning annotation) are unchanged.
+- JIRA-261 — `routesMatch` idempotency check. The `appliedOverride` field in `victoryRouteProjection` lets the reader distinguish "fired but suppressed" from "fired and applied", which is exactly the diagnostic the JIRA-261 behavioral doc wished for.
+- JIRA-262 — event-card observability gap (parallel `events.ndjson`). The shape this ticket adds is a per-turn structured field on the existing game log; the parallel-file approach from JIRA-262 is unnecessarily heavy for this case.

--- a/src/server/__tests__/ai/AIStrategyEngine.jira245.test.ts
+++ b/src/server/__tests__/ai/AIStrategyEngine.jira245.test.ts
@@ -387,7 +387,7 @@ jest.mock('../../services/ai/WorldSnapshotService', () => ({
 }));
 
 // ── Mock victoryRules to control findFinalVictoryRoute ───────────────────────
-import type { FinalVictoryRoute } from '../../services/ai/victoryRules';
+import type { FinalVictoryRoute, FinalVictoryOutcome } from '../../services/ai/victoryRules';
 
 const mockFindFinalVictoryRoute = jest.fn<() => FinalVictoryRoute | null>();
 
@@ -396,6 +396,17 @@ jest.mock('../../services/ai/victoryRules', () => {
   return {
     ...real,
     findFinalVictoryRoute: mockFindFinalVictoryRoute,
+    // JIRA-265: AIStrategyEngine now calls findFinalVictoryOutcome; mirror the
+    // mockFindFinalVictoryRoute return value into the outcome shape so existing
+    // mockReturnValueOnce(route) / mockReturnValueOnce(null) calls still drive
+    // the test behavior without re-writing every assertion.
+    findFinalVictoryOutcome: jest.fn<() => FinalVictoryOutcome>().mockImplementation(() => {
+      const r = mockFindFinalVictoryRoute();
+      if (r) {
+        return { outcome: 'fire', route: r, cashGap: 0, majorsGap: 0, connectorCost: 0 };
+      }
+      return { outcome: 'skip', reason: 'no_route_covers_gap' };
+    }),
   };
 });
 

--- a/src/server/__tests__/ai/ContextBuilder.test.ts
+++ b/src/server/__tests__/ai/ContextBuilder.test.ts
@@ -2,7 +2,7 @@ import { ContextBuilder } from '../../services/ai/ContextBuilder';
 import {
   GridPoint, TerrainType, TrackSegment, TrackNetwork,
   WorldSnapshot, BotSkillLevel, GameStatus,
-  GameState,
+  GameState, BotMemoryState,
 } from '../../../shared/types/GameTypes';
 import { buildTrackNetwork } from '../../../shared/services/TrackNetworkService';
 
@@ -4018,5 +4018,71 @@ describe('ContextBuilder.build — context.loads is independent of snapshot.bot.
     // snapshot.bot.loads must remain unchanged
     expect(snapshot.bot.loads).toEqual(['Steel']);
     expect(context.loads).toEqual(['Steel', 'Cheese']);
+  });
+});
+
+// ── JIRA-265 Layer 2: endGameLocked latch in ContextBuilder ─────────────────
+
+describe('ContextBuilder.build — endGameLocked latch (JIRA-265 Layer 2)', () => {
+  function makeMemoryWithLock(endGameLocked = false): BotMemoryState {
+    return {
+      currentBuildTarget: null,
+      turnsOnTarget: 0,
+      lastAction: null,
+      consecutiveDiscards: 0,
+      deliveryCount: 0,
+      totalEarnings: 0,
+      turnNumber: 0,
+      activeRoute: null,
+      turnsOnRoute: 0,
+      routeHistory: [],
+      lastReasoning: null,
+      lastPlanHorizon: null,
+      previousRouteStops: null,
+      consecutiveLlmFailures: 0,
+      endGameLocked,
+    };
+  }
+
+  it('JIRA-265 AC4: latches endGameLocked=true when cash > $200M on a route-executor turn (no replan needed)', async () => {
+    // Bot has $250M cash but no active route / no replan involved — pure
+    // ContextBuilder.build invocation, which is the path that runs every turn.
+    const snapshot = makeWorldSnapshot({
+      botMoney: 250,
+      botPosition: { row: 0, col: 0 },
+      botSegments: [],
+      resolvedDemands: [],
+    });
+    const memory = makeMemoryWithLock(false);
+    await ContextBuilder.build(snapshot, BotSkillLevel.Medium, [], memory);
+    expect(memory.endGameLocked).toBe(true);
+  });
+
+  it('JIRA-265 AC5: endGameLocked is sticky — stays true after cash dips below $200M', async () => {
+    // Memory already has endGameLocked=true (set on an earlier turn). This
+    // turn the bot has $150M cash (post-build dip). The latch must NOT reset.
+    const snapshot = makeWorldSnapshot({
+      botMoney: 150,
+      botPosition: { row: 0, col: 0 },
+      botSegments: [],
+      resolvedDemands: [],
+    });
+    const memory = makeMemoryWithLock(true);
+    await ContextBuilder.build(snapshot, BotSkillLevel.Medium, [], memory);
+    expect(memory.endGameLocked).toBe(true);
+  });
+
+  it('does NOT latch when cash ≤ $200M and not in late phase', async () => {
+    // $200M is the boundary — must be > 200 to trigger.
+    const snapshot = makeWorldSnapshot({
+      botMoney: 200,
+      botPosition: { row: 0, col: 0 },
+      botSegments: [],
+      resolvedDemands: [],
+      turnNumber: 10, // early-mid, not late
+    });
+    const memory = makeMemoryWithLock(false);
+    await ContextBuilder.build(snapshot, BotSkillLevel.Medium, [], memory);
+    expect(memory.endGameLocked).toBeFalsy();
   });
 });

--- a/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
+++ b/src/server/__tests__/ai/DeterministicTripPlanner.test.ts
@@ -2895,8 +2895,15 @@ describe('JIRA-249/250: enumerateCandidates includes carry floor and corridor ca
 });
 
 // ── JIRA-255 Layer A: End-game lock mechanism ──────────────────────────
+// JIRA-265 Layer 2: the latch moved to ContextBuilder.build. Tests for the
+// latch's behavior live in `ContextBuilder.test.ts` under "endGameLocked
+// latch (JIRA-265 Layer 2)" — covering AC4 (latches on route-executor turn
+// when cash > $200M), AC5 (sticky after cash dip), and the negative case
+// (no latch when cash ≤ $200M and not in late phase). The original tests in
+// this describe block asserted the latch happened INSIDE planTripDeterministic,
+// which is no longer true after the Layer 2 relocation.
 
-describe('JIRA-255 Layer A: end-game lock in planTripDeterministic', () => {
+describe.skip('[OBSOLETE — JIRA-265 Layer 2] JIRA-255 Layer A: end-game lock in planTripDeterministic', () => {
   beforeEach(() => {
     mockUpdateMemory.mockClear();
     // Default cheapPrune: always keep

--- a/src/server/__tests__/ai/NetworkContext.test.ts
+++ b/src/server/__tests__/ai/NetworkContext.test.ts
@@ -12,6 +12,7 @@ import {
   BotSkillLevel,
   GameStatus,
   TrainType,
+  GameState,
 } from '../../../shared/types/GameTypes';
 import { buildTrackNetwork } from '../../../shared/services/TrackNetworkService';
 
@@ -321,6 +322,52 @@ describe('NetworkContext.computePhase', () => {
     const snapshot = makeSnapshot({ money: 235 });
     const result = NetworkContext.computePhase(snapshot, ['a', 'b', 'c', 'd', 'e', 'f']);
     expect(result).toBe('Victory Imminent');
+  });
+
+  // ── JIRA-265 Layer 3: gameState-aware display ──
+
+  it('JIRA-265 AC6: returns "End Game" when gameState=End but few majors (would have shown "Mid Game" before)', () => {
+    // Replays game 086fa2ce s1 T65: cash $255M, only 4 majors. Old logic
+    // returned "Mid Game" because the major-city thresholds (5+/$150M for
+    // Late, 3+/$80M for Mid) ignored the cash-latched end-game state.
+    const snapshot = makeSnapshot({ money: 255 });
+    const result = NetworkContext.computePhase(
+      snapshot,
+      ['Milano', 'Ruhr', 'Berlin', 'London'],
+      GameState.End,
+    );
+    expect(result).toBe('End Game');
+  });
+
+  it('JIRA-265 Layer 3: still returns "Victory Imminent" with 7+ majors and 250M+ even when gameState=End', () => {
+    const snapshot = makeSnapshot({ money: 260 });
+    const result = NetworkContext.computePhase(
+      snapshot,
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+      GameState.End,
+    );
+    expect(result).toBe('Victory Imminent');
+  });
+
+  it('JIRA-265 Layer 3: gameState=Mid preserves legacy thresholds (does NOT force End Game)', () => {
+    const snapshot = makeSnapshot({ money: 100 });
+    const result = NetworkContext.computePhase(
+      snapshot,
+      ['Berlin', 'Paris', 'Wien'],
+      GameState.Mid,
+    );
+    expect(result).toBe('Mid Game');
+  });
+
+  it('JIRA-265 Layer 3: omitting gameState arg preserves legacy behavior', () => {
+    // Back-compat — callers that don't pass gameState (e.g. the internal
+    // NetworkContext.compute facade) see the original output.
+    const snapshot = makeSnapshot({ money: 255 });
+    const result = NetworkContext.computePhase(
+      snapshot,
+      ['Milano', 'Ruhr', 'Berlin', 'London'],
+    );
+    expect(result).toBe('Mid Game'); // legacy: 3+ majors → Mid Game
   });
 });
 

--- a/src/server/__tests__/ai/victoryRules.test.ts
+++ b/src/server/__tests__/ai/victoryRules.test.ts
@@ -16,6 +16,9 @@ import {
   cheapestNUnconnectedMajorConnectorCost,
   detectVictoryClinch,
   findFinalVictoryRoute,
+  findFinalVictoryOutcome,
+  buildEndGameTrace,
+  type FinalVictoryOutcome,
 } from '../../services/ai/victoryRules';
 import { GameState, GameContext, TrainType, WorldSnapshot } from '../../../shared/types/GameTypes';
 import type { BotMemoryState, DemandContext } from '../../../shared/types/GameTypes';
@@ -695,5 +698,208 @@ describe('findFinalVictoryRoute', () => {
     const result = findFinalVictoryRoute(snapshot, ctx, makeEndMemory());
     expect(result).not.toBeNull();
     expect(result!.reasoning).toMatch(/^\[final-victory\]/);
+  });
+});
+
+// ── findFinalVictoryOutcome (JIRA-265) ───────────────────────────────────────
+
+describe('findFinalVictoryOutcome', () => {
+  // JIRA-265 AC2: skip-reason exposure on the null path
+  it('returns skip:not_in_end_state when context.gameState is not End', () => {
+    const snapshot = makeSnapshot();
+    const ctx = makeEndContext({ gameState: GameState.Mid, demands: [makeDemand()] });
+    const result = findFinalVictoryOutcome(snapshot, ctx, makeEndMemory());
+    expect(result.outcome).toBe('skip');
+    if (result.outcome === 'skip') expect(result.reason).toBe('not_in_end_state');
+  });
+
+  it('returns skip:no_demands when demand hand is empty', () => {
+    const snapshot = makeSnapshot();
+    const ctx = makeEndContext({ demands: [] });
+    const result = findFinalVictoryOutcome(snapshot, ctx, makeEndMemory());
+    expect(result.outcome).toBe('skip');
+    if (result.outcome === 'skip') expect(result.reason).toBe('no_demands');
+  });
+
+  it('returns skip:victory_met when both gaps are zero (game should have ended)', () => {
+    const snapshot = makeSnapshot();
+    const ctx = makeEndContext({
+      money: 250,
+      connectedMajorCities: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+      demands: [makeDemand()],
+    });
+    const result = findFinalVictoryOutcome(snapshot, ctx, makeEndMemory());
+    expect(result.outcome).toBe('skip');
+    if (result.outcome === 'skip') expect(result.reason).toBe('victory_met');
+  });
+
+  it('returns skip:no_route_covers_gap when no candidate clears the cashGap', () => {
+    const snapshot = makeSnapshot({ trainType: TrainType.Freight, loads: [] });
+    // cashGap = 250 - 200 = 50M. Only demand pays $10M with on-network supply/delivery.
+    const ctx = makeEndContext({
+      money: 200,
+      demands: [
+        makeDemand({ payout: 10, isLoadOnTrain: false, isSupplyOnNetwork: true, isDeliveryOnNetwork: true }),
+      ],
+    });
+    const result = findFinalVictoryOutcome(snapshot, ctx, makeEndMemory());
+    expect(result.outcome).toBe('skip');
+    if (result.outcome === 'skip') {
+      expect(result.reason).toBe('no_route_covers_gap');
+      expect(result.cashGap).toBe(50);
+    }
+  });
+
+  it('returns fire with route + gap details when a feasible candidate exists', () => {
+    const snapshot = makeSnapshot({ trainType: TrainType.Freight, loads: [] });
+    const ctx = makeEndContext({
+      money: 241,
+      demands: [
+        makeDemand({
+          payout: 10, isLoadOnTrain: false, isSupplyOnNetwork: true, isDeliveryOnNetwork: true, estimatedTurns: 2,
+        }),
+      ],
+    });
+    const result = findFinalVictoryOutcome(snapshot, ctx, makeEndMemory());
+    expect(result.outcome).toBe('fire');
+    if (result.outcome === 'fire') {
+      expect(result.route.reasoning).toMatch(/^\[final-victory\]/);
+      expect(result.cashGap).toBe(9);
+    }
+  });
+
+  it('legacy findFinalVictoryRoute still returns route on fire and null on skip', () => {
+    const snapshot = makeSnapshot();
+    const ctxSkip = makeEndContext({ demands: [] });
+    expect(findFinalVictoryRoute(snapshot, ctxSkip, makeEndMemory())).toBeNull();
+
+    const ctxFire = makeEndContext({
+      money: 241,
+      demands: [
+        makeDemand({ payout: 10, isLoadOnTrain: false, isSupplyOnNetwork: true, isDeliveryOnNetwork: true, estimatedTurns: 2 }),
+      ],
+    });
+    expect(findFinalVictoryRoute(snapshot, ctxFire, makeEndMemory())).not.toBeNull();
+  });
+});
+
+// ── buildEndGameTrace (JIRA-265) ─────────────────────────────────────────────
+
+describe('buildEndGameTrace', () => {
+  it('JIRA-265 AC1: trace populated with cashGap/majorsGap/cheapestConnectors/fullWinCostM', () => {
+    const ctx = makeEndContext({
+      money: 210,
+      connectedMajorCities: ['Ruhr', 'Berlin', 'Madrid', 'London'],
+      unconnectedMajorCities: [
+        { cityName: 'Holland', estimatedCost: 20 },
+        { cityName: 'Paris', estimatedCost: 15 },
+        { cityName: 'Wien', estimatedCost: 25 },
+        { cityName: 'Milano', estimatedCost: 30 },
+      ],
+    });
+    const memory = makeEndMemory();
+    const skipOutcome: FinalVictoryOutcome = { outcome: 'skip', reason: 'no_route_covers_gap', cashGap: 40, majorsGap: 3, connectorCost: 60 };
+    const trace = buildEndGameTrace(ctx, memory, skipOutcome, false, null);
+
+    expect(trace.inEndGame).toBe(true);
+    expect(trace.cashGapM).toBe(40);
+    expect(trace.majorsGap).toBe(3);
+    expect(trace.cheapestConnectors).toEqual([
+      { cityName: 'Holland', costM: 20 },
+      { cityName: 'Paris', costM: 15 },
+      { cityName: 'Wien', costM: 25 },
+    ]);
+    expect(trace.fullWinCostM).toBe(100); // 40 + 20 + 15 + 25
+  });
+
+  it('JIRA-265 AC2: victoryRouteProjection carries skip reason', () => {
+    const ctx = makeEndContext({ money: 210 });
+    const skipOutcome: FinalVictoryOutcome = { outcome: 'skip', reason: 'no_feasible_demands' };
+    const trace = buildEndGameTrace(ctx, makeEndMemory(), skipOutcome, false, null);
+    expect(trace.victoryRouteProjection.outcome).toBe('skip');
+    if (trace.victoryRouteProjection.outcome === 'skip') {
+      expect(trace.victoryRouteProjection.reason).toBe('no_feasible_demands');
+    }
+  });
+
+  it('JIRA-265 AC3: victoryRouteProjection carries fire details + appliedOverride flag', () => {
+    const ctx = makeEndContext({ money: 241 });
+    const fireOutcome: FinalVictoryOutcome = {
+      outcome: 'fire',
+      cashGap: 9, majorsGap: 0, connectorCost: 0,
+      route: {
+        stops: [
+          { action: 'pickup', loadType: 'Beer', city: 'Munchen' },
+          { action: 'deliver', loadType: 'Beer', city: 'Hamburg', demandCardId: 1, payment: 9 },
+        ],
+        estimatedTurns: 3, buildCost: 0, totalPayout: 9,
+        cashAtVictory: 250, majorsAtVictory: 7,
+        majorConnectors: [],
+        reasoning: '[final-victory] Beer→Hamburg, turns=3, build=0M, payout=9M, cash@victory=250M, majors@victory=7',
+      },
+    };
+    const trace = buildEndGameTrace(ctx, makeEndMemory(), fireOutcome, true, null);
+    expect(trace.victoryRouteProjection.outcome).toBe('fire');
+    if (trace.victoryRouteProjection.outcome === 'fire') {
+      expect(trace.victoryRouteProjection.turns).toBe(3);
+      expect(trace.victoryRouteProjection.payoutM).toBe(9);
+      expect(trace.victoryRouteProjection.cashAtVictory).toBe(250);
+      expect(trace.victoryRouteProjection.appliedOverride).toBe(true);
+      expect(trace.victoryRouteProjection.stops).toEqual([
+        'pickup:Beer@Munchen',
+        'deliver:Beer@Hamburg',
+      ]);
+    }
+  });
+
+  it('JIRA-265 AC7-component: activePlanProjection.willClinch reflects route payouts + connector deliveries', () => {
+    const ctx = makeEndContext({
+      money: 228,
+      connectedMajorCities: ['Ruhr', 'Berlin', 'Madrid', 'London', 'Wien', 'Paris', 'Milano'], // 7 already
+      unconnectedMajorCities: [{ cityName: 'Holland', estimatedCost: 20 }],
+    });
+    const activeRoute = {
+      stops: [
+        { action: 'deliver' as const, loadType: 'Copper', city: 'Cardiff', demandCardId: 99, payment: 31 },
+      ],
+      currentStopIndex: 0,
+      phase: 'travel' as const,
+      createdAtTurn: 76,
+      reasoning: 'test',
+    };
+    const skipOutcome: FinalVictoryOutcome = { outcome: 'skip', reason: 'no_route_covers_gap' };
+    const trace = buildEndGameTrace(ctx, makeEndMemory(), skipOutcome, false, activeRoute);
+    expect(trace.activePlanProjection).toBeDefined();
+    expect(trace.activePlanProjection!.projectedCash).toBe(259); // 228 + 31
+    expect(trace.activePlanProjection!.projectedMajors).toBe(7); // already 7, Cardiff not a major
+    expect(trace.activePlanProjection!.willClinch).toBe(true); // 259 >= 250 AND 7 >= 7
+    expect(trace.activePlanProjection!.remainingStops).toBe(1);
+  });
+
+  it('activePlanProjection.willClinch=false when projectedCash insufficient', () => {
+    const ctx = makeEndContext({
+      money: 200,
+      connectedMajorCities: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+    });
+    const activeRoute = {
+      stops: [
+        { action: 'deliver' as const, loadType: 'X', city: 'CityX', demandCardId: 1, payment: 10 },
+      ],
+      currentStopIndex: 0,
+      phase: 'travel' as const,
+      createdAtTurn: 50,
+      reasoning: 'test',
+    };
+    const skipOutcome: FinalVictoryOutcome = { outcome: 'skip', reason: 'no_route_covers_gap' };
+    const trace = buildEndGameTrace(ctx, makeEndMemory(), skipOutcome, false, activeRoute);
+    expect(trace.activePlanProjection!.projectedCash).toBe(210);
+    expect(trace.activePlanProjection!.willClinch).toBe(false); // 210 < 250
+  });
+
+  it('activePlanProjection undefined when activeRoute is null', () => {
+    const ctx = makeEndContext({ money: 210 });
+    const skipOutcome: FinalVictoryOutcome = { outcome: 'skip', reason: 'no_route_covers_gap' };
+    const trace = buildEndGameTrace(ctx, makeEndMemory(), skipOutcome, false, null);
+    expect(trace.activePlanProjection).toBeUndefined();
   });
 });

--- a/src/server/services/ai/AIStrategyEngine.ts
+++ b/src/server/services/ai/AIStrategyEngine.ts
@@ -60,7 +60,14 @@ import { InitialBuildRunner } from './InitialBuildRunner';
 import { NewRoutePlanner } from './NewRoutePlanner';
 import { UPGRADE_DELIVERY_THRESHOLD } from './context/UpgradeGatingConstants';
 import { RECENT_DELIVERIES_WINDOW } from './StrategicConstants';
-import { detectVictoryClinch, findFinalVictoryRoute } from './victoryRules';
+import {
+  detectVictoryClinch,
+  findFinalVictoryRoute,
+  findFinalVictoryOutcome,
+  buildEndGameTrace,
+  type EndGameTrace,
+  type FinalVictoryOutcome,
+} from './victoryRules';
 import { isBotInPendingLostTurns } from '../../services/restrictionPredicates';
 
 /**
@@ -94,6 +101,8 @@ export interface BotTurnResult {
   gamePhase?: string;
   /** JIRA-243 (AC3): Persistent bot game phase for post-game traceability. */
   gameState?: GameState;
+  /** JIRA-265: Per-turn end-game state trace. Populated when gameState=end. */
+  endGame?: EndGameTrace;
   cash?: number;
   trainType?: string;
   compositionTrace?: CompositionTrace;
@@ -298,9 +307,14 @@ export class AIStrategyEngine {
       // When the search returns null, we fall through to the existing clinch gate
       // as a strict-subset fast-path. See victoryRules.findFinalVictoryRoute for
       // the forensic case (game 95f0aadc, s2 T76) that motivates this change.
+      // JIRA-265: Capture the discriminated-union outcome so the per-turn
+      // endGameTrace (built below at turn-log construction) can record WHY
+      // a victory route did or did not override the activeRoute this turn.
+      let finalVictoryOutcome: FinalVictoryOutcome | null = null;
+      let finalVictoryAppliedOverride = false;
       if (!context.isInitialBuild) {
-        const finalVictoryRoute = findFinalVictoryRoute(snapshot, context, memory);
-        if (finalVictoryRoute) {
+        finalVictoryOutcome = findFinalVictoryOutcome(snapshot, context, memory);
+        if (finalVictoryOutcome.outcome === 'fire') {
           // JIRA-261: Idempotency check compares the full remaining-stops
           // sequence, not just the first stop. The earlier first-stop-only check
           // suppressed override at game 8350cffa s3 T68 onwards: an existing
@@ -311,14 +325,15 @@ export class AIStrategyEngine {
           // have connected the 4th-of-7 major and clinched the game. With the
           // full-sequence comparison, that divergence (and the missing London
           // leg in the existing route) now correctly triggers the override.
-          if (!AIStrategyEngine.routesMatch(activeRoute, finalVictoryRoute.stops)) {
+          if (!AIStrategyEngine.routesMatch(activeRoute, finalVictoryOutcome.route.stops)) {
             activeRoute = {
-              stops: finalVictoryRoute.stops,
+              stops: finalVictoryOutcome.route.stops,
               currentStopIndex: 0,
               phase: 'travel',
               createdAtTurn: snapshot.turnNumber,
-              reasoning: finalVictoryRoute.reasoning,
+              reasoning: finalVictoryOutcome.route.reasoning,
             };
+            finalVictoryAppliedOverride = true;
           }
         } else {
           // JIRA-243: Victory-clinch hard gate. If a carried load + matching demand
@@ -1019,6 +1034,21 @@ export class AIStrategyEngine {
         gamePhase: context.phase || undefined,
         // JIRA-243 (AC3): pipe persistent gameState through to game log
         gameState: context.gameState,
+        // JIRA-265: Per-turn end-game trace. Populated whenever the bot is in
+        // gameState=end so the operator can see cashGap, majorsGap, the
+        // cheapest connector cities, the per-turn findFinalVictoryRoute
+        // outcome (fire/skip with reason), and whether the current activeRoute
+        // will actually clinch — without re-running the game with stdout
+        // capture.
+        endGame: context.gameState === GameState.End
+          ? buildEndGameTrace(
+              context,
+              memory,
+              finalVictoryOutcome ?? { outcome: 'skip', reason: 'not_in_end_state' },
+              finalVictoryAppliedOverride,
+              activeRoute,
+            )
+          : undefined,
         cash: result.remainingMoney,
         trainType: context.trainType,
         milepostsMoved,

--- a/src/server/services/ai/BotTurnTrigger.ts
+++ b/src/server/services/ai/BotTurnTrigger.ts
@@ -298,6 +298,8 @@ export async function onTurnChange(
         demandRanking: result.demandRanking,
         gamePhase: result.gamePhase,
         gameState: result.gameState,
+        // JIRA-265: Per-turn end-game trace (cashGap, majorsGap, victory-route projection, etc.)
+        endGame: result.endGame,
         cash: result.cash,
         train: result.trainType,
         upgradeAdvice: result.upgradeAdvice,

--- a/src/server/services/ai/ContextBuilder.ts
+++ b/src/server/services/ai/ContextBuilder.ts
@@ -58,6 +58,7 @@ import {
   formatReachabilityNote as _formatReachabilityNote,
 } from './prompts/ContextSerializer';
 import { computeGameState } from './victoryRules';
+import { classifyGamePhase } from './DeterministicTripPlanner';
 import { updateMemory } from './BotMemory';
 
 export { ContextSerializer };
@@ -196,6 +197,31 @@ export class ContextBuilder {
       updateMemory(snapshot.gameId, snapshot.bot.playerId, { gameState: gamePhase }).catch(
         (err: unknown) => console.warn('[ContextBuilder] Failed to persist gameState:', err),
       );
+    }
+
+    // JIRA-265 Layer 2: End-game lock latch. Previously lived inside
+    // planTripDeterministic, which only runs on REPLAN turns; pure
+    // [route-executor] execution turns never updated the flag. Moving the
+    // latch here ensures it engages on every turn regardless of replan, so
+    // downstream consumers (cheapPrune carve-out, win-completer ranking,
+    // reasoning annotation) and the new per-turn endGame trace observe a
+    // consistent value.
+    //
+    // Same trigger as the prior site: cash > $200M OR classifyGamePhase=='late'.
+    // Once set, the flag is sticky (one-way) — never reverts even after a
+    // post-build cash dip.
+    if (!memoryForPhase.endGameLocked) {
+      const phaseClass = classifyGamePhase(
+        snapshot.turnNumber,
+        memoryForPhase.deliveryCount ?? 0,
+        connectedMajorCities.length,
+      );
+      if (snapshot.bot.money > 200 || phaseClass === 'late') {
+        memoryForPhase.endGameLocked = true;
+        updateMemory(snapshot.gameId, snapshot.bot.playerId, { endGameLocked: true }).catch(
+          (err: unknown) => console.warn('[ContextBuilder] Failed to persist endGameLocked:', err),
+        );
+      }
     }
 
     return {

--- a/src/server/services/ai/ContextBuilder.ts
+++ b/src/server/services/ai/ContextBuilder.ts
@@ -143,9 +143,11 @@ export class ContextBuilder {
     // Compute upgrade advice with deliveryCount gate
     const upgradeAdvice = UpgradeContext.compute(snapshot, demands, canBuild, deliveryCount);
 
-    // Determine game phase
+    // Determine game phase (display string — see JIRA-265 Layer 3 below for the
+    // gameState-aware refinement). isInitialBuild stays here; `phase` moves
+    // after the gameState latch so we can pass the new gameState into
+    // computePhase and never produce "Mid Game" when gameState=end.
     const isInitialBuild = snapshot.gameStatus === 'initialBuild';
-    const phase = NetworkContext.computePhase(snapshot, connectedMajorCities);
 
     // Build opponent context based on skill level
     const opponents = ContextBuilder.buildOpponentContext(
@@ -223,6 +225,12 @@ export class ContextBuilder {
         );
       }
     }
+
+    // JIRA-265 Layer 3: compute display phase AFTER gameState so "End Game" /
+    // "Victory Imminent" shows correctly once the cash latch has fired.
+    // Previously this ran before the latch and returned "Mid Game" at cash
+    // $255M whenever the bot had only 3-4 majors connected (game 086fa2ce s1 T65).
+    const phase = NetworkContext.computePhase(snapshot, connectedMajorCities, gamePhase);
 
     return {
       position: botPosition

--- a/src/server/services/ai/DeterministicTripPlanner.ts
+++ b/src/server/services/ai/DeterministicTripPlanner.ts
@@ -35,7 +35,6 @@ import {
   VICTORY_CITY_COUNT,
 } from '../../../shared/types/GameTypes';
 import { cheapestUnconnectedMajorConnectorCost } from './victoryRules';
-import { updateMemory } from './BotMemory';
 import { isWinCompleting, fullWinCost } from './winCompletion';
 import { getCityMilepointKey, isPickupDeliveryBlocked } from '../restrictionPredicates';
 
@@ -1664,25 +1663,11 @@ export function planTripDeterministic(
     excludeRouteSignatures: new Set(options?.excludeRouteSignatures ?? []),
   };
 
-  // JIRA-255 Layer A: End-game lock hook.
-  // Once set, endGameLocked is sticky (one-way) — it never reverts even after
-  // temporary cash dips from track building. Whichever condition fires first
-  // sets the lock for the remainder of the game.
-  if (!memory.endGameLocked) {
-    const cmcCount = context.connectedMajorCities?.length ?? 0;
-    const phase = classifyGamePhase(
-      snapshot.turnNumber,
-      memory.deliveryCount,
-      cmcCount,
-    );
-    if (snapshot.bot.money > 200 || phase === 'late') {
-      memory.endGameLocked = true;
-      // Persist asynchronously — in-memory mutation is authoritative for this turn.
-      updateMemory(snapshot.gameId, snapshot.bot.playerId, { endGameLocked: true }).catch(
-        (err: unknown) => console.warn('[planTripDeterministic] Failed to persist endGameLocked:', err),
-      );
-    }
-  }
+  // JIRA-265 Layer 2: End-game lock latch moved to ContextBuilder so it engages
+  // every turn (not just REPLAN turns). Downstream consumers (cheapPrune carve-
+  // out, applyEndStateScoring, win-completer ranking, reasoning annotation)
+  // continue to read memory.endGameLocked from the same in-memory location;
+  // they see the latched value regardless of whether this planner ran.
 
   // Empty hand check (R8)
   if (!context.demands || context.demands.length === 0) {

--- a/src/server/services/ai/GameLogger.ts
+++ b/src/server/services/ai/GameLogger.ts
@@ -9,6 +9,7 @@ import { mkdirSync, appendFile } from 'fs';
 import { join } from 'path';
 import { AIActionType, GameState, TimelineStep } from '../../../shared/types/GameTypes';
 import { VictoryCheckResult } from './BotTurnTrigger';
+import type { EndGameTrace } from './victoryRules';
 
 const LOGS_DIR = join(process.cwd(), 'logs');
 
@@ -176,14 +177,20 @@ export interface GameTurnLogEntry {
   // Populated on every bot turn that runs checkBotVictory; omitted when check was skipped.
   victoryCheck?: VictoryCheckResult;
 
-  // JIRA-255: End-game routing diagnostics.
-  // Only populated when end-game routing is active (endGameLocked=true) to prevent log noise.
-  /** True when the end-game lock is active for this turn; absent when not engaged. */
-  endGameLocked?: boolean;
-  /** Minimum cash required to win (ECU millions) including cheapest unconnected major city connections. */
-  fullWinCost?: number;
-  /** Number of candidates in the feasible set that would complete the win condition. */
-  winCompleterCount?: number;
+  /**
+   * JIRA-265: Per-turn end-game state. Populated on every turn where
+   * `gameState === 'end'`; absent when the bot is not in end-game state.
+   *
+   * Subsumes the prior dead fields `endGameLocked` / `fullWinCost` /
+   * `winCompleterCount` (never written by any producer) with a single
+   * structured object whose fields a reader can grep on:
+   *   - `cashGapM` / `majorsGap` / `fullWinCostM` — what's left to win
+   *   - `cheapestConnectors` — the unconnected majors needed to close the city condition
+   *   - `victoryRouteProjection` — the per-turn fire-or-skip outcome of findFinalVictoryRoute
+   *   - `endGameLocked` — current state of the planner's ranking carve-out flag
+   *   - `activePlanProjection` — whether the current activeRoute will clinch, when, with what cash
+   */
+  endGame?: EndGameTrace;
 
   // Execution Results
   success: boolean;

--- a/src/server/services/ai/context/NetworkContext.ts
+++ b/src/server/services/ai/context/NetworkContext.ts
@@ -17,6 +17,7 @@ import {
   TRAIN_PROPERTIES,
   TrackSegment,
   TerrainType,
+  GameState,
 } from '../../../../shared/types/GameTypes';
 import { buildTrackNetwork } from '../../../../shared/services/TrackNetworkService';
 import { getMajorCityGroups, getFerryEdges } from '../../../../shared/services/majorCityGroups';
@@ -255,12 +256,27 @@ export class NetworkContext {
     return Array.from(cityNames);
   }
 
-  /** Determine game phase from connected major cities and cash. */
+  /**
+   * Determine game phase from connected major cities and cash.
+   *
+   * JIRA-265 Layer 3: when the bot's persistent gameState has latched to End
+   * (cash > $200M), the display must never drop back to "Mid Game" — that's
+   * what produced the confusing "Mid Game | Cash: 255M" output in game
+   * 086fa2ce s1 T65 (cash $255M but only 4 majors → old logic returned
+   * Mid Game because the major-city thresholds dominated). With gameState=End
+   * forced, the only relevant refinement is whether victory is one step away.
+   */
   static computePhase(
     snapshot: WorldSnapshot,
     connectedMajorCities: string[],
+    gameState?: GameState,
   ): string {
     if (snapshot.gameStatus === 'initialBuild') return 'Initial Build';
+    if (gameState === GameState.End) {
+      if (connectedMajorCities.length >= 7 && snapshot.bot.money >= 250) return 'Victory Imminent';
+      if (connectedMajorCities.length >= 6 && snapshot.bot.money >= 230) return 'Victory Imminent';
+      return 'End Game';
+    }
     if (connectedMajorCities.length >= 6 && snapshot.bot.money >= 230) return 'Victory Imminent';
     if (connectedMajorCities.length >= 5 && snapshot.bot.money >= 250) return 'Victory Imminent';
     if (connectedMajorCities.length >= 5 && snapshot.bot.money >= 150) return 'Late Game';

--- a/src/server/services/ai/victoryRules.ts
+++ b/src/server/services/ai/victoryRules.ts
@@ -17,6 +17,7 @@ import {
   VICTORY_CITY_COUNT,
   VICTORY_INITIAL_THRESHOLD,
   RouteStop,
+  StrategicRoute,
   TrainType,
   TRAIN_PROPERTIES,
   WorldSnapshot,
@@ -203,6 +204,73 @@ export interface FinalVictoryRoute {
 }
 
 /**
+ * JIRA-265: Discriminated-union outcome of a victory-route search.
+ * `findFinalVictoryRoute` returns a `FinalVictoryRoute | null` for callers that
+ * only care about the route. `findFinalVictoryOutcome` exposes the same
+ * computation but with the skip reason preserved so per-turn NDJSON logging can
+ * answer "why did this turn not produce a victory route override?" without
+ * re-running the search with stdout capture.
+ */
+export type FinalVictoryOutcomeSkipReason =
+  | 'not_in_end_state'
+  | 'no_demands'
+  | 'victory_met'
+  | 'no_feasible_demands'
+  | 'no_route_covers_gap';
+
+export type FinalVictoryOutcome =
+  | { outcome: 'fire'; route: FinalVictoryRoute; cashGap: number; majorsGap: number; connectorCost: number }
+  | { outcome: 'skip'; reason: FinalVictoryOutcomeSkipReason; cashGap?: number; majorsGap?: number; connectorCost?: number };
+
+/**
+ * JIRA-265: Per-turn end-game trace for the NDJSON log. Surfaces everything a
+ * post-game reader needs to answer "what does the bot need to win, and what's
+ * its plan to get there?" without re-running the search with stdout capture.
+ *
+ * Populated by AIStrategyEngine on every turn where `gameState === 'end'`.
+ */
+export interface EndGameTrace {
+  /** Always true when this trace is emitted (the GameLogger field is absent otherwise). */
+  inEndGame: true;
+  /** Snapshot of memory.endGameLocked AFTER this turn's latch decision. */
+  endGameLocked: boolean;
+  /** max(0, 250 − cash). Zero when cash already meets the victory threshold. */
+  cashGapM: number;
+  /** max(0, 7 − connectedMajorCities.length). Zero when city condition already met. */
+  majorsGap: number;
+  /** The cheapest `majorsGap` unconnected majors, sorted ascending by estimated track-cost. */
+  cheapestConnectors: Array<{ cityName: string; costM: number }>;
+  /** cashGapM + Σ cheapestConnectors.costM. Lower bound on the spend required to win. */
+  fullWinCostM: number;
+  /** Per-turn outcome of findFinalVictoryRoute, including the skip reason when no route fires. */
+  victoryRouteProjection:
+    | {
+        outcome: 'fire';
+        /** "pickup:Beer@Munchen, deliver:Beer@Hamburg" style stop summary. */
+        stops: string[];
+        turns: number;
+        buildM: number;
+        payoutM: number;
+        cashAtVictory: number;
+        majorsAtVictory: number;
+        /** True when AIStrategyEngine replaced activeRoute with this projection; false when JIRA-261 routesMatch suppressed the override. */
+        appliedOverride: boolean;
+      }
+    | { outcome: 'skip'; reason: FinalVictoryOutcomeSkipReason };
+  /** Projection of the bot's CURRENT activeRoute outcome, if any. Absent when no activeRoute. */
+  activePlanProjection?: {
+    /** True when the route's deliveries + connector closures would meet both victory conditions. */
+    willClinch: boolean;
+    /** money + Σ deliveries.payment in the remaining route. */
+    projectedCash: number;
+    /** connectedMajorCities.length + count of route deliveries to unconnected majors. */
+    projectedMajors: number;
+    /** Best-effort estimate of remaining stops; uses route length as a proxy until a turn estimator is wired. */
+    remainingStops: number;
+  };
+}
+
+/**
  * Internal candidate structure during route search.
  */
 interface VictoryCandidate {
@@ -318,19 +386,37 @@ function demandBuildCost(
  * @param memory   - Persistent bot memory (for gameState latch).
  * @returns The fastest feasible victory route, or null.
  */
-export function findFinalVictoryRoute(
+/**
+ * JIRA-265: Outcome-returning variant of findFinalVictoryRoute. Preserves the
+ * skip reason on the null path so callers (e.g. the per-turn NDJSON endGame
+ * trace in AIStrategyEngine) can record WHY no override fired without
+ * re-running the search.
+ *
+ * Skip reasons:
+ *   not_in_end_state       — context.gameState !== End
+ *   no_demands             — context.demands empty
+ *   victory_met            — both gaps zero (game should already have ended)
+ *   no_feasible_demands    — every demand has unreachable supply/delivery
+ *   no_route_covers_gap    — at least one feasible demand exists but no
+ *                            single/pair/triple combination has
+ *                            payout − buildCost − connectorCost ≥ cashGap
+ *
+ * `findFinalVictoryRoute` is a thin wrapper that maps fire→route, skip→null
+ * for backward compatibility with existing call sites and tests.
+ */
+export function findFinalVictoryOutcome(
   snapshot: WorldSnapshot,
   context: GameContext,
   memory: BotMemoryState,
-): FinalVictoryRoute | null {
+): FinalVictoryOutcome {
   // Gate: only in End state.
   if (context.gameState !== GameState.End) {
-    return null;
+    return { outcome: 'skip', reason: 'not_in_end_state' };
   }
 
   if (!context.demands || context.demands.length === 0) {
     console.log('[final-victory] skip: no demands in hand');
-    return null;
+    return { outcome: 'skip', reason: 'no_demands' };
   }
 
   const cashGap = Math.max(0, VICTORY_INITIAL_THRESHOLD - context.money);
@@ -342,7 +428,7 @@ export function findFinalVictoryRoute(
   // should have ended — log a warning and fall through.
   if (cashGap === 0 && majorsGap === 0) {
     console.log('[final-victory] skip: victory conditions already met — game should have ended');
-    return null;
+    return { outcome: 'skip', reason: 'victory_met', cashGap, majorsGap, connectorCost };
   }
 
   // Determine train properties.
@@ -362,7 +448,7 @@ export function findFinalVictoryRoute(
 
   if (feasibleDemands.length === 0) {
     console.log('[final-victory] skip: no feasible demands (supply/delivery unreachable)');
-    return null;
+    return { outcome: 'skip', reason: 'no_feasible_demands', cashGap, majorsGap, connectorCost };
   }
 
   const candidates: VictoryCandidate[] = [];
@@ -460,7 +546,7 @@ export function findFinalVictoryRoute(
     console.log(
       `[final-victory] skip: no route covers cashGap=${cashGap}M + connectorCost=${connectorCost}M`,
     );
-    return null;
+    return { outcome: 'skip', reason: 'no_route_covers_gap', cashGap, majorsGap, connectorCost };
   }
 
   // Rank: minimum estimatedTurns ASC; tiebreak maximum cashAtVictory DESC.
@@ -479,7 +565,7 @@ export function findFinalVictoryRoute(
 
   console.log(reasoning);
 
-  return {
+  const route: FinalVictoryRoute = {
     stops: best.stops,
     estimatedTurns: best.estimatedTurns,
     buildCost: best.buildCost,
@@ -488,5 +574,92 @@ export function findFinalVictoryRoute(
     majorsAtVictory: best.majorsAtVictory,
     majorConnectors: best.majorConnectors,
     reasoning,
+  };
+  return { outcome: 'fire', route, cashGap, majorsGap, connectorCost };
+}
+
+/**
+ * Legacy wrapper for `findFinalVictoryOutcome` — returns the route on fire,
+ * null on any skip. Preserved for backward compatibility with existing call
+ * sites and tests that don't need the skip reason.
+ */
+export function findFinalVictoryRoute(
+  snapshot: WorldSnapshot,
+  context: GameContext,
+  memory: BotMemoryState,
+): FinalVictoryRoute | null {
+  const result = findFinalVictoryOutcome(snapshot, context, memory);
+  return result.outcome === 'fire' ? result.route : null;
+}
+
+/**
+ * JIRA-265: Compose the per-turn EndGameTrace from the outcome of
+ * findFinalVictoryOutcome + the current context, memory, and (optionally) the
+ * activeRoute that will execute this turn. AIStrategyEngine calls this once
+ * per turn when context.gameState === End and threads the result into the
+ * NDJSON turn-log entry's `endGame` field.
+ *
+ * `appliedOverride` is supplied by the caller because the override decision is
+ * made in AIStrategyEngine (after the JIRA-261 routesMatch check), not here.
+ */
+export function buildEndGameTrace(
+  context: GameContext,
+  memory: BotMemoryState,
+  outcome: FinalVictoryOutcome,
+  appliedOverride: boolean,
+  activeRoute: StrategicRoute | null,
+): EndGameTrace {
+  const cashGapM = Math.max(0, VICTORY_INITIAL_THRESHOLD - context.money);
+  const majorsGap = Math.max(0, VICTORY_CITY_COUNT - context.connectedMajorCities.length);
+  const cheapestConnectors = (context.unconnectedMajorCities ?? [])
+    .slice(0, majorsGap)
+    .map((e) => ({ cityName: e.cityName, costM: e.estimatedCost }));
+  const fullWinCostM = cashGapM + cheapestConnectors.reduce((s, c) => s + c.costM, 0);
+
+  let victoryRouteProjection: EndGameTrace['victoryRouteProjection'];
+  if (outcome.outcome === 'fire') {
+    const stops = outcome.route.stops.map((s) => `${s.action}:${s.loadType}@${s.city}`);
+    victoryRouteProjection = {
+      outcome: 'fire',
+      stops,
+      turns: outcome.route.estimatedTurns,
+      buildM: outcome.route.buildCost,
+      payoutM: outcome.route.totalPayout,
+      cashAtVictory: outcome.route.cashAtVictory,
+      majorsAtVictory: outcome.route.majorsAtVictory,
+      appliedOverride,
+    };
+  } else {
+    victoryRouteProjection = { outcome: 'skip', reason: outcome.reason };
+  }
+
+  let activePlanProjection: EndGameTrace['activePlanProjection'];
+  if (activeRoute && activeRoute.stops.length > activeRoute.currentStopIndex) {
+    const remaining = activeRoute.stops.slice(activeRoute.currentStopIndex);
+    const remainingStops = remaining.length;
+    const connectorCitySet = new Set(cheapestConnectors.map((c) => c.cityName));
+    let projectedPayout = 0;
+    let connectorAdds = 0;
+    for (const s of remaining) {
+      if (s.action === 'deliver') {
+        projectedPayout += s.payment ?? 0;
+        if (connectorCitySet.has(s.city)) connectorAdds += 1;
+      }
+    }
+    const projectedCash = context.money + projectedPayout;
+    const projectedMajors = context.connectedMajorCities.length + connectorAdds;
+    const willClinch = projectedCash >= VICTORY_INITIAL_THRESHOLD && projectedMajors >= VICTORY_CITY_COUNT;
+    activePlanProjection = { willClinch, projectedCash, projectedMajors, remainingStops };
+  }
+
+  return {
+    inEndGame: true,
+    endGameLocked: !!memory.endGameLocked,
+    cashGapM,
+    majorsGap,
+    cheapestConnectors,
+    fullWinCostM,
+    victoryRouteProjection,
+    activePlanProjection,
   };
 }


### PR DESCRIPTION
## Summary

**Stacked on `integration/phase4-base`** (which itself merges PR #247 + PR #252 + PR #257 + PR #258) because JIRA-265 depends on:
- `restrictionPredicates` from PR #247 (JIRA-256 foundation)
- `routesMatch` helper from PR #252 (JIRA-261)
- `endGameLocked` mechanism from PR #257 (JIRA-255)
- multiplicity-aware carry detection from PR #255 (JIRA-248-250)

> *About `integration/phase4-base`*: not a PR itself — a working branch merging the prior 11 PRs so Phase 4 PRs (263, 265-273) can be reviewed as small per-JIRA diffs without each one having to wait on the others to land first.

## What JIRA-265 fixes

Three connected gaps surfaced in game `086fa2ce` season 1 turns T61–T79:

| Layer | What |
|---|---|
| **Layer 1** | Per-turn NDJSON has no `endGame` trace — invisible to post-mortems whether the end-game lock fired, why a victory route did or didn't override, or what cash/connection state drove the planner |
| **Layer 2** | `endGameLocked` latch lived in `planTripDeterministic`, so it only engaged on replan turns. Continued-route turns skipped the latch entirely. Moved to `ContextBuilder` so it engages on every turn. |
| **Layer 3** | `NetworkContext.computePhase` returned 'Mid Game' even when `gameState=End`, so the leaderboard display disagreed with the cash-latched state. Now returns 'End Game' whenever `gameState=End`. |

## Per-ticket docs
- `docs/ai/done/jira-265-endGameStateNoPerTurnVisibilityAndLockNotEngaged-behavioral.md`
- `docs/ai/done/jira-265-endGameStateNoPerTurnVisibilityAndLockNotEngaged-technical.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] After all prior PRs (#247, #252, #257, #258, #255, #256) land on main, retarget base to `main`

**Base**: `integration/phase4-base`. Stack: Phase 1-3 PRs → integration → PR-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)