### PR TITLE
feat(ai): JIRA-269 — move LLM-vs-deterministic dispatch inside NewRoutePlanner

### DIFF
--- a/docs/ai/done/jira-269-mediumBotPassesTurnAfterInitialRouteCompletes.md
+++ b/docs/ai/done/jira-269-mediumBotPassesTurnAfterInitialRouteCompletes.md
@@ -1,0 +1,20 @@
+# JIRA-269 — Medium bots pass every turn with `[no-api-key] No LLM API key configured — passing turn` once the initial route completes
+
+Regression from JIRA-268. Medium is deterministic; it should never reach a code path that gates on LLM credentials.
+
+## Source
+
+`logs/game-c73cccf8-919e-462c-8250-28b2199665a4.ndjson`, player s1, T2–T8. New game on commit `45b39db`. 2026-05-27.
+
+## Trace
+
+| Turn | action | reasoning |
+|------|--------|-----------|
+| T2–T4 | BuildTrack | initial build + route execution, normal |
+| T6+ | DiscardHand | `[no-api-key] No LLM API key configured — passing turn` |
+
+Every Medium game ends in practice as soon as the initial route completes.
+
+## Expected behavior
+
+When the bot needs a new plan, the dispatcher hands the request to a planner. The planner decides LLM vs deterministic based on the bot's skill. The dispatcher does not inspect credentials or skill level.

--- a/src/server/__tests__/ai/AIStrategyEngine.test.ts
+++ b/src/server/__tests__/ai/AIStrategyEngine.test.ts
@@ -529,10 +529,16 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
   });
 
   describe('successful turn — PassTurn (no API key)', () => {
-    it('should pass turn directly when no LLM API key is available', async () => {
+    it('should pass turn directly when no LLM API key is available for an LLM skill level', async () => {
+      // Remove ALL credential paths so hasLLMApiKey returns false for anthropic provider
+      const savedUseClaudeCode = process.env.ANTHROPIC_USE_CLAUDE_CODE;
       delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.ANTHROPIC_USE_CLAUDE_CODE;
 
-      const snapshot = makeSnapshot({ botConfig: null } as any);
+      // Use Easy skill — requires LLM, has no key → NewRoutePlanner returns cannotPlan
+      const snapshot = makeSnapshot({
+        botConfig: { skillLevel: BotSkillLevel.Easy, provider: 'anthropic' } as any,
+      });
       const context = makeContext();
 
       mockCapture.mockResolvedValue(snapshot);
@@ -540,7 +546,10 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
 
       const result = await AIStrategyEngine.takeTurn('game-1', 'bot-1');
 
-      // Without API key, should PassTurn directly (no heuristic fallback)
+      // Restore env
+      if (savedUseClaudeCode !== undefined) process.env.ANTHROPIC_USE_CLAUDE_CODE = savedUseClaudeCode;
+
+      // Without API key for LLM skill, should PassTurn via cannotPlan path
       expect(result.action).toBe(AIActionType.PassTurn);
       expect(result.reasoning).toContain('no-api-key');
 
@@ -1992,13 +2001,16 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
       expect(result.retried).toBe(false);
     });
 
-    it('should set model="no-api-key" when no LLM API key configured', async () => {
+    it('should set model="no-api-key" when no LLM API key configured for LLM skill level', async () => {
+      // Remove ALL credential paths so hasLLMApiKey returns false for anthropic provider
+      const savedUseClaudeCode = process.env.ANTHROPIC_USE_CLAUDE_CODE;
       delete process.env.ANTHROPIC_API_KEY;
       delete process.env.GOOGLE_AI_API_KEY;
+      delete process.env.ANTHROPIC_USE_CLAUDE_CODE;
 
       mockGetMemory.mockResolvedValue({
         turnNumber: 0,
-        
+
         consecutiveDiscards: 0,
         lastAction: null,
         activeRoute: null,
@@ -2011,12 +2023,18 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
         consecutiveLlmFailures: 0,
       });
 
-      const snapshot = makeSnapshot({ botConfig: null } as any);
+      // Use Easy skill — requires LLM, has no key → cannotPlan → model='no-api-key'
+      const snapshot = makeSnapshot({
+        botConfig: { skillLevel: BotSkillLevel.Easy, provider: 'anthropic' } as any,
+      });
       const context = makeContext();
       mockCapture.mockResolvedValue(snapshot);
       mockContextBuild.mockResolvedValue(context);
 
       const result = await AIStrategyEngine.takeTurn('game-1', 'bot-1');
+
+      // Restore env
+      if (savedUseClaudeCode !== undefined) process.env.ANTHROPIC_USE_CLAUDE_CODE = savedUseClaudeCode;
 
       expect(result.model).toBe('no-api-key');
       expect(result.llmLatencyMs).toBe(0);
@@ -2542,13 +2560,16 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
       delete process.env.ANTHROPIC_API_KEY;
     });
 
-    it('should have no llmLog when no API key configured', async () => {
+    it('should have no llmLog when no API key configured for LLM skill level', async () => {
+      // Remove ALL credential paths so hasLLMApiKey returns false for anthropic provider
+      const savedUseClaudeCode = process.env.ANTHROPIC_USE_CLAUDE_CODE;
       delete process.env.ANTHROPIC_API_KEY;
       delete process.env.GOOGLE_AI_API_KEY;
+      delete process.env.ANTHROPIC_USE_CLAUDE_CODE;
 
       mockGetMemory.mockResolvedValue({
         turnNumber: 0,
-        
+
         consecutiveDiscards: 0,
         lastAction: null,
         activeRoute: null,
@@ -2561,12 +2582,18 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
         consecutiveLlmFailures: 0,
       });
 
-      const snapshot = makeSnapshot({ botConfig: null } as any);
+      // Use Easy skill — requires LLM, has no key → cannotPlan → no llmLog
+      const snapshot = makeSnapshot({
+        botConfig: { skillLevel: BotSkillLevel.Easy, provider: 'anthropic' } as any,
+      });
       const context = makeContext();
       mockCapture.mockResolvedValue(snapshot);
       mockContextBuild.mockResolvedValue(context);
 
       const result = await AIStrategyEngine.takeTurn('game-1', 'bot-1');
+
+      // Restore env
+      if (savedUseClaudeCode !== undefined) process.env.ANTHROPIC_USE_CLAUDE_CODE = savedUseClaudeCode;
 
       expect(result.llmLog).toBeUndefined();
     });

--- a/src/server/__tests__/ai/AIStrategyEngine.test.ts
+++ b/src/server/__tests__/ai/AIStrategyEngine.test.ts
@@ -4376,7 +4376,7 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
       // Override TripPlanner mock for this test: planTrip returns a route directly,
       // without calling brain.planRoute (which is null for Medium bots).
       TripPlanner.mockImplementationOnce(() => ({
-        planTrip: jest.fn().mockResolvedValue({
+        planTrip: jest.fn<() => Promise<unknown>>().mockResolvedValue({
           route,
           llmLatencyMs: 0,
           llmTokens: { input: 0, output: 0 },

--- a/src/server/__tests__/ai/AIStrategyEngine.test.ts
+++ b/src/server/__tests__/ai/AIStrategyEngine.test.ts
@@ -4338,4 +4338,114 @@ describe('AIStrategyEngine.takeTurn (Integration)', () => {
     });
   });
 
+  // ── JIRA-269 TEST-001: AIStrategyEngine dispatch integration ──────────────
+  // Regression tests that verify the new single-branch dispatcher works
+  // correctly for both the deterministic (Medium) and cannotPlan (Easy+no-key)
+  // paths from the AIStrategyEngine level.
+
+  describe('JIRA-269 TEST-001: AIStrategyEngine dispatch integration', () => {
+    it('Medium bot with no active route and demands produces a non-PassTurn plan', async () => {
+      // Medium bots: hasLLMApiKey returns false → brain=null → DETERMINISTIC_SKILLS path
+      // TripPlanner.planTripDeterministic is called internally; the mock must return a
+      // route without calling brain.planRoute (which would throw for null brain).
+
+      // Explicitly reset memory so no leaked activeRoute from prior tests causes
+      // the route-executor path to fire instead of NewRoutePlanner.
+      mockGetMemory.mockResolvedValue({
+        turnNumber: 0,
+        consecutiveDiscards: 0,
+        lastAction: null,
+        activeRoute: null,
+        turnsOnRoute: 0,
+        routeHistory: [],
+        currentBuildTarget: null,
+        turnsOnTarget: 0,
+        deliveryCount: 0,
+        totalEarnings: 0,
+        consecutiveLlmFailures: 0,
+      });
+
+      const { TripPlanner } = require('../../services/ai/TripPlanner');
+      const route: StrategicRoute = {
+        stops: [{ action: 'pickup', loadType: 'Steel', city: 'Berlin' }],
+        currentStopIndex: 0,
+        phase: 'build' as const,
+        reasoning: 'Deterministic route — Medium skill',
+        createdAtTurn: 1,
+      };
+      // Override TripPlanner mock for this test: planTrip returns a route directly,
+      // without calling brain.planRoute (which is null for Medium bots).
+      TripPlanner.mockImplementationOnce(() => ({
+        planTrip: jest.fn().mockResolvedValue({
+          route,
+          llmLatencyMs: 0,
+          llmTokens: { input: 0, output: 0 },
+          llmLog: [],
+        }),
+      }));
+
+      mockTurnExecutorPlannerExecute.mockResolvedValue(mockTurnExecResult({
+        plan: { type: AIActionType.BuildTrack, segments: [makeSegment(10, 10, 10, 11)] },
+        routeComplete: false,
+        routeAbandoned: false,
+        updatedRoute: route,
+        description: 'Building toward Berlin (deterministic)',
+      }));
+
+      const snapshot = makeSnapshot({
+        botConfig: { skillLevel: BotSkillLevel.Medium, provider: 'anthropic' } as any,
+      });
+      const context = makeContext({ demands: [makeViableDemand()] });
+      mockCapture.mockResolvedValue(snapshot);
+      mockContextBuild.mockResolvedValue(context);
+
+      const result = await AIStrategyEngine.takeTurn('game-1', 'bot-1');
+
+      // Medium bot should produce a real plan, not a PassTurn
+      expect(result.action).not.toBe(AIActionType.PassTurn);
+      expect(result.reasoning).not.toContain('[no-api-key]');
+      // LLMStrategyBrain should NOT have been created (Medium never uses LLM)
+      expect(LLMStrategyBrain).not.toHaveBeenCalled();
+    });
+
+    it('Easy bot with no API key produces PassTurn with [no-api-key] reasoning', async () => {
+      // Remove ALL credential paths so hasLLMApiKey returns false for Easy → brain=null
+      const savedUseClaudeCode = process.env.ANTHROPIC_USE_CLAUDE_CODE;
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.ANTHROPIC_USE_CLAUDE_CODE;
+
+      // Explicitly reset memory so no leaked activeRoute from prior tests causes
+      // the route-executor path to fire instead of NewRoutePlanner (cannotPlan).
+      mockGetMemory.mockResolvedValue({
+        turnNumber: 0,
+        consecutiveDiscards: 0,
+        lastAction: null,
+        activeRoute: null,
+        turnsOnRoute: 0,
+        routeHistory: [],
+        currentBuildTarget: null,
+        turnsOnTarget: 0,
+        deliveryCount: 0,
+        totalEarnings: 0,
+        consecutiveLlmFailures: 0,
+      });
+
+      const snapshot = makeSnapshot({
+        botConfig: { skillLevel: BotSkillLevel.Easy, provider: 'anthropic' } as any,
+      });
+      const context = makeContext({ demands: [makeViableDemand()] });
+      mockCapture.mockResolvedValue(snapshot);
+      mockContextBuild.mockResolvedValue(context);
+
+      const result = await AIStrategyEngine.takeTurn('game-1', 'bot-1');
+
+      // Restore env
+      if (savedUseClaudeCode !== undefined) process.env.ANTHROPIC_USE_CLAUDE_CODE = savedUseClaudeCode;
+
+      // ADR-5: [no-api-key] reasoning preserved verbatim
+      expect(result.action).toBe(AIActionType.PassTurn);
+      expect(result.reasoning).toContain('[no-api-key] No LLM API key configured — passing turn');
+    });
+  });
+
 });

--- a/src/server/__tests__/ai/NewRoutePlanner.test.ts
+++ b/src/server/__tests__/ai/NewRoutePlanner.test.ts
@@ -40,6 +40,17 @@ import type {
 import type { LLMStrategyBrain } from '../../services/ai/LLMStrategyBrain';
 import type { CompositionTrace, TurnExecutorResult } from '../../services/ai/TurnExecutorPlanner';
 import type { TripPlanResult } from '../../services/ai/TripPlanner';
+import type { NewRoutePlannerResult } from '../../services/ai/schemas';
+
+/**
+ * Type-narrowing helper — asserts the result is the successful (non-cannotPlan) variant.
+ * Used in tests that exercise the normal planning path.
+ */
+function assertPlanResult(result: NewRoutePlannerResult): asserts result is Extract<NewRoutePlannerResult, { cannotPlan?: false }> {
+  if (result.cannotPlan) {
+    throw new Error(`Expected a plan result but got cannotPlan: ${result.reason}`);
+  }
+}
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -286,6 +297,8 @@ describe('NewRoutePlanner.run', () => {
         gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
+
       // Auto-delivery executed
       expect(mockExecutePlan).toHaveBeenCalledTimes(1);
       const deliverArg = mockExecutePlan.mock.calls[0][0] as TurnPlanDeliverLoad;
@@ -341,6 +354,7 @@ describe('NewRoutePlanner.run', () => {
         gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
       expect(result.activeRoute).toBeDefined();
       expect(result.decision.model).toBe('trip-planner');
       expect(result.decision.reasoning).toContain('[route-planned]');
@@ -362,6 +376,7 @@ describe('NewRoutePlanner.run', () => {
         gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
       expect(mockHeuristicFallback).toHaveBeenCalledTimes(1);
       expect(result.decision.model).toBe('heuristic-fallback');
       expect(result.decision.plan).toBe(fallbackPlan);
@@ -380,6 +395,7 @@ describe('NewRoutePlanner.run', () => {
         gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
       expect(result.decision.plan.type).toBe(AIActionType.PassTurn);
       expect(result.decision.model).toBe('llm-failed');
     });
@@ -401,6 +417,7 @@ describe('NewRoutePlanner.run', () => {
         tag, gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
       expect(result.pendingUpgradeAction).not.toBeNull();
       expect(result.pendingUpgradeAction!.type).toBe(AIActionType.UpgradeTrain);
       expect(result.pendingUpgradeAction!.targetTrain).toBe(TrainType.FastFreight);
@@ -422,6 +439,7 @@ describe('NewRoutePlanner.run', () => {
         tag, gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
       expect(result.pendingUpgradeAction).toBeNull();
       expect(result.upgradeSuppressionReason).toContain('Upgrade blocked');
     });
@@ -446,6 +464,7 @@ describe('NewRoutePlanner.run', () => {
         tag, gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
       // Upgrade should be suppressed because route was abandoned this turn
       expect(result.pendingUpgradeAction).toBeNull();
       expect(result.upgradeSuppressionReason).toBe('route_abandoned_this_turn');
@@ -495,6 +514,7 @@ describe('NewRoutePlanner.run', () => {
         gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
       expect(result.deadLoadDropActions).toHaveLength(1);
       expect(result.deadLoadDropActions[0].type).toBe(AIActionType.DropLoad);
       expect(result.deadLoadDropActions[0].load).toBe('Wood');
@@ -536,6 +556,7 @@ describe('NewRoutePlanner.run', () => {
         tag, gameId, botPlayerId, BotSkillLevel.Medium,
       );
 
+      assertPlanResult(result);
       expect(brain.evaluateUpgradeBeforeDrop).toHaveBeenCalledTimes(1);
       expect(result.pendingUpgradeAction).not.toBeNull();
       expect(result.pendingUpgradeAction!.targetTrain).toBe(TrainType.HeavyFreight);
@@ -567,10 +588,11 @@ describe('NewRoutePlanner.run', () => {
 
       const snapshot = makeSnapshot({ money: 50, trainType: TrainType.Freight, loads: ['Wood', 'Iron'] });
 
+      // Hard skill — LLM enhancements (cargo-conflict) are enabled
       const result = await NewRoutePlanner.run(
         snapshot, makeContext(), brain, gridPoints,
         makeMemory({ deliveryCount: 5 }),
-        tag, gameId, botPlayerId, BotSkillLevel.Medium,
+        tag, gameId, botPlayerId, BotSkillLevel.Hard,
       );
 
       expect(brain.evaluateCargoConflict).toHaveBeenCalledTimes(1);
@@ -597,6 +619,78 @@ describe('NewRoutePlanner.run', () => {
         tag, gameId, botPlayerId, BotSkillLevel.Easy,
       );
 
+      expect(brain.evaluateCargoConflict).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── JIRA-269: LLM-vs-deterministic dispatch and null-brain guard ─────────
+
+  describe('JIRA-269 — internal dispatch (null brain)', () => {
+    it('returns { cannotPlan: true, reason: "no-api-key" } for Easy skill with null brain', async () => {
+      const result = await NewRoutePlanner.run(
+        makeSnapshot(), makeContext(), null, gridPoints, makeMemory(),
+        tag, gameId, botPlayerId, BotSkillLevel.Easy,
+      );
+
+      expect(result.cannotPlan).toBe(true);
+      if (result.cannotPlan) {
+        expect(result.reason).toBe('no-api-key');
+      }
+    });
+
+    it('returns { cannotPlan: true, reason: "no-api-key" } for Hard skill with null brain', async () => {
+      const result = await NewRoutePlanner.run(
+        makeSnapshot(), makeContext(), null, gridPoints, makeMemory(),
+        tag, gameId, botPlayerId, BotSkillLevel.Hard,
+      );
+
+      expect(result.cannotPlan).toBe(true);
+      if (result.cannotPlan) {
+        expect(result.reason).toBe('no-api-key');
+      }
+    });
+
+    it('returns a plan result (no cannotPlan) for Medium skill with null brain', async () => {
+      // Medium skill uses deterministic path — brain not required
+      const result = await NewRoutePlanner.run(
+        makeSnapshot(), makeContext(), null, gridPoints, makeMemory(),
+        tag, gameId, botPlayerId, BotSkillLevel.Medium,
+      );
+
+      // Should not be a cannotPlan result
+      expect(result.cannotPlan).toBeFalsy();
+      assertPlanResult(result);
+      // Should have reached the planning stage
+      expect(result.decision).toBeDefined();
+    });
+  });
+
+  describe('JIRA-269 — ADR-4: Medium skill never calls LLM enhancements', () => {
+    it('does NOT call brain.evaluateUpgradeBeforeDrop or brain.evaluateCargoConflict for Medium skill even with non-null brain', async () => {
+      // A conflict route: 3 pickups but only 2 capacity — cargo conflict conditions met
+      const route = makeRoute({
+        stops: [makeStop('pickup', 'A', 'Steel'), makeStop('pickup', 'B', 'Iron'), makeStop('pickup', 'C', 'Coal'), makeStop('deliver', 'X', 'Steel')],
+        currentStopIndex: 0,
+      });
+      MockTripPlannerClass.mockImplementation(() => ({
+        planTrip: jest.fn().mockResolvedValue(makeTripResult(route)),
+      }) as unknown as TripPlanner);
+
+      const brain = makeBrain({
+        evaluateUpgradeBeforeDrop: jest.fn().mockResolvedValue({ action: 'upgrade', targetTrain: TrainType.HeavyFreight, reasoning: 'capacity' }),
+        evaluateCargoConflict: jest.fn().mockResolvedValue({ action: 'drop', dropLoad: 'Coal', reasoning: 'lowest' }),
+      });
+
+      // Snapshot: freight (capacity 2), 0 loads → 3 pickups > 2 slots = conflict
+      await NewRoutePlanner.run(
+        makeSnapshot({ trainType: TrainType.Freight, loads: [] }),
+        makeContext(),
+        brain, gridPoints, makeMemory({ deliveryCount: 5 }),
+        tag, gameId, botPlayerId, BotSkillLevel.Medium,
+      );
+
+      // ADR-4: Medium deterministic path — LLM enhancements always skipped
+      expect(brain.evaluateUpgradeBeforeDrop).not.toHaveBeenCalled();
       expect(brain.evaluateCargoConflict).not.toHaveBeenCalled();
     });
   });

--- a/src/server/services/ai/AIStrategyEngine.ts
+++ b/src/server/services/ai/AIStrategyEngine.ts
@@ -383,44 +383,48 @@ export class AIStrategyEngine {
         // ── Auto-execute from active route (delegated to ActiveRouteContinuer) ──
         const partial = await ActiveRouteContinuer.run(activeRoute, snapshot, context, brain, gridPoints, tag, memory);
         ({ decision, activeRoute, routeWasCompleted, routeWasAbandoned, hasDelivery, execCompositionTrace, pendingUpgradeAction, upgradeSuppressionReason } = partial);
-      } else if (AIStrategyEngine.hasLLMApiKey(botConfig)) {
-        // ── No active route, LLM available — delegated to NewRoutePlanner (JIRA-195b sub-slice D) ──
-        // NewRoutePlanner owns sub-stages D1-D7 + E. Returns the full Stage3Result
-        // including reassigned snapshot and context (the JIRA-170 boundary becomes
-        // explicit in the type system) plus autoDeliveredLoads and tripPlanResult
+      } else {
+        // ── No active route — delegated to NewRoutePlanner (JIRA-195b sub-slice D / JIRA-269) ──
+        // NewRoutePlanner owns sub-stages D1-D7 + E and all LLM-vs-deterministic dispatch (ADR-1).
+        // brain may be null — NewRoutePlanner handles the no-api-key case internally.
+        // Returns the full Stage3Result including reassigned snapshot and context (the JIRA-170
+        // boundary becomes explicit in the type system) plus autoDeliveredLoads and tripPlanResult
         // for downstream game/LLM logging.
         const stage3Partial = await NewRoutePlanner.run(
-          snapshot, context, brain!, gridPoints, memory, tag,
+          snapshot, context, brain, gridPoints, memory, tag,
           gameId, botPlayerId, skillLevel,
         );
-        ({
-          decision, activeRoute, routeWasCompleted, routeWasAbandoned, hasDelivery,
-          secondaryDeliveryLog, pendingUpgradeAction, upgradeSuppressionReason,
-          execCompositionTrace,
-        } = stage3Partial);
-        snapshot = stage3Partial.snapshot;
-        context = stage3Partial.context;
-        if (stage3Partial.deadLoadDropActions.length > 0) {
-          deadLoadDropActions.push(...stage3Partial.deadLoadDropActions);
+
+        if (stage3Partial.cannotPlan) {
+          // ADR-2: cannotPlan is a typed discriminator — emit PassTurn with preserved reasoning.
+          console.error(`${tag} [LLM] No API key configured — passing turn`);
+          decision = {
+            plan: { type: AIActionType.PassTurn },
+            reasoning: '[no-api-key] No LLM API key configured — passing turn',
+            planHorizon: 'Immediate',
+            model: 'no-api-key',
+            latencyMs: 0,
+            retried: false,
+            userPrompt: '[No API key] Passing turn — no LLM provider configured',
+          };
+        } else {
+          ({
+            decision, activeRoute, routeWasCompleted, routeWasAbandoned, hasDelivery,
+            secondaryDeliveryLog, pendingUpgradeAction, upgradeSuppressionReason,
+            execCompositionTrace,
+          } = stage3Partial);
+          snapshot = stage3Partial.snapshot;
+          context = stage3Partial.context;
+          if (stage3Partial.deadLoadDropActions.length > 0) {
+            deadLoadDropActions.push(...stage3Partial.deadLoadDropActions);
+          }
+          if (stage3Partial.autoDeliveredLoads.length > 0) {
+            autoDeliveredLoads.push(...stage3Partial.autoDeliveredLoads);
+          }
+          if (stage3Partial.tripPlanResult) {
+            tripPlanResult = stage3Partial.tripPlanResult;
+          }
         }
-        if (stage3Partial.autoDeliveredLoads.length > 0) {
-          autoDeliveredLoads.push(...stage3Partial.autoDeliveredLoads);
-        }
-        if (stage3Partial.tripPlanResult) {
-          tripPlanResult = stage3Partial.tripPlanResult;
-        }
-      } else {
-        // No LLM key — pass turn with debug logging
-        console.error(`${tag} [LLM] No API key configured — passing turn`);
-        decision = {
-          plan: { type: AIActionType.PassTurn },
-          reasoning: '[no-api-key] No LLM API key configured — passing turn',
-          planHorizon: 'Immediate',
-          model: 'no-api-key',
-          latencyMs: 0,
-          retried: false,
-          userPrompt: '[No API key] Passing turn — no LLM provider configured',
-        };
       }
 
       // ── JIRA-195b sub-slice A: Assemble Stage3Result from four-branch locals ──

--- a/src/server/services/ai/NewRoutePlanner.ts
+++ b/src/server/services/ai/NewRoutePlanner.ts
@@ -51,7 +51,9 @@ import { TurnExecutorPlanner, CompositionTrace } from './TurnExecutorPlanner';
 import { appendLLMCall } from './LLMTranscriptLogger';
 import { TripPlanner, TripPlanResult } from './TripPlanner';
 import { loadGridPoints as loadGridPointsMap } from '../MapTopology';
-import type { Stage3Result } from './schemas';
+import type { Stage3Result, NewRoutePlannerResult } from './schemas';
+
+export type { NewRoutePlannerResult };
 
 /**
  * Minimum number of completed deliveries before a bot may upgrade its train.
@@ -61,40 +63,38 @@ import type { Stage3Result } from './schemas';
 const MIN_DELIVERIES_BEFORE_UPGRADE = 2;
 
 /**
- * NewRoutePlanner result — full Stage3Result plus two diagnostic fields the
- * caller's outer scope still needs for game/LLM logging.
+ * Skill levels that use deterministic (non-LLM) trip planning.
+ * Brain may be null for these skill levels.
  */
-export interface NewRoutePlannerResult extends Stage3Result {
-  autoDeliveredLoads: Array<{ loadType: string; city: string; payment: number; cardId: number }>;
-  tripPlanResult: TripPlanResult | null;
-}
+const DETERMINISTIC_SKILLS = new Set([BotSkillLevel.Medium]);
 
 export class NewRoutePlanner {
   /**
-   * Run the no-active-route LLM consultation branch for one turn.
+   * Run the no-active-route planning branch for one turn.
    *
-   * Caller must verify `brain` is non-null (no-LLM-key path stays inline in the
-   * orchestrator per ADR-2). On entry, `activeRoute` is null; on return, it may be
-   * a fresh planned route or null (heuristic-fallback or pass-turn paths).
+   * Dispatch logic (ADR-1):
+   *   - skillLevel ∈ DETERMINISTIC_SKILLS (Medium): proceeds deterministic; brain may be null.
+   *   - skillLevel ∈ {Easy, Hard} and brain != null: proceeds via LLM path.
+   *   - skillLevel ∈ {Easy, Hard} and brain === null: returns { cannotPlan: true, reason: 'no-api-key' }.
    *
    * @param snapshot     World state at decision time. May be reassigned internally
    *                     by JIRA-170 auto-delivery refresh; the final value is
    *                     returned via `result.snapshot`.
    * @param context      Decision-relevant context. May be reassigned internally
    *                     by JIRA-170; final value returned via `result.context`.
-   * @param brain        LLM brain — required (caller has already verified).
+   * @param brain        LLM brain — null is allowed for Medium (deterministic) skill.
    * @param gridPoints   Hex-grid topology for path planning.
    * @param memory       Bot memory state (deliveryCount, consecutiveLlmFailures).
    * @param tag          Log prefix for traceability.
    * @param gameId       Game UUID — needed for snapshot refresh + LLM transcript log.
    * @param botPlayerId  Bot player UUID — needed for snapshot refresh + LLM transcript log.
-   * @param skillLevel   Bot skill level — gates JIRA-92 cargo-conflict LLM call.
-   * @returns Full Stage3Result + autoDeliveredLoads + tripPlanResult.
+   * @param skillLevel   Bot skill level — governs LLM-vs-deterministic dispatch.
+   * @returns Full Stage3Result + autoDeliveredLoads + tripPlanResult, or cannotPlan sentinel.
    */
   static async run(
     snapshot: WorldSnapshot,
     context: GameContext,
-    brain: LLMStrategyBrain,
+    brain: LLMStrategyBrain | null,
     gridPoints: GridPoint[],
     memory: BotMemoryState,
     tag: string,
@@ -102,6 +102,10 @@ export class NewRoutePlanner {
     botPlayerId: string,
     skillLevel: BotSkillLevel,
   ): Promise<NewRoutePlannerResult> {
+    // ADR-1 dispatch: LLM skill levels require a brain; deterministic skill levels do not.
+    if (!DETERMINISTIC_SKILLS.has(skillLevel) && brain === null) {
+      return { cannotPlan: true, reason: 'no-api-key' };
+    }
     let decision: LLMDecisionResult;
     let activeRoute: StrategicRoute | null = null;
     let routeWasCompleted = false;
@@ -176,7 +180,7 @@ export class NewRoutePlanner {
           timestamp: new Date().toISOString(),
           caller: 'trip-planner',
           method: 'shortCircuit',
-          model: brain.modelName,
+          model: brain?.modelName ?? 'deterministic',
           systemPrompt: '',
           userPrompt: '',
           responseText: '',
@@ -286,9 +290,13 @@ export class NewRoutePlanner {
       })();
       const effectiveFreeSlots = trainCapacity - snapshot.bot.loads.length;
 
+      // ADR-4: LLM enhancements (upgrade-before-drop, cargo-conflict) only run on
+      // non-deterministic LLM skill levels. Easy and Medium both skip this block:
+      //  - Easy: existing game rule — cargo conflict not evaluated for Easy bots
+      //  - Medium: deterministic path — skips LLM enhancements regardless of brain availability
       if (
         routePickupCount > effectiveFreeSlots &&
-        skillLevel !== BotSkillLevel.Easy
+        skillLevel === BotSkillLevel.Hard
       ) {
         // ── D6a: JIRA-105b — Upgrade-before-drop check ──
         // Before asking to drop, check if upgrading gives enough capacity
@@ -313,7 +321,7 @@ export class NewRoutePlanner {
             }
           }
 
-          if (upgradeOptions.length > 0) {
+          if (upgradeOptions.length > 0 && brain) {
             // Sort by cost ascending (cheapest first)
             upgradeOptions.sort((a, b) => a.cost - b.cost);
 
@@ -322,6 +330,7 @@ export class NewRoutePlanner {
               .filter(s => s.action === 'deliver' && s.payment)
               .reduce((sum, s) => sum + (s.payment ?? 0), 0);
 
+            // ADR-4: evaluateUpgradeBeforeDrop is an LLM enhancement — only call when brain exists.
             try {
               const upgradePrompt = ContextSerializer.serializeUpgradeBeforeDropPrompt(
                 snapshot, activeRoute, upgradeOptions, totalRoutePayout, context.demands,
@@ -360,7 +369,8 @@ export class NewRoutePlanner {
           );
           const conflictingLoads = snapshot.bot.loads.filter(l => !routeDeliveryLoads.has(l));
 
-          if (conflictingLoads.length > 0) {
+          // ADR-4: evaluateCargoConflict is an LLM enhancement — skip when brain is null.
+          if (conflictingLoads.length > 0 && brain) {
             try {
               const cargoPrompt = ContextSerializer.serializeCargoConflictPrompt(snapshot, activeRoute, conflictingLoads, context.demands);
               const conflictResult = await brain.evaluateCargoConflict(cargoPrompt, snapshot, context);

--- a/src/server/services/ai/TripPlanner.ts
+++ b/src/server/services/ai/TripPlanner.ts
@@ -120,9 +120,14 @@ const MAX_RETRIES = 2;
 // ── TripPlanner ──────────────────────────────────────────────────────
 
 export class TripPlanner {
-  private readonly brain: LLMStrategyBrain;
+  private readonly brain: LLMStrategyBrain | null;
 
-  constructor(brain: LLMStrategyBrain) {
+  /**
+   * @param brain LLM brain. May be null for deterministic skill levels (e.g. Medium).
+   *              All LLM call sites guard against null; the Medium deterministic path
+   *              does not dereference brain at all.
+   */
+  constructor(brain: LLMStrategyBrain | null) {
     this.brain = brain;
   }
 
@@ -139,10 +144,9 @@ export class TripPlanner {
     /** JIRA-253 Layer B: Route signatures to exclude from deterministic planner consideration. */
     excludeRouteSignatures?: string[],
   ): Promise<TripPlanResult> {
-    const config = this.brain.strategyConfig;
-    const adapter = this.brain.providerAdapter;
-    const model = this.brain.modelName;
-    const skillLevel = config.skillLevel;
+    // For deterministic skill levels (e.g. Medium) brain may be null.
+    // Only dereference brain fields in the LLM path (after the Medium guard below).
+    const skillLevel = this.brain?.strategyConfig.skillLevel ?? BotSkillLevel.Medium;
 
     // ── JIRA-207B (R10c): Pre-LLM short-circuit — evaluate NEW OPTIONS filter ──
     // If every demand card is either unaffordable or already a carry-load commitment, the
@@ -239,6 +243,17 @@ export class TripPlanner {
       console.warn('[TripPlanner] Medium deterministic returned no_feasible_candidates; falling through to planRoute heuristic');
       return this.heuristicFallback(snapshot, context, gridPoints, memory, [detResult.synthesizedAttempt]);
     }
+
+    // Reaching here means skillLevel is Easy or Hard (not Medium).
+    // Brain is required for the LLM path — should never be null here because
+    // NewRoutePlanner.run already short-circuits cannotPlan for null-brain LLM skills.
+    // The assertion keeps TypeScript happy and provides a runtime safety net.
+    if (!this.brain) {
+      console.error('[TripPlanner] brain is null on LLM path — returning route=null');
+      return { route: null, llmLatencyMs: 0, llmTokens: { input: 0, output: 0 }, llmLog: [] };
+    }
+    const adapter = this.brain.providerAdapter;
+    const model = this.brain.modelName;
 
     // Build strategic context for Medium skill (Task 1 foundation — now dead code for Medium,
     // preserved as dead code per JIRA-220 §"Out of scope" for potential Hard rebuild.
@@ -528,6 +543,18 @@ export class TripPlanner {
     memory: BotMemoryState,
     priorLlmLog: LlmAttempt[],
   ): Promise<TripPlanResult> {
+    // Brain is required for the heuristic fallback path. When brain is null
+    // (deterministic skill level), skip the LLM heuristic and return route=null
+    // so the caller falls through to ActionResolver.heuristicFallback.
+    if (!this.brain) {
+      console.warn('[TripPlanner] heuristicFallback skipped — no brain (deterministic skill level)');
+      return {
+        route: null,
+        llmLatencyMs: 0,
+        llmTokens: { input: 0, output: 0 },
+        llmLog: priorLlmLog,
+      };
+    }
     console.warn(`[TripPlanner] All attempts failed, falling back to planRoute()`);
     try {
       const fallback = await this.brain.planRoute(

--- a/src/server/services/ai/schemas.ts
+++ b/src/server/services/ai/schemas.ts
@@ -379,6 +379,26 @@ export interface Stage3Result {
   context: import('../../../shared/types/GameTypes').GameContext;
 }
 
+// ── NewRoutePlannerResult ─────────────────────────────────────────────────
+
+/**
+ * NewRoutePlanner.run return type — discriminated union on `cannotPlan`.
+ *
+ * When `cannotPlan` is true the planner short-circuited before any LLM call
+ * (e.g. no API key for a skill level that requires LLM).  All Stage3Result
+ * fields are absent in that variant.
+ *
+ * When `cannotPlan` is false/absent the result extends Stage3Result and adds
+ * two diagnostic fields the caller still needs for game/LLM logging.
+ */
+export type NewRoutePlannerResult =
+  | { cannotPlan: true; reason: 'no-api-key' }
+  | ({
+      cannotPlan?: false;
+      autoDeliveredLoads: Array<{ loadType: string; city: string; payment: number; cardId: number }>;
+      tripPlanResult: import('./TripPlanner').TripPlanResult | null;
+    } & Stage3Result);
+
 // ── PhaseAResult ──────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

**Stacked on PR #262** (JIRA-268). Both touch the bot brain construction / dispatch path.

`AIStrategyEngine` had hardcoded LLM-vs-deterministic dispatch branches at the top of `takeTurn`. This PR moves that dispatch inside `NewRoutePlanner` so the boundary between strategy types lives in one place — `AIStrategyEngine` now hands off to `NewRoutePlanner` once a new route is needed, and `NewRoutePlanner` decides internally whether to consult the LLM brain or run deterministically.

Surfaced when Medium-skill bots were passing the turn after their initial route completed instead of replanning (the old dispatch was checking `brain != null` in the wrong scope).

## Per-ticket docs
- `docs/ai/done/jira-269-mediumBotPassesTurnAfterInitialRouteCompletes.md`

## Commits
- `2dfe6d7` — BE-002: move LLM-vs-deterministic dispatch inside NewRoutePlanner
- `a50a5bb` — TEST-001: AIStrategyEngine dispatch integration tests

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Once stack merges, retarget base to `main`

**Base**: `pr/jira-268` (PR #262).

🤖 Generated with [Claude Code](https://claude.com/claude-code)