### PR TITLE
fix(ai): JIRA-270 — drop !brain short-circuit in PostDeliveryReplanner

### DIFF
--- a/docs/ai/done/jira-270-botDoesntReplanAfterMidRouteDelivery.md
+++ b/docs/ai/done/jira-270-botDoesntReplanAfterMidRouteDelivery.md
@@ -1,0 +1,24 @@
+# JIRA-270 — Bot doesn't replan after a mid-route delivery, ignoring the new demand card drawn at delivery time
+
+Per game rules, every delivery causes a new demand card to be drawn. The new card can change what's optimal — most acutely when the pickup city of the new card is the bot's current position. The bot should consider replanning after every delivery, not skip the evaluation just because the current route has remaining stops.
+
+## Source
+
+`logs/game-c73cccf8-919e-462c-8250-28b2199665a4.ndjson`, player s1, T15–T17. Game ran after JIRA-269 fix landed.
+
+## Trace
+
+| Turn | action | delivered | remaining route after |
+|------|--------|-----------|-----------------------|
+| T9 | BuildTrack (trip-planner-deterministic) | — | `pickup Bauxite@Budapest, pickup Beer@Munchen, deliver Beer@Hamburg, deliver Bauxite@Munchen` |
+| T15 | MoveTrain (route-executor) | Beer@Hamburg ($9) | `deliver Bauxite@Munchen` (1 stop) |
+| T16 | MoveTrain (route-executor) | — | (executing) |
+| T17 | MoveTrain (route-executor) | Bauxite@Munchen ($14) | (route complete) |
+
+At T15 immediately after the Hamburg delivery, the bot's demand hand contains `Imports: Hamburg → Glasgow @ $24`. The bot is standing in Hamburg. Picking up Imports right there is a zero-detour, zero-cost-to-position opportunity that splices in cleanly before continuing west to Munchen. The bot does not consider it. It continues 2 turns west for a $14 Bauxite delivery while a $24 Imports pickup is one milepost-of-zero-cost away.
+
+## Expected behavior
+
+Every delivery triggers a new demand-card draw. After every delivery, the bot should re-evaluate whether the current route is still optimal given the new demand state. The decision can still be "keep going" — that's fine — but it must be a decision made by comparison against the post-delivery demand hand, not a reflex.
+
+The evaluation must apply regardless of how many stops remain in the current route. A mid-route delivery is just as much a card-draw event as a route-terminating delivery; both reshape the demand landscape.

--- a/src/server/__tests__/ai/PostDeliveryReplanner.test.ts
+++ b/src/server/__tests__/ai/PostDeliveryReplanner.test.ts
@@ -394,40 +394,12 @@ describe('PostDeliveryReplanner.replan — sub-path 3: TripPlanner throws', () =
   });
 });
 
-// ── Sub-path 4: No brain available ────────────────────────────────────────
+// ── Sub-path 4: gridPoints unavailable ────────────────────────────────────
+// JIRA-270: brain-null no longer skips the planner. TripPlanner.planTrip
+// dispatches Medium deterministically per JIRA-269, so brain presence is
+// not a precondition for planning. Only an empty/missing grid blocks replan.
 
-describe('PostDeliveryReplanner.replan — sub-path 4: no brain or no gridPoints', () => {
-  it('returns moveTargetInvalidated=true when brain is null', async () => {
-    const result = await PostDeliveryReplanner.replan(
-      makeRoute(),
-      makeSnapshot(),
-      makeContext(),
-      null, // no brain
-      makeGridPoints(),
-      0,
-      '[TEST]',
-    );
-
-    expect(result.moveTargetInvalidated).toBe(true);
-    expect(MockTripPlannerClass).not.toHaveBeenCalled();
-    expect(mockRevalidate).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns moveTargetInvalidated=true when brain is undefined', async () => {
-    const result = await PostDeliveryReplanner.replan(
-      makeRoute(),
-      makeSnapshot(),
-      makeContext(),
-      undefined,
-      makeGridPoints(),
-      0,
-      '[TEST]',
-    );
-
-    expect(result.moveTargetInvalidated).toBe(true);
-    expect(MockTripPlannerClass).not.toHaveBeenCalled();
-  });
-
+describe('PostDeliveryReplanner.replan — sub-path 4: gridPoints unavailable', () => {
   it('returns moveTargetInvalidated=true when gridPoints is empty', async () => {
     const result = await PostDeliveryReplanner.replan(
       makeRoute(),
@@ -459,19 +431,57 @@ describe('PostDeliveryReplanner.replan — sub-path 4: no brain or no gridPoints
     expect(MockTripPlannerClass).not.toHaveBeenCalled();
   });
 
-  it('handles null brain gracefully (revalidation path)', async () => {
+  it('returns moveTargetInvalidated=true when brain is null AND gridPoints empty', async () => {
     const result = await PostDeliveryReplanner.replan(
       makeRoute(),
       makeSnapshot(),
       makeContext(),
       null,
+      [], // both conditions for the bail
+      0,
+      '[TEST]',
+    );
+
+    expect(result.moveTargetInvalidated).toBe(true);
+    expect(MockTripPlannerClass).not.toHaveBeenCalled();
+  });
+});
+
+// ── JIRA-270: Null-brain bots still replan via TripPlanner ─────────────────
+// Medium-skill bots (and any future deterministic skill) have null brain but
+// must still consult TripPlanner after every delivery. TripPlanner's internal
+// Medium dispatch (JIRA-269) handles the deterministic path.
+
+describe('PostDeliveryReplanner.replan — JIRA-270: null brain consults TripPlanner', () => {
+  it('calls TripPlanner when brain is null and gridPoints are present', async () => {
+    const result = await PostDeliveryReplanner.replan(
+      makeRoute(),
+      makeSnapshot(),
+      makeContext(),
+      null, // Medium-skill bot
       makeGridPoints(),
       0,
       '[TEST]',
     );
 
-    // Without brain, falls back to revalidation path
-    expect(result).toBeDefined();
+    // TripPlanner IS consulted — JIRA-269 made it nullable-brain-safe.
+    expect(MockTripPlannerClass).toHaveBeenCalledTimes(1);
+    expect(result.moveTargetInvalidated).toBe(true);
+  });
+
+  it('calls TripPlanner when brain is undefined and gridPoints are present', async () => {
+    const result = await PostDeliveryReplanner.replan(
+      makeRoute(),
+      makeSnapshot(),
+      makeContext(),
+      undefined,
+      makeGridPoints(),
+      0,
+      '[TEST]',
+    );
+
+    expect(MockTripPlannerClass).toHaveBeenCalledTimes(1);
+    expect(result.moveTargetInvalidated).toBe(true);
   });
 });
 

--- a/src/server/services/ai/PostDeliveryReplanner.ts
+++ b/src/server/services/ai/PostDeliveryReplanner.ts
@@ -146,9 +146,12 @@ export class PostDeliveryReplanner {
     deliveriesThisTurn: number,
     tag: string,
   ): Promise<ReplanResult> {
-    // Sub-path 4: No brain available — revalidate existing route.
-    // Also check for impossibility even in the no-brain path (JIRA-233).
-    if (!brain || !gridPoints || gridPoints.length === 0) {
+    // Sub-path 4: gridPoints unavailable — cannot plan, revalidate existing route.
+    // JIRA-270: brain may be null (Medium-skill bot); TripPlanner.planTrip
+    // dispatches Medium deterministically per JIRA-269, so brain presence is
+    // not a precondition for planning. Only an empty grid blocks the replan.
+    // Impossibility check is preserved in this branch (JIRA-233).
+    if (!gridPoints || gridPoints.length === 0) {
       const revalidated = TurnExecutorPlanner.revalidateRemainingDeliveries(activeRoute, context);
       const skipped = TurnExecutorPlanner.skipCompletedStops(revalidated, context);
       if (skipped.currentStopIndex < skipped.stops.length && isRouteImpossible(skipped, context)) {
@@ -163,7 +166,7 @@ export class PostDeliveryReplanner {
       return { route: skipped, moveTargetInvalidated: true };
     }
 
-    // Sub-paths 1–3: brain is available.
+    // Sub-paths 1–3: planner path (brain may be null; TripPlanner handles skill dispatch).
     // JIRA-233: Compute impossibility check OUTSIDE the try block so routeWasAbandoned
     // is accessible from both the try body and the catch handler.
     let postDeliveryRoute: StrategicRoute | null = activeRoute.currentStopIndex < activeRoute.stops.length
@@ -188,7 +191,7 @@ export class PostDeliveryReplanner {
 
     try {
       const memory = await getMemory(snapshot.gameId, snapshot.bot.playerId);
-      const tripPlanner = new TripPlanner(brain);
+      const tripPlanner = new TripPlanner(brain ?? null);
 
       const replanMemory: BotMemoryState = {
         ...memory,


### PR DESCRIPTION
## Summary

**Stacked on PR #263** (JIRA-269). Both touch the dispatch path between deterministic and LLM strategies.

After JIRA-269 moved LLM-vs-deterministic dispatch inside `NewRoutePlanner`, `PostDeliveryReplanner` still had a `!brain` short-circuit that returned `null` for Medium-skill (no-brain) bots — preventing them from replanning after a mid-route delivery. This PR drops that short-circuit so deterministic post-delivery replan runs for all skills.

## Per-ticket docs
- `docs/ai/done/jira-270-botDoesntReplanAfterMidRouteDelivery.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Once stack merges, retarget base to `main`

**Base**: `pr/jira-269` (PR #263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)