### PR TITLE
feat(ai): JIRA-272 — PostDeliveryReplanner discriminated union dispatch (bundles JIRA-271 perf)

### DIFF
--- a/docs/ai/done/jira-271-botContinuesMovingAfterDeliveryWithoutReplan.md
+++ b/docs/ai/done/jira-271-botContinuesMovingAfterDeliveryWithoutReplan.md
@@ -1,0 +1,25 @@
+# JIRA-271 — After a delivery completes the active route, the bot consumes the remaining movement budget on auto-pilot instead of stopping to replan
+
+When a delivery completes the active route, the bot should stop at the delivery city, draw the new demand card the delivery triggered, replan against the fresh hand, and let the new plan decide what to do with any remaining budget. Today it just keeps moving.
+
+## Source
+
+`logs/game-c73cccf8-919e-462c-8250-28b2199665a4.ndjson`, player s1, T23. Same game as JIRA-269/JIRA-270.
+
+## Trace
+
+T23 actionTimeline:
+
+| Step | Action | Path / Effect |
+|------|--------|---------------|
+| 0 | Move | (36,48) → (32,44) Stuttgart, 6 mileposts |
+| 1 | Deliver | Labor @ Stuttgart, +$16, route completes |
+| 2 | Move | (32,44) → (36,48), 6 mileposts — exact reverse of step 0 |
+
+End-of-turn: `activeRoute = None`, `positionEnd = (36,48)`, budget 12/12 used. After the route completed at step 1, the bot consumed the remaining 6 mileposts retracing its inbound path without any plan dictating the destination.
+
+## Expected behavior
+
+When a delivery completes the active route, the bot stops moving, replans, and only THEN decides what to do with whatever movement budget remains. The new plan may legitimately direct the bot to move back the way it came — that's fine — but the move must come from the plan, not from auto-piloting remaining budget.
+
+Related but distinct from JIRA-270: that fix made the post-delivery replan call happen. This bug is that even when the replan happens, the bot keeps moving in the same turn instead of letting the plan be the source of the next move.

--- a/docs/ai/done/jira-272-postDeliveryReplanShouldBeUnconditional.md
+++ b/docs/ai/done/jira-272-postDeliveryReplanShouldBeUnconditional.md
@@ -1,0 +1,28 @@
+# JIRA-272 — Replan-after-delivery is conditional, not structural: the same bug keeps showing up at different control-flow waypoints
+
+JIRA-269, JIRA-270, and JIRA-271 are the same family. Each was a code path that took action after a delivery (or in lieu of planning) without first replanning. Each fix neutralized one `if` gate. The obligation "replan before taking further action" lives implicitly across the bot turn pipeline — gated by different conditions at each call site, with the bot's position in the turn encoded in the call stack rather than as state.
+
+## Source
+
+- **JIRA-269** (`5663d13`): the dispatcher gated new-route planning on `hasLLMApiKey`. Medium bots fell through to PassTurn no-api-key.
+- **JIRA-270** (`ac8c107`): `PostDeliveryReplanner` gated TripPlanner consultation on `!brain`. Medium bots skipped the replan entirely.
+- **JIRA-271** (open): `MovementPhasePlanner` consumes remaining movement budget after a route-completing delivery with no plan in hand (game `c73cccf8` T23 — Stuttgart out-and-back).
+
+Shared signature: an action taken after a delivery without first guaranteeing the replan ran.
+
+## Expected behavior
+
+The replan obligation after a delivery must be **structural**, not conditional. The pipeline must fail closed: any control-flow path that reaches "do something" — move, build, upgrade, drop — after a delivery, without having transited the replan step, should be a structural impossibility, not a forgotten `if`.
+
+The same property must hold regardless of skill or credential presence. Replan is a property of the turn, not of the bot config. No `if (brain)` or `if (skillLevel)` branch should be able to decide whether the replan happens.
+
+## Scope
+
+Post-delivery replan obligation specifically. Narrower than a full bot-turn-pipeline state-machine refactor. JIRA-271 lands on the new structural shape; JIRA-269 and JIRA-270 must not regress.
+
+## Out of scope
+
+- Full bot-turn pipeline state-machine refactor.
+- `AIStrategyEngine` god-service decomposition.
+- TripPlanner enumeration / scoring changes.
+- The exact technical shape (enum, FSM, types) — behavioral requirement only.

--- a/src/server/__tests__/ai/MovementPhasePlanner.deferReplanSameCity.test.ts
+++ b/src/server/__tests__/ai/MovementPhasePlanner.deferReplanSameCity.test.ts
@@ -235,8 +235,9 @@ beforeEach(() => {
   });
 
   mockPostDeliveryReplan.mockResolvedValue({
+    kind: 'route-continued',
     route: { stops: [], currentStopIndex: 0, phase: 'travel', createdAtTurn: 10, reasoning: 'replanned' } as StrategicRoute,
-    moveTargetInvalidated: false,
+    moveTargetInvalidated: false as const,
   });
 
   jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -302,8 +303,9 @@ describe('MovementPhasePlanner — same-city replan deferral', () => {
     // would normally need a move — but since the test goal is just to count replan
     // calls, we return an empty route from the first replan to short-circuit.
     mockPostDeliveryReplan.mockResolvedValueOnce({
+      kind: 'no-route',
       route: { stops: [], currentStopIndex: 0, phase: 'travel', createdAtTurn: 10, reasoning: 'after first replan' } as StrategicRoute,
-      moveTargetInvalidated: true,
+      moveTargetInvalidated: true as const,
     });
 
     await MovementPhasePlanner.run(

--- a/src/server/__tests__/ai/MovementPhasePlanner.postDeliveryReplanCarriedLoad.test.ts
+++ b/src/server/__tests__/ai/MovementPhasePlanner.postDeliveryReplanCarriedLoad.test.ts
@@ -340,8 +340,9 @@ beforeEach(() => {
 
   // PostDeliveryReplanner returns a new route after replan
   mockPostDeliveryReplan.mockResolvedValue({
+    kind: 'route-replaced',
     route: makeRoute({ reasoning: 'post-delivery replan', stops: [] }),
-    moveTargetInvalidated: true,
+    moveTargetInvalidated: true as const,
     replanLlmLog: [{ status: 'success', attempt: 1 }],
   });
 

--- a/src/server/__tests__/ai/MovementPhasePlanner.test.ts
+++ b/src/server/__tests__/ai/MovementPhasePlanner.test.ts
@@ -447,8 +447,9 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
 
     const replanRoute = makeRoute({ reasoning: 'replanned' });
     mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'route-replaced',
       route: replanRoute,
-      moveTargetInvalidated: true,
+      moveTargetInvalidated: true as const,
     });
 
     const result = await MovementPhasePlanner.run(
@@ -461,12 +462,11 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
     expect(mockPostDeliveryReplan).toHaveBeenCalledTimes(1);
     expect(result.hasDelivery).toBe(true);
     expect(result.deliveriesThisTurn).toBe(1);
-    expect(result.lastMoveTargetCity).toBeNull(); // cleared by moveTargetInvalidated
+    expect(result.lastMoveTargetCity).toBeNull(); // cleared by route-replaced
   });
 
-  it('keeps lastMoveTargetCity when moveTargetInvalidated is false', async () => {
-    // Edge case: if for some reason replan returns false (shouldn't happen per spec,
-    // but testing the wiring)
+  it('keeps lastMoveTargetCity when route-continued (keep_current_plan)', async () => {
+    // route-continued outcome: route preserved — stale move target NOT cleared.
     mockIsStopComplete.mockReturnValue(false);
 
     const route = makeRoute({
@@ -485,8 +485,9 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
 
     const replanRoute = makeRoute({ reasoning: 'replanned' });
     mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'route-continued',
       route: replanRoute,
-      moveTargetInvalidated: false,
+      moveTargetInvalidated: false as const,
     });
 
     // Pre-set lastMoveTargetCity by making bot have moved first would be complex,
@@ -499,9 +500,8 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
     );
 
     // lastMoveTargetCity was null to begin with (no move before delivery),
-    // and moveTargetInvalidated=false means we DON'T overwrite it to null
-    // The result here depends on whether there was a prior move — there wasn't,
-    // so it stays null from initialization
+    // and route-continued means we DON'T overwrite it to null.
+    // The result here depends on whether there was a prior move — there wasn't.
     expect(result.hasDelivery).toBe(true);
   });
 
@@ -641,8 +641,9 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
     // Wien is on network so the move branch fires
     context.citiesOnNetwork = ['Berlin', 'Wien'];
     mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'route-replaced',
       route: replanRoute,
-      moveTargetInvalidated: true,
+      moveTargetInvalidated: true as const,
     });
 
     // gridPoints: row=10,col=10 → Berlin so delivery fires on move-2 arrival
@@ -736,8 +737,9 @@ describe('MovementPhasePlanner.run — delivery + PostDeliveryReplanner', () => 
       reasoning: 'replanned-cumulative',
     });
     mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'route-replaced',
       route: replanRoute,
-      moveTargetInvalidated: true,
+      moveTargetInvalidated: true as const,
     });
 
     // gridPoints: row=10,col=10 → Berlin so delivery fires after move-2 arrival
@@ -833,8 +835,9 @@ describe('MovementPhasePlanner.run — PhaseAResult fields', () => {
     });
 
     mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'no-route',
       route: makeRoute({ stops: [], currentStopIndex: 0 }),
-      moveTargetInvalidated: true,
+      moveTargetInvalidated: true as const,
     });
 
     const result = await MovementPhasePlanner.run(
@@ -906,10 +909,11 @@ describe('JIRA-202: arrival on last milepost executes stop action', () => {
       plan: { type: AIActionType.DeliverLoad, load: 'Wine', city: 'Berlin' },
     });
 
-    // Post-delivery replan returns empty route
+    // Post-delivery replan returns empty route (no-route)
     mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'no-route',
       route: makeRoute({ stops: [], currentStopIndex: 0 }),
-      moveTargetInvalidated: true,
+      moveTargetInvalidated: true as const,
     });
 
     // Provide gridPoints so position update sets city='Berlin'
@@ -2144,8 +2148,9 @@ describe('JIRA-249 Layer 3: MovementPhasePlanner runtime arrival guard', () => {
     });
 
     mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'no-route',
       route: makeRoute({ stops: [], currentStopIndex: 0 }),
-      moveTargetInvalidated: true,
+      moveTargetInvalidated: true as const,
     });
 
     const trace = makeTrace();
@@ -2178,5 +2183,265 @@ describe('JIRA-249 Layer 3: MovementPhasePlanner runtime arrival guard', () => {
 
     expect(trace.a2.terminationReason).toBe('arrived_for_deliver_but_load_not_carried');
     expect(result.accumulatedPlans.some(p => p.type === AIActionType.PassTurn)).toBe(false);
+  });
+});
+
+// ── JIRA-271 regression: no-route outcome ends movement loop ────────────────
+//
+// Bug: after a route-completing delivery, if replan returns no-route, the bot
+// continued the movement loop and emitted a return-move using leftover budget.
+// Fix: the switch dispatch `break`s the movement loop on no-route / route-abandoned.
+
+describe('JIRA-271 regression: no-route outcome immediately ends the movement loop', () => {
+  it('delivers final stop → replan returns no-route → no further move emitted despite leftover budget', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    // Bot is at Berlin (delivery city) with a single-stop deliver route.
+    // Speed = 9 mileposts; delivery itself consumes 0 movement — leftover = 9.
+    // Without the fix the loop would have continued and tried to emit a move.
+    const route = makeRoute({
+      stops: [{ action: 'deliver', city: 'Berlin', loadType: 'Wine', demandCardId: 10, payment: 18 }],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'],
+      speed: 9,
+    });
+
+    mockExecuteStopAction.mockResolvedValue({
+      success: true,
+      plan: { type: AIActionType.DeliverLoad, load: 'Wine', city: 'Berlin' },
+    });
+
+    // Replan returns no-route: route is exhausted, no new route available.
+    mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'no-route',
+      route: makeRoute({ stops: [], currentStopIndex: 0 }),
+      moveTargetInvalidated: true as const,
+    });
+
+    const trace = makeTrace();
+    const result = await MovementPhasePlanner.run(route, makeSnapshot(), context, trace);
+
+    // Delivery happened
+    expect(result.hasDelivery).toBe(true);
+    expect(result.deliveriesThisTurn).toBe(1);
+
+    // Replan was called once
+    expect(mockPostDeliveryReplan).toHaveBeenCalledTimes(1);
+
+    // JIRA-271: NO move action emitted after the delivery (loop broke on no-route)
+    const moveActions = result.accumulatedPlans.filter(p => p.type === AIActionType.MoveTrain);
+    expect(moveActions).toHaveLength(0);
+
+    // ActionResolver.resolveMove should NOT have been called at all
+    // (the loop exited before the move-resolution path)
+    expect(mockResolveMove).not.toHaveBeenCalled();
+
+    // Termination reason: the original route was fully executed (only stop was delivered)
+    // and the replan's revalidated route is empty/exhausted, so the loop ends with
+    // route_complete. 'no_route_after_replan' is reserved for the case where stops
+    // remain in the replanned route but the planner declined to produce a new one.
+    expect(trace.a2.terminationReason).toBe('route_complete');
+  });
+
+  it('delivers final stop → replan returns route-abandoned → no further move emitted', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    const route = makeRoute({
+      stops: [{ action: 'deliver', city: 'Berlin', loadType: 'Wine', demandCardId: 10, payment: 18 }],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'],
+      speed: 9,
+    });
+
+    mockExecuteStopAction.mockResolvedValue({
+      success: true,
+      plan: { type: AIActionType.DeliverLoad, load: 'Wine', city: 'Berlin' },
+    });
+
+    mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'route-abandoned',
+      route: makeRoute({ stops: [], currentStopIndex: 0 }),
+      moveTargetInvalidated: true as const,
+      routeWasAbandoned: true as const,
+    });
+
+    const trace = makeTrace();
+    const result = await MovementPhasePlanner.run(route, makeSnapshot(), context, trace);
+
+    expect(result.hasDelivery).toBe(true);
+    expect(mockPostDeliveryReplan).toHaveBeenCalledTimes(1);
+
+    const moveActions = result.accumulatedPlans.filter(p => p.type === AIActionType.MoveTrain);
+    expect(moveActions).toHaveLength(0);
+    expect(mockResolveMove).not.toHaveBeenCalled();
+
+    expect(trace.a2.terminationReason).toBe('route_abandoned_after_replan');
+    expect(result.routeAbandoned).toBe(true);
+  });
+});
+
+// ── TEST-002: Structural invariant — replan always fires before subsequent actions ─
+//
+// Invariant: every code path that emits actions after a delivery MUST go through
+// PostDeliveryReplanner.replan first. The switch dispatch enforces this structurally.
+
+describe('TEST-002: structural invariant — PostDeliveryReplanner.replan fires before any post-delivery action', () => {
+  it('route-continued: replan fires, loop continues, subsequent move is attempted', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    const route = makeRoute({
+      stops: [
+        { action: 'deliver', city: 'Berlin', loadType: 'Wine', demandCardId: 10, payment: 18 },
+        { action: 'pickup', city: 'Paris', loadType: 'Coal' },
+      ],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'],
+      citiesOnNetwork: ['Paris'],
+    });
+
+    mockExecuteStopAction.mockResolvedValue({
+      success: true,
+      plan: { type: AIActionType.DeliverLoad, load: 'Wine', city: 'Berlin' },
+    });
+
+    // route-continued: route carries over — loop tries to move to Paris.
+    // Return a route with no more stops so the loop exits cleanly after the move attempt.
+    const continuedRoute = makeRoute({
+      stops: [
+        { action: 'pickup', city: 'Paris', loadType: 'Coal' },
+      ],
+      currentStopIndex: 0,
+    });
+    mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'route-continued',
+      route: continuedRoute,
+      moveTargetInvalidated: false as const,
+    });
+
+    // resolveMove returns a move action toward Paris; override path length to 9 so
+    // the budget is fully consumed after the first move and the loop exits.
+    const { computeEffectivePathLength } = jest.requireMock('../../../shared/services/majorCityGroups');
+    computeEffectivePathLength.mockReturnValue(9);
+
+    mockResolveMove.mockResolvedValue({
+      success: true,
+      plan: { type: AIActionType.MoveTrain, path: [{ row: 5, col: 5 }, { row: 6, col: 5 }] },
+      budgetUsed: 9,
+    });
+
+    await MovementPhasePlanner.run(route, makeSnapshot(), context, makeTrace());
+
+    // Core invariant: replan fired exactly once (after the delivery)
+    expect(mockPostDeliveryReplan).toHaveBeenCalledTimes(1);
+    // Loop continued after replan: resolveMove was called at least once
+    expect(mockResolveMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('route-replaced: replan fires, lastMoveTargetCity cleared, loop continues', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    const route = makeRoute({
+      stops: [{ action: 'deliver', city: 'Berlin', loadType: 'Wine', demandCardId: 10, payment: 18 }],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'],
+    });
+
+    mockExecuteStopAction.mockResolvedValue({
+      success: true,
+      plan: { type: AIActionType.DeliverLoad, load: 'Wine', city: 'Berlin' },
+    });
+
+    const replacedRoute = makeRoute({
+      stops: [{ action: 'pickup', city: 'Hamburg', loadType: 'Steel' }],
+      currentStopIndex: 0,
+      reasoning: 'post-delivery replaced route',
+    });
+    mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'route-replaced',
+      route: replacedRoute,
+      moveTargetInvalidated: true as const,
+    });
+
+    const result = await MovementPhasePlanner.run(route, makeSnapshot(), context, makeTrace());
+
+    // replan fired
+    expect(mockPostDeliveryReplan).toHaveBeenCalledTimes(1);
+    // lastMoveTargetCity cleared (route-replaced)
+    expect(result.lastMoveTargetCity).toBeNull();
+    // delivery happened
+    expect(result.hasDelivery).toBe(true);
+  });
+
+  it('no-route: replan fires, loop terminates — ActionResolver.resolveMove NOT called', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    const route = makeRoute({
+      stops: [{ action: 'deliver', city: 'Berlin', loadType: 'Wine', demandCardId: 10, payment: 18 }],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'],
+    });
+
+    mockExecuteStopAction.mockResolvedValue({
+      success: true,
+      plan: { type: AIActionType.DeliverLoad, load: 'Wine', city: 'Berlin' },
+    });
+
+    mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'no-route',
+      route: makeRoute({ stops: [], currentStopIndex: 0 }),
+      moveTargetInvalidated: true as const,
+    });
+
+    await MovementPhasePlanner.run(route, makeSnapshot(), context, makeTrace());
+
+    expect(mockPostDeliveryReplan).toHaveBeenCalledTimes(1);
+    // Loop broke immediately — no move attempted
+    expect(mockResolveMove).not.toHaveBeenCalled();
+  });
+
+  it('route-abandoned: replan fires, loop terminates — ActionResolver.resolveMove NOT called', async () => {
+    mockIsStopComplete.mockReturnValue(false);
+
+    const route = makeRoute({
+      stops: [{ action: 'deliver', city: 'Berlin', loadType: 'Wine', demandCardId: 10, payment: 18 }],
+      currentStopIndex: 0,
+    });
+    const context = makeContext({
+      position: { row: 5, col: 5, city: 'Berlin' },
+      loads: ['Wine'],
+    });
+
+    mockExecuteStopAction.mockResolvedValue({
+      success: true,
+      plan: { type: AIActionType.DeliverLoad, load: 'Wine', city: 'Berlin' },
+    });
+
+    mockPostDeliveryReplan.mockResolvedValue({
+      kind: 'route-abandoned',
+      route: makeRoute({ stops: [], currentStopIndex: 0 }),
+      moveTargetInvalidated: true as const,
+      routeWasAbandoned: true as const,
+    });
+
+    const result = await MovementPhasePlanner.run(route, makeSnapshot(), context, makeTrace());
+
+    expect(mockPostDeliveryReplan).toHaveBeenCalledTimes(1);
+    expect(mockResolveMove).not.toHaveBeenCalled();
+    expect(result.routeAbandoned).toBe(true);
   });
 });

--- a/src/server/__tests__/ai/PostDeliveryReplanner.test.ts
+++ b/src/server/__tests__/ai/PostDeliveryReplanner.test.ts
@@ -1,24 +1,24 @@
 /**
  * PostDeliveryReplanner unit tests (JIRA-195 Slice 3a + JIRA-198 upgrade consumption).
  *
- * Covers all four sub-paths:
- *   1. Success — TripPlanner returns a route → enriched + skipCompletedStops
- *   2. Null route — TripPlanner returns null → revalidate existing route
- *   3. Throw — TripPlanner throws → revalidate existing route
- *   4. No brain — brain null or gridPoints empty → revalidate existing route
- *
- * In every sub-path, moveTargetInvalidated must be true (JIRA-194 contract).
+ * Covers all four sub-paths, now mapped to the PostDeliveryOutcome discriminated union:
+ *   1. Success — TripPlanner returns a route → RouteReplacedOutcome (or RouteContinuedOutcome via strictly-faster gate)
+ *   2. Null route (keep_current_plan) — TripPlanner returns keep_current_plan → RouteContinuedOutcome
+ *   2b. Null route (other) — TripPlanner returns null → NoRouteOutcome
+ *   3. Throw — TripPlanner throws → NoRouteOutcome (or RouteAbandonedOutcome if impossibility fired)
+ *   4. No grid — gridPoints empty/undefined → NoRouteOutcome (or RouteAbandonedOutcome if impossible)
  *
  * JIRA-198 upgrade consumption scenarios (B13.2):
- *   - Success: upgradeOnRoute eligible → pendingUpgradeAction populated
- *   - Gate-blocked: delivery count below threshold → pendingUpgradeAction null + reason
- *   - Unaffordable: insufficient funds → pendingUpgradeAction null + reason
- *   - Invalid-path: invalid upgrade from current train → pendingUpgradeAction null + reason
- *   - Sub-paths 2/3/4: both fields undefined
+ *   - Success: upgradeOnRoute eligible → RouteReplacedOutcome with pendingUpgradeAction populated
+ *   - Gate-blocked: delivery count below threshold → RouteReplacedOutcome with pendingUpgradeAction null + reason
+ *   - Unaffordable: insufficient funds → RouteReplacedOutcome with pendingUpgradeAction null + reason
+ *   - Invalid-path: invalid upgrade from current train → RouteReplacedOutcome with pendingUpgradeAction null + reason
+ *   - Sub-paths 2/3/4: both fields absent (NoRouteOutcome / RouteContinuedOutcome do not carry upgrade fields)
  *   - Multi-replan accumulation: last non-null wins; null does not clobber non-null
  */
 
 import { PostDeliveryReplanner } from '../../services/ai/PostDeliveryReplanner';
+import type { RouteReplacedOutcome, RouteContinuedOutcome, NoRouteOutcome, RouteAbandonedOutcome } from '../../services/ai/PostDeliveryReplanner';
 import { TurnExecutorPlanner } from '../../services/ai/TurnExecutorPlanner';
 import type {
   AIActionType,
@@ -267,9 +267,11 @@ describe('PostDeliveryReplanner.replan — sub-path 1: TripPlanner success', () 
       '[TEST]',
     );
 
-    expect(result.replanLlmLog).toBe(llmLog);
-    expect(result.replanSystemPrompt).toBe('system-prompt');
-    expect(result.replanUserPrompt).toBe('user-prompt');
+    expect(result.kind).toBe('route-replaced');
+    const replaced = result as RouteReplacedOutcome;
+    expect(replaced.replanLlmLog).toBe(llmLog);
+    expect(replaced.replanSystemPrompt).toBe('system-prompt');
+    expect(replaced.replanUserPrompt).toBe('user-prompt');
   });
 
   it('patches deliveryCount in memory before calling TripPlanner (JIRA-185)', async () => {
@@ -378,19 +380,24 @@ describe('PostDeliveryReplanner.replan — sub-path 3: TripPlanner throws', () =
       planTrip: jest.fn().mockRejectedValue(new Error('network error')),
     }));
 
+    // Use a route with cargo so the impossibility check does not fire.
+    // The throw test is about the throw path, not impossibility.
     const result = await PostDeliveryReplanner.replan(
       makeRoute(),
       makeSnapshot(),
-      makeContext(),
+      makeContext({ loads: ['Coal'] }), // Coal in cargo → not impossible
       makeBrain(),
       makeGridPoints(),
       0,
       '[TEST]',
     );
 
-    expect(result.replanLlmLog).toBeUndefined();
-    expect(result.replanSystemPrompt).toBeUndefined();
-    expect(result.replanUserPrompt).toBeUndefined();
+    // TripPlanner threw → NoRouteOutcome (no LLM log fields captured)
+    expect(result.kind).toBe('no-route');
+    const noRoute = result as NoRouteOutcome;
+    expect(noRoute.replanLlmLog).toBeUndefined();
+    expect(noRoute.replanSystemPrompt).toBeUndefined();
+    expect(noRoute.replanUserPrompt).toBeUndefined();
   });
 });
 
@@ -559,8 +566,11 @@ describe('JIRA-198: PostDeliveryReplanner.replan — upgrade consumption (sub-pa
       '[TEST]',
     );
 
-    expect(result.pendingUpgradeAction).toEqual(upgradeAction);
-    expect(result.upgradeSuppressionReason).toBeNull();
+    // TripPlanner returned a route → RouteReplacedOutcome with upgrade fields
+    expect(result.kind).toBe('route-replaced');
+    const replaced = result as RouteReplacedOutcome;
+    expect(replaced.pendingUpgradeAction).toEqual(upgradeAction);
+    expect(replaced.upgradeSuppressionReason).toBeNull();
     // tryConsumeUpgrade was called with the correct delivery count
     // (memory.deliveryCount=2 + deliveriesThisTurn=2 = 4, which meets the gate)
     expect(mockTryConsumeUpgrade).toHaveBeenCalledWith(
@@ -588,8 +598,10 @@ describe('JIRA-198: PostDeliveryReplanner.replan — upgrade consumption (sub-pa
       '[TEST]',
     );
 
-    expect(result.pendingUpgradeAction).toBeNull();
-    expect(result.upgradeSuppressionReason).toBe('Upgrade blocked: only 3 deliveries (need 4)');
+    expect(result.kind).toBe('route-replaced');
+    const replaced = result as RouteReplacedOutcome;
+    expect(replaced.pendingUpgradeAction).toBeNull();
+    expect(replaced.upgradeSuppressionReason).toBe('Upgrade blocked: only 3 deliveries (need 4)');
   });
 
   it('AC2: returns null + reason when bot cannot afford the upgrade (unaffordable)', async () => {
@@ -609,8 +621,10 @@ describe('JIRA-198: PostDeliveryReplanner.replan — upgrade consumption (sub-pa
       '[TEST]',
     );
 
-    expect(result.pendingUpgradeAction).toBeNull();
-    expect(result.upgradeSuppressionReason).toContain('insufficient funds');
+    expect(result.kind).toBe('route-replaced');
+    const replaced = result as RouteReplacedOutcome;
+    expect(replaced.pendingUpgradeAction).toBeNull();
+    expect(replaced.upgradeSuppressionReason).toContain('insufficient funds');
   });
 
   it('AC2: returns null + reason for invalid upgrade path', async () => {
@@ -630,51 +644,63 @@ describe('JIRA-198: PostDeliveryReplanner.replan — upgrade consumption (sub-pa
       '[TEST]',
     );
 
-    expect(result.pendingUpgradeAction).toBeNull();
-    expect(result.upgradeSuppressionReason).toContain('invalid upgrade path');
+    expect(result.kind).toBe('route-replaced');
+    const replaced = result as RouteReplacedOutcome;
+    expect(replaced.pendingUpgradeAction).toBeNull();
+    expect(replaced.upgradeSuppressionReason).toContain('invalid upgrade path');
   });
 
-  it('sub-path 2 (null route): both upgrade fields undefined', async () => {
+  it('sub-path 2 (null route): no upgrade fields (no-route or route-abandoned)', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (MockTripPlannerClass as any).mockImplementation(() => ({
       planTrip: jest.fn().mockResolvedValue({ route: null, llmLog: [] }),
     }));
 
+    // Use a non-impossible route context to get a clean no-route outcome
+    const routeWithCargo = makeRoute({ currentStopIndex: 1 });
+    const contextWithCargo = makeContext({ loads: ['Coal'] }); // Coal in cargo → not impossible
     const result = await PostDeliveryReplanner.replan(
-      makeRoute(), makeSnapshot(), makeContext(), makeBrain(), makeGridPoints(), 0, '[TEST]',
+      routeWithCargo, makeSnapshot(), contextWithCargo, makeBrain(), makeGridPoints(), 0, '[TEST]',
     );
 
-    expect(result.pendingUpgradeAction).toBeUndefined();
-    expect(result.upgradeSuppressionReason).toBeUndefined();
+    // no-route or route-abandoned — neither carries upgrade fields
+    expect(['no-route', 'route-abandoned']).toContain(result.kind);
     expect(mockTryConsumeUpgrade).not.toHaveBeenCalled();
   });
 
-  it('sub-path 3 (throw): both upgrade fields undefined', async () => {
+  it('sub-path 3 (throw): no upgrade fields (no-route or route-abandoned)', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (MockTripPlannerClass as any).mockImplementation(() => ({
       planTrip: jest.fn().mockRejectedValue(new Error('LLM error')),
     }));
 
+    // Use a non-impossible route context to get a clean no-route outcome
+    const routeWithCargo = makeRoute({ currentStopIndex: 1 });
+    const contextWithCargo = makeContext({ loads: ['Coal'] }); // Coal in cargo → not impossible
     const result = await PostDeliveryReplanner.replan(
-      makeRoute(), makeSnapshot(), makeContext(), makeBrain(), makeGridPoints(), 0, '[TEST]',
+      routeWithCargo, makeSnapshot(), contextWithCargo, makeBrain(), makeGridPoints(), 0, '[TEST]',
     );
 
-    expect(result.pendingUpgradeAction).toBeUndefined();
-    expect(result.upgradeSuppressionReason).toBeUndefined();
+    // no-route or route-abandoned — neither carries upgrade fields
+    expect(['no-route', 'route-abandoned']).toContain(result.kind);
     expect(mockTryConsumeUpgrade).not.toHaveBeenCalled();
   });
 
-  it('sub-path 4 (no brain): both upgrade fields undefined', async () => {
+  it('sub-path 4 (no brain + grid present): no upgrade fields (JIRA-270 — TripPlanner consulted)', async () => {
+    // With null brain but grid present, TripPlanner IS called (JIRA-270 path)
+    // Default mock returns null route → no-route or route-abandoned (depending on impossibility)
+    const routeWithCargo = makeRoute({ currentStopIndex: 1 });
+    const contextWithCargo = makeContext({ loads: ['Coal'] }); // Coal in cargo → not impossible
     const result = await PostDeliveryReplanner.replan(
-      makeRoute(), makeSnapshot(), makeContext(), null, makeGridPoints(), 0, '[TEST]',
+      routeWithCargo, makeSnapshot(), contextWithCargo, null, makeGridPoints(), 0, '[TEST]',
     );
 
-    expect(result.pendingUpgradeAction).toBeUndefined();
-    expect(result.upgradeSuppressionReason).toBeUndefined();
+    // no-route — neither carries upgrade fields
+    expect(['no-route', 'route-abandoned']).toContain(result.kind);
     expect(mockTryConsumeUpgrade).not.toHaveBeenCalled();
   });
 
-  it('sub-path 1 with no upgradeOnRoute: both upgrade fields undefined', async () => {
+  it('sub-path 1 with no upgradeOnRoute: RouteReplacedOutcome without upgrade fields', async () => {
     // Route has no upgradeOnRoute — tryConsumeUpgrade should NOT be called
     const routeWithoutUpgrade = makeRoute(); // no upgradeOnRoute
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -686,8 +712,10 @@ describe('JIRA-198: PostDeliveryReplanner.replan — upgrade consumption (sub-pa
       makeRoute(), makeSnapshot(), makeContext(), makeBrain(), makeGridPoints(), 0, '[TEST]',
     );
 
-    expect(result.pendingUpgradeAction).toBeUndefined();
-    expect(result.upgradeSuppressionReason).toBeUndefined();
+    expect(result.kind).toBe('route-replaced');
+    const replaced = result as RouteReplacedOutcome;
+    expect(replaced.pendingUpgradeAction).toBeUndefined();
+    expect(replaced.upgradeSuppressionReason).toBeUndefined();
     expect(mockTryConsumeUpgrade).not.toHaveBeenCalled();
   });
 });
@@ -720,8 +748,11 @@ describe('JIRA-198: multi-replan accumulation — last non-null action wins', ()
       makeRoute(), makeSnapshot(), makeContext(), makeBrain(), makeGridPoints(), 1, '[TEST]',
     );
 
-    expect(result1.pendingUpgradeAction).toBeNull();
-    expect(result1.upgradeSuppressionReason).toContain('only 3 deliveries');
+    // RouteReplacedOutcome with suppressed upgrade
+    expect(result1.kind).toBe('route-replaced');
+    const replaced1 = result1 as RouteReplacedOutcome;
+    expect(replaced1.pendingUpgradeAction).toBeNull();
+    expect(replaced1.upgradeSuppressionReason).toContain('only 3 deliveries');
 
     // Second replan call: upgrade now eligible
     const upgradeAction = { type: 'UpgradeTrain' as AIActionType, targetTrain: 'fast_freight', cost: 20 };
@@ -735,15 +766,17 @@ describe('JIRA-198: multi-replan accumulation — last non-null action wins', ()
       makeRoute(), makeSnapshot(), makeContext(), makeBrain(), makeGridPoints(), 2, '[TEST]',
     );
 
-    expect(result2.pendingUpgradeAction).toEqual(upgradeAction);
-    expect(result2.upgradeSuppressionReason).toBeNull();
+    expect(result2.kind).toBe('route-replaced');
+    const replaced2 = result2 as RouteReplacedOutcome;
+    expect(replaced2.pendingUpgradeAction).toEqual(upgradeAction);
+    expect(replaced2.upgradeSuppressionReason).toBeNull();
 
     // Verify: accumulator (in MovementPhasePlanner) would keep the non-null from result2
     // since result2.pendingUpgradeAction !== null, it replaces the earlier null.
   });
 
-  it('second replan emits null after first had valid upgrade → non-null is preserved', async () => {
-    // First replan: valid upgrade
+  it('second replan emits no-route/route-abandoned after first had valid upgrade → accumulator preserves non-null', async () => {
+    // First replan: valid upgrade → RouteReplacedOutcome
     const routeWithUpgrade = makeRoute({ upgradeOnRoute: 'fast_freight' });
     const upgradeAction = { type: 'UpgradeTrain' as AIActionType, targetTrain: 'fast_freight', cost: 20 };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -752,30 +785,32 @@ describe('JIRA-198: multi-replan accumulation — last non-null action wins', ()
     }));
     mockTryConsumeUpgrade.mockReturnValue({ action: upgradeAction });
 
+    // Use non-impossible context for first replan to get route-replaced
+    const contextWithCargo = makeContext({ loads: ['Coal'] });
     const result1 = await PostDeliveryReplanner.replan(
-      makeRoute(), makeSnapshot(), makeContext(), makeBrain(), makeGridPoints(), 2, '[TEST]',
+      makeRoute(), makeSnapshot(), contextWithCargo, makeBrain(), makeGridPoints(), 2, '[TEST]',
     );
 
-    expect(result1.pendingUpgradeAction).toEqual(upgradeAction);
+    expect(result1.kind).toBe('route-replaced');
+    const replaced1 = result1 as RouteReplacedOutcome;
+    expect(replaced1.pendingUpgradeAction).toEqual(upgradeAction);
 
-    // Second replan: null route → sub-path 2 (no upgrade fields produced)
+    // Second replan: null route → no-route or route-abandoned (no upgrade fields)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (MockTripPlannerClass as any).mockImplementation(() => ({
       planTrip: jest.fn().mockResolvedValue({ route: null, llmLog: [] }),
     }));
 
     const result2 = await PostDeliveryReplanner.replan(
-      makeRoute(), makeSnapshot(), makeContext(), makeBrain(), makeGridPoints(), 2, '[TEST]',
+      makeRoute(), makeSnapshot(), contextWithCargo, makeBrain(), makeGridPoints(), 2, '[TEST]',
     );
 
-    // Sub-path 2 returns undefined for both upgrade fields
-    expect(result2.pendingUpgradeAction).toBeUndefined();
-    expect(result2.upgradeSuppressionReason).toBeUndefined();
+    // no-route or route-abandoned — neither carries upgrade fields
+    expect(['no-route', 'route-abandoned']).toContain(result2.kind);
 
-    // The accumulator in MovementPhasePlanner checks: if result2.pendingUpgradeAction is
-    // undefined (not null), it does NOT update the accumulator — preserving result1's value.
-    // This contract is enforced by the "pendingUpgradeAction !== undefined" guard in
-    // MovementPhasePlanner.
+    // The accumulator in MovementPhasePlanner checks the kind: for no-route / route-abandoned,
+    // there are no upgrade fields → the accumulator preserves result1's value.
+    // This behaviour is enforced by the switch dispatch in MovementPhasePlanner (BE-002).
   });
 });
 
@@ -988,8 +1023,11 @@ describe('JIRA-233 BE-002: route impossibility detection wiring (AC4)', () => {
     expect(capturedMemory).toBeDefined();
     expect(capturedMemory!.activeRoute).toBeNull();
 
-    // 2. routeWasAbandoned must be true in the ReplanResult
-    expect(result.routeWasAbandoned).toBe(true);
+    // 2. routeWasAbandoned is signaled via RouteAbandonedOutcome — impossibility fired
+    // AND TripPlanner returned null → route-abandoned outcome.
+    expect(result.kind).toBe('route-abandoned');
+    const abandoned = result as RouteAbandonedOutcome;
+    expect(abandoned.routeWasAbandoned).toBe(true);
 
     // 3. [route-abandoned] warn must have been emitted exactly once
     const abandonedLogs = warnSpy.mock.calls.filter(
@@ -1035,7 +1073,8 @@ describe('JIRA-233 BE-002: route impossibility detection wiring (AC4)', () => {
 
     // Route NOT cleared — activeRoute passed through to planner
     expect(capturedMemory!.activeRoute).toBe(achievableRoute);
-    expect(result.routeWasAbandoned).toBeFalsy();
+    // Result is not route-abandoned (no impossibility fired)
+    expect(result.kind).not.toBe('route-abandoned');
   });
 });
 
@@ -1110,8 +1149,11 @@ describe('JIRA-233 BE-002: t73-t80 regression — opportunistic delivery leaves 
     expect(capturedMemory).toBeDefined();
     expect(capturedMemory!.activeRoute).toBeNull();
 
-    // AC5 assertion 2: routeWasAbandoned is signaled back to the caller
-    expect(result.routeWasAbandoned).toBe(true);
+    // AC5 assertion 2: routeWasAbandoned is signaled back to the caller via RouteReplacedOutcome
+    // (impossibility fired but TripPlanner returned a fresh route → route-replaced with routeWasAbandoned)
+    expect(result.kind).toBe('route-replaced');
+    const replaced = result as RouteReplacedOutcome;
+    expect(replaced.routeWasAbandoned).toBe(true);
 
     // AC5 assertion 3: planner returned a fresh route (not PassTurn!)
     expect(result.route).not.toBeNull();

--- a/src/server/services/ai/DeterministicTripPlanner.ts
+++ b/src/server/services/ai/DeterministicTripPlanner.ts
@@ -83,6 +83,32 @@ export const PRUNE_MAX_BUILD_M = 130;
 export const HOP_AVG_COST_M = 1.3;
 
 /**
+ * Wall-clock budget for the cheapPrune loop inside planTripDeterministic.
+ *
+ * The pre-existing perf-budget alarm at the end of enumeration only LOGS when
+ * enumerationMs > 200 — it never aborts. On late-game dense networks the loop
+ * can run for many minutes (smoke-game T73: 928 seconds entirely in this
+ * loop) as each candidate's cheapPrune fires estimateGraphPathCost (Dijkstra)
+ * per leg. Once we cross this budget we stop pruning and proceed with the
+ * survivors we already have; the bot picks a still-valid plan instead of
+ * stalling the turn for 15 minutes. Set comfortably above typical 200ms runs
+ * but well below the multi-minute pathological cases.
+ */
+export const PRUNE_WALL_CLOCK_BUDGET_MS = 5000;
+
+/**
+ * Per-iteration wall-clock budget for a single cheapPrune call (which fans out
+ * to N estimateGraphPathCost → findBuildPath Dijkstras for an N-stop route).
+ * Bounds the worst-case work for ONE candidate so a single pathological
+ * Dijkstra doesn't burn the entire shared PRUNE_WALL_CLOCK_BUDGET_MS and
+ * cause every subsequent iteration to see "deadline past" and falsely mark
+ * its candidates unreachable. Smoke#6 stalled at turn 400 with all bots at
+ * $190-198M after a shared deadline caused 234 false-unreachable cap-hits;
+ * a per-iter budget isolates the damage to the truly slow candidate.
+ */
+export const CHEAP_PRUNE_PER_ITER_BUDGET_MS = 500;
+
+/**
  * JIRA-255 Layer B: Hard ceiling on turn count for win-completing candidates
  * exempted from the standard PRUNE_MAX_TURNS gate when endGameLocked is true.
  * Guards against pathological estimates (e.g., 50-turn candidates that the
@@ -973,6 +999,7 @@ export function cheapPrune(
   snapshot: WorldSnapshot,
   memory?: Pick<BotMemoryState, 'endGameLocked'>,
   context?: Pick<GameContext, 'unconnectedMajorCities' | 'connectedMajorCities'>,
+  deadlineMs?: number,
 ): { keep: boolean; estTurns: number; estBuild: number } {
   let totalBuild = 0;
   let totalTurns = 0;
@@ -989,7 +1016,7 @@ export function cheapPrune(
   // mildly inflated estBuild here is the right trade given the loose
   // 130M / 12-turn thresholds — false-negatives at those bounds are rare.
   for (const s of candidate.stops) {
-    const leg = estimateGraphPathCost(prevCity, s.city, snapshot, speed);
+    const leg = estimateGraphPathCost(prevCity, s.city, snapshot, speed, deadlineMs);
     if (!leg.reachable) return { keep: false, estTurns: 999, estBuild: 999 };
     totalBuild += leg.buildCost;
     totalTurns += leg.estimatedTurns;
@@ -1734,8 +1761,11 @@ export function planTripDeterministic(
     .flatMap(e => e.restrictions.pickupDelivery);
   const hasActivePickupDeliveryRestriction = pickupDeliveryRestrictions.length > 0;
   const survivors: Candidate[] = [];
+  let prunedByWallClock = 0;
+  let wallClockExceeded = false;
 
-  for (const cand of allCandidates) {
+  for (let candIdx = 0; candIdx < allCandidates.length; candIdx++) {
+    const cand = allCandidates[candIdx];
     if (hasActivePickupDeliveryRestriction) {
       const stop0 = cand.stops[0];
       if (stop0 && (stop0.action === 'pickup' || stop0.action === 'deliver')) {
@@ -1748,7 +1778,16 @@ export function planTripDeterministic(
     }
     // JIRA-255: cheapPrune carries memory + context so the win-completion
     // carve-out can spare cash-completing routes from the turns/build caps.
-    const { keep, estTurns, estBuild } = cheapPrune(cand, startPos, speed, opts, snapshot, memory, context);
+    // Wall-clock deadline is PER-ITERATION, not shared across the whole
+    // prune loop. Smoke#6 demonstrated that a shared deadline causes
+    // subsequent iterations to see "deadline past" and falsely abort their
+    // Dijkstras after one slow iteration, marking many candidates falsely
+    // unreachable (234 false aborts → bot stalled at $198M, $52M short of
+    // win). Per-iter budget isolates the slow Dijkstra to that one bad
+    // candidate; the outer loop break still caps total time at
+    // PRUNE_WALL_CLOCK_BUDGET_MS.
+    const pruneDeadline = Date.now() + CHEAP_PRUNE_PER_ITER_BUDGET_MS;
+    const { keep, estTurns, estBuild } = cheapPrune(cand, startPos, speed, opts, snapshot, memory, context, pruneDeadline);
     if (keep) {
       survivors.push(cand);
     } else {
@@ -1760,15 +1799,30 @@ export function planTripDeterministic(
         prunedByBuild++;
       }
     }
+
+    // Wall-clock budget: bail out if the cheapPrune loop has been running
+    // longer than PRUNE_WALL_CLOCK_BUDGET_MS. The remaining candidates are
+    // not evaluated and are NOT counted as survivors; the planner proceeds
+    // with what we have. Without this, a single turn on a dense late-game
+    // network could spend 10+ minutes here (smoke-game T73: 928s).
+    if (Date.now() - enumStartMs > PRUNE_WALL_CLOCK_BUDGET_MS) {
+      prunedByWallClock = allCandidates.length - candIdx - 1;
+      wallClockExceeded = true;
+      break;
+    }
   }
 
   const enumerationMs = Date.now() - enumStartMs;
   const rawCount = allCandidates.length;
 
-  // JIRA-230 BE-004: perf budget alarm
-  if (rawCount > 5000 || enumerationMs > 200) {
+  // JIRA-230 BE-004: perf budget alarm. Now also fires when wall-clock cap
+  // truncated the loop, surfacing the abort plus the cut count.
+  if (rawCount > 5000 || enumerationMs > 200 || wallClockExceeded) {
+    const wcNote = wallClockExceeded
+      ? ` WALL-CLOCK-CAP-HIT cutCandidates=${prunedByWallClock}`
+      : '';
     console.warn(
-      `[perf-budget] planTripDeterministic overrun: raw=${rawCount} survivors=${survivors.length} enumerationMs=${enumerationMs}`,
+      `[perf-budget] planTripDeterministic overrun: raw=${rawCount} survivors=${survivors.length} enumerationMs=${enumerationMs}${wcNote}`,
     );
   }
 

--- a/src/server/services/ai/MovementPhasePlanner.ts
+++ b/src/server/services/ai/MovementPhasePlanner.ts
@@ -42,7 +42,15 @@ import { LLMStrategyBrain } from './LLMStrategyBrain';
 import { ActionResolver } from './ActionResolver';
 import { TurnExecutorPlanner, CompositionTrace, RouteAbandonRecord, AbandonReason } from './TurnExecutorPlanner';
 import { TurnExecutor } from './TurnExecutor';
-import { PostDeliveryReplanner } from './PostDeliveryReplanner';
+import { PostDeliveryReplanner, PostDeliveryOutcome } from './PostDeliveryReplanner';
+
+/**
+ * Exhaustiveness helper: TypeScript will flag this as a compile error if a
+ * new PostDeliveryOutcome variant is added without being handled in the switch.
+ */
+function assertNeverOutcome(outcome: never): never {
+  throw new Error(`[MovementPhasePlanner] Unhandled PostDeliveryOutcome kind: ${JSON.stringify(outcome)}`);
+}
 import { computeEffectivePathLength, getMajorCityLookup, getFerryEdges } from '../../../shared/services/majorCityGroups';
 import { TURN_BUILD_BUDGET } from '../../../shared/constants/gameRules';
 import { isCoordOnNetwork } from './context/NetworkContext';
@@ -390,7 +398,7 @@ export class MovementPhasePlanner {
           }
           // Delegate post-delivery replan to PostDeliveryReplanner
           const _replanStart = Date.now();
-          const replanResult = await PostDeliveryReplanner.replan(
+          const replanOutcome: PostDeliveryOutcome = await PostDeliveryReplanner.replan(
             activeRoute,
             snapshot,
             context,
@@ -404,28 +412,86 @@ export class MovementPhasePlanner {
             trace.timing.replanCount += 1;
           }
 
-          activeRoute = replanResult.route;
-          if (replanResult.moveTargetInvalidated) {
-            lastMoveTargetCity = null; // JIRA-194: clear stale move target
-          }
-          // JIRA-233: propagate route abandonment from impossibility check
-          if (replanResult.routeWasAbandoned) {
-            routeAbandonedByImpossibility = true;
-          }
-          if (replanResult.replanLlmLog) replanLlmLog = replanResult.replanLlmLog;
-          if (replanResult.replanSystemPrompt) replanSystemPrompt = replanResult.replanSystemPrompt;
-          if (replanResult.replanUserPrompt) replanUserPrompt = replanResult.replanUserPrompt;
-          // JIRA-198: Merge upgrade signal — last non-null action wins across replans.
-          if (replanResult.pendingUpgradeAction !== undefined) {
-            if (replanResult.pendingUpgradeAction !== null) {
-              // Non-null result: always adopt the latest upgrade decision
-              pendingUpgradeAction = replanResult.pendingUpgradeAction;
-              upgradeSuppressionReason = null;
-            } else if (pendingUpgradeAction === undefined || pendingUpgradeAction === null) {
-              // Null result: only update suppression reason if we don't already have a non-null action
-              pendingUpgradeAction = null;
-              upgradeSuppressionReason = replanResult.upgradeSuppressionReason;
+          // ADR-1/ADR-2: Dispatch on the discriminated union kind. no-route and
+          // route-abandoned MUST end the movement loop immediately, regardless of
+          // remaining budget (JIRA-271 fix). The default case is exhaustive (ADR-4).
+          switch (replanOutcome.kind) {
+            case 'route-continued':
+              // Route preserved (keep_current_plan or strictly-faster gate rejection).
+              // Move target remains valid — do NOT clear lastMoveTargetCity.
+              activeRoute = replanOutcome.route;
+              if (replanOutcome.replanLlmLog) replanLlmLog = replanOutcome.replanLlmLog;
+              if (replanOutcome.replanSystemPrompt) replanSystemPrompt = replanOutcome.replanSystemPrompt;
+              if (replanOutcome.replanUserPrompt) replanUserPrompt = replanOutcome.replanUserPrompt;
+              break;
+
+            case 'route-replaced':
+              // New route from TripPlanner. Clear stale move target (JIRA-194).
+              activeRoute = replanOutcome.route;
+              lastMoveTargetCity = null;
+              if (replanOutcome.replanLlmLog) replanLlmLog = replanOutcome.replanLlmLog;
+              if (replanOutcome.replanSystemPrompt) replanSystemPrompt = replanOutcome.replanSystemPrompt;
+              if (replanOutcome.replanUserPrompt) replanUserPrompt = replanOutcome.replanUserPrompt;
+              // JIRA-233: propagate impossibility abandonment signal
+              if (replanOutcome.routeWasAbandoned) {
+                routeAbandonedByImpossibility = true;
+              }
+              // JIRA-198: Merge upgrade signal — last non-null action wins across replans.
+              if (replanOutcome.pendingUpgradeAction !== undefined) {
+                if (replanOutcome.pendingUpgradeAction !== null) {
+                  // Non-null result: always adopt the latest upgrade decision
+                  pendingUpgradeAction = replanOutcome.pendingUpgradeAction;
+                  upgradeSuppressionReason = null;
+                } else if (pendingUpgradeAction === undefined || pendingUpgradeAction === null) {
+                  // Null result: only update suppression reason if we don't already have a non-null action
+                  pendingUpgradeAction = null;
+                  upgradeSuppressionReason = replanOutcome.upgradeSuppressionReason;
+                }
+              }
+              break;
+
+            case 'no-route': {
+              // No viable route (null from planner or route fully completed).
+              // ADR-2/JIRA-271: End the movement loop immediately, bypassing the
+              // post-loop route_complete check which would overwrite terminationReason.
+              if (replanOutcome.replanLlmLog) replanLlmLog = replanOutcome.replanLlmLog;
+              if (replanOutcome.replanSystemPrompt) replanSystemPrompt = replanOutcome.replanSystemPrompt;
+              if (replanOutcome.replanUserPrompt) replanUserPrompt = replanOutcome.replanUserPrompt;
+              // When the route had all its stops executed, signal route_complete so
+              // downstream consumers (and the existing post-loop semantics) see the
+              // completion. Otherwise the planner declined to replan with stops
+              // remaining — no completion signal.
+              const routeComplete =
+                replanOutcome.route.currentStopIndex >= replanOutcome.route.stops.length;
+              trace.a2.terminationReason = routeComplete
+                ? 'route_complete'
+                : 'no_route_after_replan';
+              trace.outputPlan = plans.map(p => p.type);
+              return MovementPhasePlanner.makeResult(
+                replanOutcome.route, plans, hasDelivery, null, deliveriesThisTurn,
+                snapshot, context, routeComplete, false,
+                replanLlmLog, replanSystemPrompt, replanUserPrompt,
+                pendingUpgradeAction, upgradeSuppressionReason,
+              );
             }
+
+            case 'route-abandoned':
+              // Impossibility check fired (JIRA-233 R2/R3). End the movement loop.
+              // ADR-2: Early-return so the post-loop route_complete check cannot
+              // overwrite terminationReason or suppress the routeAbandoned flag.
+              trace.a2.terminationReason = 'route_abandoned_after_replan';
+              trace.outputPlan = plans.map(p => p.type);
+              return MovementPhasePlanner.makeResult(
+                replanOutcome.route, plans, hasDelivery, null, deliveriesThisTurn,
+                snapshot, context, false, true,
+                undefined, undefined, undefined,
+                pendingUpgradeAction, upgradeSuppressionReason,
+              );
+
+            default:
+              // ADR-4: Compile-time exhaustiveness check. TypeScript will flag this
+              // if a new variant is added without being handled above.
+              assertNeverOutcome(replanOutcome);
           }
         }
 

--- a/src/server/services/ai/PathCostEstimator.ts
+++ b/src/server/services/ai/PathCostEstimator.ts
@@ -131,6 +131,7 @@ export function estimateGraphPathCost(
   to: string | GridCoord,
   snapshot: WorldSnapshot,
   trainSpeed: number,
+  deadlineMs?: number,
 ): PathCost {
   const segmentsHash = hashSegments(snapshot.bot.existingSegments);
   const cacheKey = makeCacheKey(from, to, segmentsHash, trainSpeed);
@@ -140,8 +141,15 @@ export function estimateGraphPathCost(
     return cached;
   }
 
-  const result = computePathCost(from, to, snapshot, trainSpeed);
-  cache.set(cacheKey, result);
+  const result = computePathCost(from, to, snapshot, trainSpeed, deadlineMs);
+  // When a deadline was supplied AND the result came back unreachable, skip
+  // caching: the unreachability might be a false-negative caused by the
+  // Dijkstra aborting on the wall-clock deadline rather than a real
+  // unreachable-target finding. Caching it would poison subsequent (deadline-
+  // free) callers. Reachable results are always safe to cache.
+  if (result.reachable || deadlineMs === undefined) {
+    cache.set(cacheKey, result);
+  }
   return result;
 }
 
@@ -153,6 +161,7 @@ function computePathCost(
   to: string | GridCoord,
   snapshot: WorldSnapshot,
   trainSpeed: number,
+  deadlineMs?: number,
 ): PathCost {
   // Resolve inputs to arrays of coords
   const fromCoords: Array<{ row: number; col: number }> =
@@ -194,7 +203,7 @@ function computePathCost(
         continue;
       }
 
-      const estimate = estimateRouteSegment(fromCoord, toCoord, snapshotInput);
+      const estimate = estimateRouteSegment(fromCoord, toCoord, snapshotInput, deadlineMs);
 
       if (!estimate.reachable) {
         // This pair is blocked; continue trying other outpost combinations

--- a/src/server/services/ai/PostDeliveryReplanner.ts
+++ b/src/server/services/ai/PostDeliveryReplanner.ts
@@ -72,49 +72,119 @@ function estimateRouteTurns(
   }
 }
 
-// ── ReplanResult ──────────────────────────────────────────────────────────
+// ── PostDeliveryOutcome discriminated union ───────────────────────────────
 
 /**
- * Result returned by PostDeliveryReplanner.replan().
- *
- * `moveTargetInvalidated` is true in every code path that REPLACES the active
- * route (all four sub-paths set it true — even the no-brain fallback, because
- * revalidateRemainingDeliveries + skipCompletedStops always produce a new route
- * object, and lastMoveTargetCity from the prior route is stale regardless).
+ * The existing route still has remaining stops and the planner preserved it
+ * (keep_current_plan or strictly-faster gate rejected the candidate in End state).
+ * The movement loop continues on the existing route; lastMoveTargetCity is valid.
  */
-export interface ReplanResult {
-  /** Updated active route after replan (may be revalidated, enriched, or unchanged). */
-  route: StrategicRoute;
-  /**
-   * True whenever the activeRoute object was replaced. The caller MUST clear
-   * `lastMoveTargetCity` when this is true to prevent JIRA-194 stale-index bugs.
-   */
-  moveTargetInvalidated: boolean;
+export interface RouteContinuedOutcome {
+  readonly kind: 'route-continued';
+  /** The preserved (revalidated) route — same logical route, no replacement. */
+  readonly route: StrategicRoute;
+  /** Always false — existing stop indices remain valid. */
+  readonly moveTargetInvalidated: false;
   /** LLM log from TripPlanner, if called. */
-  replanLlmLog?: LlmAttempt[];
+  readonly replanLlmLog?: LlmAttempt[];
   /** System prompt sent to TripPlanner, if called. */
-  replanSystemPrompt?: string;
+  readonly replanSystemPrompt?: string;
   /** User prompt sent to TripPlanner, if called. */
-  replanUserPrompt?: string;
+  readonly replanUserPrompt?: string;
+}
+
+/**
+ * TripPlanner returned a new route that replaced the existing one.
+ * The movement loop continues on the new route; lastMoveTargetCity must be cleared.
+ */
+export interface RouteReplacedOutcome {
+  readonly kind: 'route-replaced';
+  /** The new route from TripPlanner (after skipCompletedStops). */
+  readonly route: StrategicRoute;
+  /** Always true — new route object, stale stop indices are no longer valid. */
+  readonly moveTargetInvalidated: true;
+  /** LLM log from TripPlanner. */
+  readonly replanLlmLog?: LlmAttempt[];
+  /** System prompt sent to TripPlanner. */
+  readonly replanSystemPrompt?: string;
+  /** User prompt sent to TripPlanner. */
+  readonly replanUserPrompt?: string;
   /**
    * Upgrade action to inject into the turn plan (JIRA-198), or null when the
    * eligibility gate blocked the LLM-requested upgrade.
-   * Undefined when the LLM did not request an upgrade (sub-paths 2/3/4 also
-   * leave this undefined because no upgradeOnRoute was emitted).
+   * Undefined when no upgradeOnRoute was emitted by TripPlanner.
    */
-  pendingUpgradeAction?: TurnPlanUpgradeTrain | null;
+  readonly pendingUpgradeAction?: TurnPlanUpgradeTrain | null;
   /**
    * Human-readable reason explaining why an upgrade was blocked (JIRA-198).
    * Undefined when no upgrade was requested or when the upgrade was accepted.
    */
-  upgradeSuppressionReason?: string | null;
+  readonly upgradeSuppressionReason?: string | null;
   /**
-   * True when the active route was abandoned because its next stop became
-   * impossible to complete (JIRA-233, R2). Callers must propagate this flag
-   * so AIStrategyEngine can record the abandonment in routeHistory.
+   * True when the route was abandoned due to impossibility before TripPlanner
+   * was called, but TripPlanner returned a new route afterwards (JIRA-233 R2/R3).
+   * The caller should propagate this to AIStrategyEngine for routeHistory recording.
    */
-  routeWasAbandoned?: boolean;
+  readonly routeWasAbandoned?: true;
 }
+
+/**
+ * The route is fully completed OR TripPlanner returned null (for reasons other
+ * than keep_current_plan). The caller MUST end the movement loop immediately —
+ * there is no viable route to continue on. This is the JIRA-271 fix: previously
+ * a fully-completed route with remaining budget would fall through and try to move
+ * on a completed route, producing spurious movements.
+ */
+export interface NoRouteOutcome {
+  readonly kind: 'no-route';
+  /** The revalidated route (may have stale indices if fully completed). */
+  readonly route: StrategicRoute;
+  /** Always true — route was replaced/revalidated. */
+  readonly moveTargetInvalidated: true;
+  /** LLM log from TripPlanner, if called. */
+  readonly replanLlmLog?: LlmAttempt[];
+  /** System prompt sent to TripPlanner, if called. */
+  readonly replanSystemPrompt?: string;
+  /** User prompt sent to TripPlanner, if called. */
+  readonly replanUserPrompt?: string;
+}
+
+/**
+ * The impossibility check (JIRA-233 R2) fired and the route was cleared. The
+ * caller MUST end the movement loop immediately and propagate routeWasAbandoned
+ * to AIStrategyEngine so it can record the event in routeHistory.
+ */
+export interface RouteAbandonedOutcome {
+  readonly kind: 'route-abandoned';
+  /** The revalidated route (next stop is impossible). */
+  readonly route: StrategicRoute;
+  /** Always true — route object was replaced/cleared. */
+  readonly moveTargetInvalidated: true;
+  /** Always true — signals the impossibility abandonment to the caller. */
+  readonly routeWasAbandoned: true;
+}
+
+/**
+ * Discriminated union returned by PostDeliveryReplanner.replan().
+ *
+ * ADR-1: The union replaces the previous ReplanResult bag so the caller's
+ *        switch dispatch is exhaustive at compile time (ADR-4).
+ * ADR-2: `no-route` and `route-abandoned` MUST end the movement loop
+ *        immediately, regardless of remaining budget (JIRA-271 fix).
+ * ADR-5: Replan-log / upgrade fields attach to specific variants only.
+ */
+export type PostDeliveryOutcome =
+  | RouteContinuedOutcome
+  | RouteReplacedOutcome
+  | NoRouteOutcome
+  | RouteAbandonedOutcome;
+
+/**
+ * @deprecated Use PostDeliveryOutcome instead. ReplanResult is kept as a
+ * type alias for backwards compatibility during the transition period.
+ * Will be removed once all callers have been updated.
+ */
+export type ReplanResult = PostDeliveryOutcome;
 
 // ── PostDeliveryReplanner ─────────────────────────────────────────────────
 
@@ -145,7 +215,7 @@ export class PostDeliveryReplanner {
     gridPoints: GridPoint[] | undefined,
     deliveriesThisTurn: number,
     tag: string,
-  ): Promise<ReplanResult> {
+  ): Promise<PostDeliveryOutcome> {
     // Sub-path 4: gridPoints unavailable — cannot plan, revalidate existing route.
     // JIRA-270: brain may be null (Medium-skill bot); TripPlanner.planTrip
     // dispatches Medium deterministically per JIRA-269, so brain presence is
@@ -161,9 +231,12 @@ export class PostDeliveryReplanner {
           `[route-abandoned] route impossible: next stop=${JSON.stringify(nextStop)}, ` +
           `cargo=${JSON.stringify(context.loads)}, remaining stops=${remainingCount}`,
         );
-        return { route: skipped, moveTargetInvalidated: true, routeWasAbandoned: true };
+        const outcome: RouteAbandonedOutcome = { kind: 'route-abandoned', route: skipped, moveTargetInvalidated: true, routeWasAbandoned: true };
+        return outcome;
       }
-      return { route: skipped, moveTargetInvalidated: true };
+      // No route returned — grid empty, movement loop must end
+      const outcome: NoRouteOutcome = { kind: 'no-route', route: skipped, moveTargetInvalidated: true };
+      return outcome;
     }
 
     // Sub-paths 1–3: planner path (brain may be null; TripPlanner handles skill dispatch).
@@ -236,14 +309,15 @@ export class PostDeliveryReplanner {
           if (candidateTurns >= currentRemaining) {
             const revalidated = TurnExecutorPlanner.revalidateRemainingDeliveries(activeRoute, context);
             const skipped = TurnExecutorPlanner.skipCompletedStops(revalidated, context);
-            return {
+            const outcome: RouteContinuedOutcome = {
+              kind: 'route-continued',
               route: skipped,
               moveTargetInvalidated: false,
               replanLlmLog,
               replanSystemPrompt,
               replanUserPrompt,
-              routeWasAbandoned: routeWasAbandoned || undefined,
             };
+            return outcome;
           }
         }
 
@@ -263,7 +337,8 @@ export class PostDeliveryReplanner {
           upgradeSuppressionReason = upgradeResult.reason ?? null;
         }
 
-        return {
+        const outcome: RouteReplacedOutcome = {
+          kind: 'route-replaced',
           route: finalRoute,
           moveTargetInvalidated: true, // JIRA-194: new route — stale stop indices no longer valid
           replanLlmLog,
@@ -273,6 +348,7 @@ export class PostDeliveryReplanner {
           upgradeSuppressionReason,
           routeWasAbandoned: routeWasAbandoned || undefined, // JIRA-233: propagate impossibility signal
         };
+        return outcome;
       }
 
       // Sub-path 2a: JIRA-207B (R10e) — TripPlanner returned keep_current_plan.
@@ -281,38 +357,53 @@ export class PostDeliveryReplanner {
       if (!replanResult.route && replanSelection?.fallbackReason === 'keep_current_plan') {
         const revalidated = TurnExecutorPlanner.revalidateRemainingDeliveries(activeRoute, context);
         const skipped = TurnExecutorPlanner.skipCompletedStops(revalidated, context);
-        return {
+        const outcome: RouteContinuedOutcome = {
+          kind: 'route-continued',
           route: skipped,
           moveTargetInvalidated: false, // Route unchanged — stale indices remain valid
           replanLlmLog,
           replanSystemPrompt,
           replanUserPrompt,
-          routeWasAbandoned: routeWasAbandoned || undefined,
         };
+        return outcome;
       }
 
-      // Sub-path 2b: TripPlanner returned null route (other reasons).
-      console.warn(`${tag} [PostDeliveryReplanner] TripPlanner returned null route. Continuing on existing route.`);
+      // Sub-path 2b: TripPlanner returned null route (other reasons) — no viable route.
+      // JIRA-271: movement loop MUST end when no route is available, regardless of budget.
+      console.warn(`${tag} [PostDeliveryReplanner] TripPlanner returned null route. Ending movement loop.`);
       const revalidated = TurnExecutorPlanner.revalidateRemainingDeliveries(activeRoute, context);
       const skipped = TurnExecutorPlanner.skipCompletedStops(revalidated, context);
-      return {
+      // JIRA-233: If impossibility already fired, surface as route-abandoned so the
+      // caller can record the abandonment in routeHistory.
+      if (routeWasAbandoned) {
+        const abandonedOutcome: RouteAbandonedOutcome = { kind: 'route-abandoned', route: skipped, moveTargetInvalidated: true, routeWasAbandoned: true };
+        return abandonedOutcome;
+      }
+      const noRouteOutcome: NoRouteOutcome = {
+        kind: 'no-route',
         route: skipped,
         moveTargetInvalidated: true, // JIRA-194: route shape replaced — clear stale move target
         replanLlmLog,
         replanSystemPrompt,
         replanUserPrompt,
-        routeWasAbandoned: routeWasAbandoned || undefined,
       };
+      return noRouteOutcome;
     } catch (err) {
-      // Sub-path 3: TripPlanner threw
-      console.warn(`${tag} [PostDeliveryReplanner] Replan failed (${(err as Error).message}). Continuing on existing route.`);
+      // Sub-path 3: TripPlanner threw — no viable route.
+      // JIRA-271: movement loop MUST end when no route is available, regardless of budget.
+      console.warn(`${tag} [PostDeliveryReplanner] Replan failed (${(err as Error).message}). Ending movement loop.`);
       const revalidated = TurnExecutorPlanner.revalidateRemainingDeliveries(activeRoute, context);
       const skipped = TurnExecutorPlanner.skipCompletedStops(revalidated, context);
-      return {
+      if (routeWasAbandoned) {
+        const outcome: RouteAbandonedOutcome = { kind: 'route-abandoned', route: skipped, moveTargetInvalidated: true, routeWasAbandoned: true };
+        return outcome;
+      }
+      const outcome: NoRouteOutcome = {
+        kind: 'no-route',
         route: skipped,
         moveTargetInvalidated: true, // JIRA-194: route shape replaced — clear stale move target
-        routeWasAbandoned: routeWasAbandoned || undefined,
       };
+      return outcome;
     }
   }
 }

--- a/src/server/services/ai/RouteDetourEstimator.ts
+++ b/src/server/services/ai/RouteDetourEstimator.ts
@@ -180,6 +180,7 @@ export function estimateRouteSegment(
   from: GridCoord,
   to: GridCoord,
   snapshot: SnapshotInput,
+  deadlineMs?: number,
 ): RouteSegmentEstimate {
   const existingEdges = buildExistingEdgeSet(snapshot.bot.existingSegments);
   // existingTrackIndex: segments-only node set (no start hex) — feeds the
@@ -191,6 +192,7 @@ export function estimateRouteSegment(
   const { path, segments: newSegments, totalCost: buildCost } = findBuildPath(
     from, to,
     existingEdges, existingTrackIndex, opponentEdges,
+    { deadlineMs },
   );
 
   if (path.length === 0) {

--- a/src/server/services/ai/computeBuildSegments.ts
+++ b/src/server/services/ai/computeBuildSegments.ts
@@ -186,6 +186,17 @@ function buildSegment(
  *                      so the practical max is ~20.
  * @returns An array of TrackSegment with full grid + pixel coordinates.
  */
+/**
+ * Wall-clock cap for the whole computeBuildSegments call. Caps the cumulative
+ * time spent in findBuildPath iterations (targeted) + the multi-source
+ * Dijkstra (untargeted/fallback). Set well above typical builds (which
+ * complete in <100ms) but below the multi-minute pathological cases observed
+ * on dense late-game networks (smoke-game T85: 17 minutes in this function).
+ * Once the budget is exhausted, callers see the best path found so far —
+ * or an empty array if nothing has been computed yet.
+ */
+export const COMPUTE_BUILD_WALL_CLOCK_BUDGET_MS = 5000;
+
 export function computeBuildSegments(
   startPositions: GridCoord[],
   existingSegments: TrackSegment[],
@@ -212,6 +223,12 @@ export function computeBuildSegments(
   if (budget <= 0) {
     return [];
   }
+
+  // Wall-clock deadline shared between the findBuildPath outer loop (targeted
+  // builds) and the multi-source Dijkstra (untargeted / fallback). See
+  // COMPUTE_BUILD_WALL_CLOCK_BUDGET_MS doc above.
+  const buildStartMs = Date.now();
+  const buildDeadlineMs = buildStartMs + COMPUTE_BUILD_WALL_CLOCK_BUDGET_MS;
 
   const grid = loadGridPoints();
   const majorCityLookup = getMajorCityLookup();
@@ -360,15 +377,19 @@ export function computeBuildSegments(
     // Call findBuildPath for each (source, effectiveTarget) pair and pick
     // the cheapest result. This replaces the multi-source Dijkstra early-termination.
     let cheapestCost = Infinity;
-    for (const src of sources) {
+    let wallClockHit = false;
+    outer: for (const src of sources) {
       for (const target of effectiveTargets) {
         const result = findBuildPath(
           src, target,
           builtEdges,
           existingTrackIndex ?? new Set<string>(),
           occupiedEdges ?? new Set<string>(),
-          // No budget cap for targeted builds (truncation happens in extractSegments)
-          { budget: null },
+          // No cost budget cap for targeted builds (truncation happens in
+          // extractSegments). Pass the shared wall-clock deadline so a single
+          // pathological Dijkstra (dense graph, distant target) can't burn the
+          // entire turn.
+          { budget: null, deadlineMs: buildDeadlineMs },
         );
         if (result.path.length > 0 && result.totalCost < cheapestCost) {
           cheapestCost = result.totalCost;
@@ -379,10 +400,19 @@ export function computeBuildSegments(
             path: result.path,
           };
         }
+        // Break out of both loops if the cumulative wall-clock cap was hit —
+        // remaining (source, target) pairs aren't worth waiting for; we have
+        // the best path found so far.
+        if (Date.now() > buildDeadlineMs) {
+          wallClockHit = true;
+          break outer;
+        }
       }
     }
 
-    if (!earlyTermPath) {
+    if (wallClockHit) {
+      console.warn(`${tag} wall-clock cap hit during findBuildPath sweep — using best-of-${cheapestCost === Infinity ? 'none' : `${cheapestCost}M`}`);
+    } else if (!earlyTermPath) {
       // All findBuildPath calls returned empty — fall back to Dijkstra hex-distance
       console.warn(`${tag} target unreachable via findBuildPath, falling back to hex-distance Dijkstra`);
     }

--- a/src/server/services/ai/pathfinding/findBuildPath.ts
+++ b/src/server/services/ai/pathfinding/findBuildPath.ts
@@ -48,6 +48,14 @@ export interface FindBuildPathOptions {
    * paths exceeding this budget. Defaults to null (no cap).
    */
   budget?: number | null;
+  /**
+   * Wall-clock deadline as `Date.now()` milliseconds. When provided, the
+   * Dijkstra loop checks against this every N iterations and aborts with an
+   * empty path once exceeded. Used by computeBuildSegments to keep Phase B
+   * builds bounded on dense late-game networks (smoke-game T85: one
+   * findBuildPath call ate 17 minutes before this cap existed).
+   */
+  deadlineMs?: number;
 }
 
 /** Result returned by findBuildPath. */
@@ -209,7 +217,7 @@ export function findBuildPath(
   opponentEdges: Set<string>,
   options: FindBuildPathOptions = {},
 ): FindBuildPathResult {
-  const { applyParallelPenalty = true, budget = null } = options;
+  const { applyParallelPenalty = true, budget = null, deadlineMs } = options;
 
   const grid = loadGridPoints();
   const majorCityLookup = getMajorCityLookup();
@@ -246,9 +254,22 @@ export function findBuildPath(
   heap.push({ row: from.row, col: from.col, cost: 0, path: [{ row: from.row, col: from.col }] });
   minCost.set(fromKey, 0);
 
+  // Wall-clock deadline check is amortised — only check every 256 heap pops so
+  // the Date.now() call doesn't add measurable per-iteration cost.
+  let popCount = 0;
+
   while (heap.size > 0) {
     const current = heap.pop()!;
     const currentKey = makeKey(current.row, current.col);
+
+    // JIRA-262 follow-up: abort if wall-clock deadline exceeded. Caller treats
+    // empty path as "unreachable within budget" — same code path as a real
+    // unreachable target. Smoke game showed a single findBuildPath spending
+    // 17 min on a dense graph; capping here prevents that.
+    if (deadlineMs !== undefined && (++popCount & 0xff) === 0 && Date.now() > deadlineMs) {
+      console.warn(`[findBuildPath] wall-clock cap hit after ${popCount} pops — aborting (from=${fromKey} to=${toKey})`);
+      return { path: [], segments: [], totalCost: 0 };
+    }
 
     const recorded = minCost.get(currentKey);
     if (recorded !== undefined && current.cost > recorded) continue;


### PR DESCRIPTION
## Summary

**Stacked on PR #264** (JIRA-270). Bundles **JIRA-271 perf** per boss approval (JIRA-271 = the wall-clock-cap perf change in `cheapPrune` / `findBuildPath` / `computeBuildSegments`; it was always conceptually paired with JIRA-272's dispatch refactor — they ship together).

## Tickets covered

| JIRA | What |
|---|---|
| **JIRA-271** | `perf(ai)`: wall-clock caps for `cheapPrune` + `findBuildPath` + `computeBuildSegments` — bounds CPU per planner call |
| **JIRA-272** | `refactor(ai)`: `PostDeliveryReplanner.replan()` returns a `PostDeliveryOutcome` discriminated union; `MovementPhasePlanner` switches dispatch on the outcome variant (route / route_complete / no_route) instead of inspecting nullable fields |

## Commits

1. `d430499` — JIRA-271 perf: wall-clock caps
2. `9388d3f` — JIRA-272 BE-001: PostDeliveryReplanner returns `PostDeliveryOutcome` discriminated union
3. `b89f990` — JIRA-272 BE-002 sibling: recover lost dispatch-shape updates to two smaller `MovementPhasePlanner.*.test.ts` files (789a65b)
4. `07642f3` — JIRA-272 follow-up: preserve `route_complete` signal in no-route outcome

## Per-ticket docs
- `docs/ai/done/jira-271-botContinuesMovingAfterDeliveryWithoutReplan.md`
- `docs/ai/done/jira-272-postDeliveryReplanShouldBeUnconditional.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Once stack merges, retarget base to `main`

**Base**: `pr/jira-270` (PR #264). Stacks: PR-13→14→15→…→17→18→19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)