### PR TITLE
fix(ai): JIRA-273 — validate carry preconditions before applying victory-route override

### DIFF
--- a/docs/ai/done/jira-273-endGameVictoryOverrideEmitsDeliversWithoutCarries.md
+++ b/docs/ai/done/jira-273-endGameVictoryOverrideEmitsDeliversWithoutCarries.md
@@ -1,0 +1,36 @@
+# JIRA-273 — End-game victory-route override emits a deliver-only route when the bot does not actually carry the required loads, wedging the bot in an infinite stuck-route-abandon loop
+
+The end-game `findFinalVictoryOutcome` override produces a route consisting entirely of DELIVER stops under the premise that the matching loads are already on the train. When that premise is false, the bot arrives at the first delivery city, the JIRA-249 runtime guard fires (`arrived_for_deliver_but_load_not_carried`), the route is abandoned, and the planner immediately re-emits the same impossible route. The game ends with the bot frozen in this cycle, cash below the victory threshold.
+
+## Source
+
+`logs/game-c73cccf8-919e-462c-8250-28b2199665a4.ndjson`, player s1, turns T242–T249 (and earlier; the cycle starts around T230s). Latest game log on `cac1493`.
+
+## Trace
+
+Same state repeats every turn. Representative T244:
+
+- `action: PassTurn`, `cash: 208M`, `position: (40,59)`
+- `activeRoute.stops: [deliver Imports@Budapest, deliver Sheep@Wroclaw]`, `currentStopIndex: 1`
+- `a2.terminationReason: arrived_for_deliver_but_load_not_carried`
+- `endGame.victoryRouteProjection.appliedOverride: true`
+- `endGame.victoryRouteProjection.stops: [deliver:Imports@Budapest, deliver:Sheep@Wroclaw]`
+- `endGame.victoryRouteProjection.payoutM: 58` → `cashAtVictory: 266` (above 250M threshold; all 7 majors connected)
+- `victoryCheck.outcome: insufficient-funds, netWorth: 208, threshold: 250`
+
+Every 3 turns the stuck-route-abandon fires (`strategy-brain` source, reasoning: `[stuck-route-abandon] no progress for 3 turns`). The route is cleared. Next turn the override re-emits the identical route. Loop continues until the game ends.
+
+## What should happen
+
+The victory-route override must only apply when its carry assumptions match the bot's actual cargo. Two acceptable shapes:
+
+1. **Reject the override when the assumed carries aren't on the train.** Fall back to whatever the regular planner produces — the bot picks up the loads first, then delivers them.
+2. **Emit a complete route that includes the necessary pickup stops.** If the bot needs to pick up Imports and Sheep first, the override's route is `[pickup Imports@X, pickup Sheep@Y, deliver Imports@Budapest, deliver Sheep@Wroclaw]`, not just the delivers.
+
+Either shape ends the loop. Today the override projects a winning outcome whose preconditions (loads carried) are never satisfied, and the planner has no recovery path because the override re-applies every replan.
+
+## Related
+
+- **JIRA-249 Layer 3** added the runtime guard that detects "arrived for deliver but load not carried" — that guard is firing correctly here; it's not the bug.
+- **JIRA-267** made `findFinalVictoryOutcome` multiplicity-aware for carried loads. This is a different failure mode: the override assumes carries that don't exist at all, not over-counting carries that do.
+- **JIRA-261** fixed first-stop-only idempotency of the override comparison. This bug is upstream — the override itself is wrong.

--- a/src/server/__tests__/ai/victoryRules.test.ts
+++ b/src/server/__tests__/ai/victoryRules.test.ts
@@ -19,6 +19,7 @@ import {
   findFinalVictoryOutcome,
   buildEndGameTrace,
   buildEffectiveCarrySet,
+  validateRouteCarryPreconditions,
   type FinalVictoryOutcome,
 } from '../../services/ai/victoryRules';
 import { GameState, GameContext, TrainType, WorldSnapshot } from '../../../shared/types/GameTypes';
@@ -1102,5 +1103,99 @@ describe('findFinalVictoryOutcome — JIRA-267 distance-aware + multiplicity-awa
     if (result.outcome === 'fire') {
       expect(result.route.estimatedTurns).toBeGreaterThanOrEqual(2);
     }
+  });
+});
+
+// ── JIRA-273: validateRouteCarryPreconditions ─────────────────────────────
+
+describe('validateRouteCarryPreconditions (JIRA-273)', () => {
+  function makeRoute(stops: Array<{ action: 'pickup' | 'deliver' | 'drop'; loadType: string; city: string }>) {
+    return {
+      stops,
+      currentStopIndex: 0,
+      phase: 'travel' as const,
+      createdAtTurn: 0,
+    };
+  }
+
+  it('pickup+deliver with empty cargo → ok', () => {
+    const r = makeRoute([
+      { action: 'pickup', loadType: 'Imports', city: 'Hamburg' },
+      { action: 'deliver', loadType: 'Imports', city: 'Budapest' },
+    ]);
+    expect(validateRouteCarryPreconditions(r, [])).toEqual({ ok: true });
+  });
+
+  it('deliver-only with matching cargo → ok', () => {
+    const r = makeRoute([{ action: 'deliver', loadType: 'Imports', city: 'Budapest' }]);
+    expect(validateRouteCarryPreconditions(r, ['Imports'])).toEqual({ ok: true });
+  });
+
+  it('deliver-only with empty cargo → reject', () => {
+    const r = makeRoute([{ action: 'deliver', loadType: 'Imports', city: 'Budapest' }]);
+    const result = validateRouteCarryPreconditions(r, []);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('deliver Imports@Budapest');
+      expect(result.reason).toContain('stop 0');
+    }
+  });
+
+  it('two delivers of same loadType, only one in cargo → reject second', () => {
+    const r = makeRoute([
+      { action: 'deliver', loadType: 'Imports', city: 'Budapest' },
+      { action: 'deliver', loadType: 'Imports', city: 'Wien' },
+    ]);
+    const result = validateRouteCarryPreconditions(r, ['Imports']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('stop 1');
+    }
+  });
+
+  it('mixed route: pickup A + deliver A + deliver B with B in cargo → ok', () => {
+    const r = makeRoute([
+      { action: 'pickup', loadType: 'Imports', city: 'Hamburg' },
+      { action: 'deliver', loadType: 'Imports', city: 'Budapest' },
+      { action: 'deliver', loadType: 'Sheep', city: 'Wroclaw' },
+    ]);
+    expect(validateRouteCarryPreconditions(r, ['Sheep'])).toEqual({ ok: true });
+  });
+
+  it('empty route → ok', () => {
+    expect(validateRouteCarryPreconditions(makeRoute([]), [])).toEqual({ ok: true });
+  });
+
+  it('multiplicity: two pickups + two delivers of same loadType, empty cargo → ok', () => {
+    const r = makeRoute([
+      { action: 'pickup', loadType: 'Imports', city: 'Hamburg' },
+      { action: 'pickup', loadType: 'Imports', city: 'Antwerpen' },
+      { action: 'deliver', loadType: 'Imports', city: 'Budapest' },
+      { action: 'deliver', loadType: 'Imports', city: 'Wien' },
+    ]);
+    expect(validateRouteCarryPreconditions(r, [])).toEqual({ ok: true });
+  });
+
+  it('JIRA-273 reproduction: c73cccf8 T244 shape — deliver Imports + deliver Sheep with cargo=[Oil] → reject', () => {
+    const r = makeRoute([
+      { action: 'deliver', loadType: 'Imports', city: 'Budapest' },
+      { action: 'deliver', loadType: 'Sheep', city: 'Wroclaw' },
+    ]);
+    const result = validateRouteCarryPreconditions(r, ['Oil']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain('Imports');
+      expect(result.reason).toContain('Oil'); // cargoLoads is mentioned in the reason
+    }
+  });
+
+  it('drop action does not consume a slot for later delivers', () => {
+    // Drop is intentionally a no-op for the validator — present for completeness.
+    const r = makeRoute([
+      { action: 'pickup', loadType: 'Imports', city: 'Hamburg' },
+      { action: 'drop', loadType: 'Imports', city: 'Berlin' },
+      // After drop, no Imports remaining — a later deliver would fail.
+    ]);
+    expect(validateRouteCarryPreconditions(r, [])).toEqual({ ok: true });
   });
 });

--- a/src/server/__tests__/ai/victoryRules.test.ts
+++ b/src/server/__tests__/ai/victoryRules.test.ts
@@ -1115,6 +1115,7 @@ describe('validateRouteCarryPreconditions (JIRA-273)', () => {
       currentStopIndex: 0,
       phase: 'travel' as const,
       createdAtTurn: 0,
+      reasoning: 'test',
     };
   }
 

--- a/src/server/services/ai/AIStrategyEngine.ts
+++ b/src/server/services/ai/AIStrategyEngine.ts
@@ -65,6 +65,7 @@ import {
   findFinalVictoryRoute,
   findFinalVictoryOutcome,
   buildEndGameTrace,
+  validateRouteCarryPreconditions,
   type EndGameTrace,
   type FinalVictoryOutcome,
 } from './victoryRules';
@@ -315,17 +316,39 @@ export class AIStrategyEngine {
       if (!context.isInitialBuild) {
         finalVictoryOutcome = findFinalVictoryOutcome(snapshot, context, memory);
         if (finalVictoryOutcome.outcome === 'fire') {
-          // JIRA-261: Idempotency check compares the full remaining-stops
-          // sequence, not just the first stop. The earlier first-stop-only check
-          // suppressed override at game 8350cffa s3 T68 onwards: an existing
-          // 4-stop deterministic route shared its first stop (`pickup Ham@Warszawa`)
-          // with the victory route, so the override never fired — even though
-          // the victory route diverged at stop 3 to add the critical
-          // `pickup Oranges@Sevilla → deliver Oranges@London` leg that would
-          // have connected the 4th-of-7 major and clinched the game. With the
-          // full-sequence comparison, that divergence (and the missing London
-          // leg in the existing route) now correctly triggers the override.
-          if (!AIStrategyEngine.routesMatch(activeRoute, finalVictoryOutcome.route.stops)) {
+          // JIRA-273: Validate the route's carry preconditions against the
+          // bot's actual cargo before applying. Catches cases where the
+          // override emits deliver-only stops for loads not on the train,
+          // which would otherwise loop forever (arrive → JIRA-249 guard fires
+          // → stuck-route-abandon → override re-fires same invalid route).
+          const carryCheck = validateRouteCarryPreconditions(
+            { ...finalVictoryOutcome.route, currentStopIndex: 0, phase: 'travel', createdAtTurn: snapshot.turnNumber },
+            snapshot.bot.loads,
+          );
+          if (!carryCheck.ok) {
+            console.warn(
+              `${tag} [final-victory-rejected] ${carryCheck.reason}`,
+            );
+            // Treat as skip: fall through to the existing skip-branch handling
+            // below. Replace the outcome so endGameTrace records the rejection.
+            finalVictoryOutcome = {
+              outcome: 'skip',
+              reason: 'carry_precondition_fail',
+              cashGap: finalVictoryOutcome.cashGap,
+              majorsGap: finalVictoryOutcome.majorsGap,
+              connectorCost: finalVictoryOutcome.connectorCost,
+            };
+          } else if (!AIStrategyEngine.routesMatch(activeRoute, finalVictoryOutcome.route.stops)) {
+            // JIRA-261: Idempotency check compares the full remaining-stops
+            // sequence, not just the first stop. The earlier first-stop-only check
+            // suppressed override at game 8350cffa s3 T68 onwards: an existing
+            // 4-stop deterministic route shared its first stop (`pickup Ham@Warszawa`)
+            // with the victory route, so the override never fired — even though
+            // the victory route diverged at stop 3 to add the critical
+            // `pickup Oranges@Sevilla → deliver Oranges@London` leg that would
+            // have connected the 4th-of-7 major and clinched the game. With the
+            // full-sequence comparison, that divergence (and the missing London
+            // leg in the existing route) now correctly triggers the override.
             activeRoute = {
               stops: finalVictoryOutcome.route.stops,
               currentStopIndex: 0,
@@ -335,7 +358,8 @@ export class AIStrategyEngine {
             };
             finalVictoryAppliedOverride = true;
           }
-        } else {
+        }
+        if (finalVictoryOutcome.outcome === 'skip') {
           // JIRA-243: Victory-clinch hard gate. If a carried load + matching demand
           // card delivery would satisfy both victory conditions (cash ≥ 250M AND
           // ≥ 7 majors connected) without further building, force the activeRoute

--- a/src/server/services/ai/victoryRules.ts
+++ b/src/server/services/ai/victoryRules.ts
@@ -218,7 +218,11 @@ export type FinalVictoryOutcomeSkipReason =
   | 'no_demands'
   | 'victory_met'
   | 'no_feasible_demands'
-  | 'no_route_covers_gap';
+  | 'no_route_covers_gap'
+  // JIRA-273: emitted by AIStrategyEngine when the override's route fails
+  // validateRouteCarryPreconditions against snapshot.bot.loads. The override
+  // had a fire candidate but its carry assumptions didn't match actual cargo.
+  | 'carry_precondition_fail';
 
 export type FinalVictoryOutcome =
   | { outcome: 'fire'; route: FinalVictoryRoute; cashGap: number; majorsGap: number; connectorCost: number }
@@ -657,6 +661,51 @@ export function findFinalVictoryOutcome(
     reasoning,
   };
   return { outcome: 'fire', route, cashGap, majorsGap, connectorCost };
+}
+
+/**
+ * JIRA-273: Verify that every `deliver` stop in `route.stops` is satisfiable
+ * given the bot's actual cargo. A deliver is satisfiable when (a) a preceding
+ * `pickup` for the same loadType exists in the route, or (b) the loadType has
+ * a remaining slot in `cargoLoads`. Multiplicity-aware: two delivers of the
+ * same loadType require two carries (across cargo + pickups), not just one.
+ *
+ * Used at the override-application site in AIStrategyEngine to reject victory
+ * routes whose carry preconditions don't match snapshot.bot.loads — preventing
+ * the c73cccf8-style stuck-route-abandon loop where the override repeatedly
+ * commits the bot to a deliver-only route for loads it never carries.
+ */
+export function validateRouteCarryPreconditions(
+  route: StrategicRoute,
+  cargoLoads: string[],
+): { ok: true } | { ok: false; reason: string } {
+  // Initial available "slots" per loadType from cargo, then grow via pickups.
+  const available = new Map<string, number>();
+  for (const load of cargoLoads) {
+    available.set(load, (available.get(load) ?? 0) + 1);
+  }
+  for (let i = 0; i < route.stops.length; i++) {
+    const stop = route.stops[i];
+    if (stop.action === 'pickup') {
+      available.set(stop.loadType, (available.get(stop.loadType) ?? 0) + 1);
+    } else if (stop.action === 'deliver') {
+      const count = available.get(stop.loadType) ?? 0;
+      if (count <= 0) {
+        return {
+          ok: false,
+          reason:
+            `deliver ${stop.loadType}@${stop.city} at stop ${i} requires carry, ` +
+            `but no prior pickup and no remaining cargo slot ` +
+            `(cargoLoads=[${cargoLoads.join(',')}])`,
+        };
+      }
+      available.set(stop.loadType, count - 1);
+    }
+    // 'drop' actions release the load but do not affect deliver feasibility
+    // for this validator's purpose; future delivers of the same loadType
+    // would still need another pickup/cargo slot.
+  }
+  return { ok: true };
 }
 
 /**


### PR DESCRIPTION
## Summary

**Top of the Phase 4 stack.** Base = `integration/phase4-tip`, which merges `pr/jira-272` (PR #265) with `pr/jira-267` (PR #261). JIRA-273 depends on both:
- `PostDeliveryOutcome` discriminated dispatch from JIRA-272
- `findFinalVictoryOutcome` per-card-instance carry set from JIRA-267

> *`integration/phase4-tip`* — working branch only, not a PR. Used so this one-commit fix can review as a small per-JIRA diff without forcing its merge to wait for every dependency individually.

## What this fixes

The end-game victory-route override (built up across JIRA-261 + JIRA-265 + JIRA-267) could emit a `deliver` stop for a load the bot wasn't actually carrying — and wasn't scheduled to pick up earlier in the same route. The bot would arrive at the delivery city with no load, the action would fail at execution time, and the override would be wasted.

This PR adds a precondition check before applying the override: each `deliver` stop in the proposed route must correspond to a load currently on the train OR scheduled to be picked up at an earlier stop in the same route.

## Per-ticket docs
- `docs/ai/done/jira-273-endGameVictoryOverrideEmitsDeliversWithoutCarries.md`

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Once full stack merges, retarget base to `main`

**Base**: `integration/phase4-tip`. **This is the final PR in the 20-PR split.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)