### PR TITLE
feat: event card UI components with overlay, highlighting, and socket wiring

### DIFF
--- a/src/client/__tests__/EventCard.test.ts
+++ b/src/client/__tests__/EventCard.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Unit tests for EventCard and EventCardOverlay Phaser components.
+ *
+ * Phaser objects cannot be instantiated in Node/JSDOM, so we unit-test the
+ * pure logic and verify that the correct scene methods are called with the
+ * expected arguments during construction.
+ */
+
+import { EventCard as EventCardComponent } from '../components/EventCard';
+import { EventCardOverlay } from '../components/EventCardOverlay';
+import {
+  EventCard,
+  EventCardType,
+  EventCardDrawnPayload,
+} from '../../shared/types/EventCard';
+
+// ---------------------------------------------------------------------------
+// Scene mock factory
+// ---------------------------------------------------------------------------
+
+function makeText() {
+  return {
+    setOrigin: jest.fn().mockReturnThis(),
+    setStroke: jest.fn().mockReturnThis(),
+    setVisible: jest.fn().mockReturnThis(),
+    setDepth: jest.fn().mockReturnThis(),
+    on: jest.fn().mockReturnThis(),
+    destroy: jest.fn(),
+  };
+}
+
+function makeRectangle() {
+  return {
+    setOrigin: jest.fn().mockReturnThis(),
+    setStrokeStyle: jest.fn().mockReturnThis(),
+    setFillStyle: jest.fn().mockReturnThis(),
+    setInteractive: jest.fn().mockReturnThis(),
+    setDepth: jest.fn().mockReturnThis(),
+    on: jest.fn().mockReturnThis(),
+    destroy: jest.fn(),
+  };
+}
+
+function makeTimerEvent(): Phaser.Time.TimerEvent {
+  return {
+    remove: jest.fn(),
+  } as unknown as Phaser.Time.TimerEvent;
+}
+
+function makeCamera(width = 1280, height = 720) {
+  return { main: { width, height } };
+}
+
+function makeScene(overrides: Record<string, unknown> = {}) {
+  const timerEvent = makeTimerEvent();
+
+  const scene = {
+    add: {
+      rectangle: jest.fn().mockReturnValue(makeRectangle()),
+      text: jest.fn().mockReturnValue(makeText()),
+      existing: jest.fn(),
+    },
+    cameras: makeCamera(),
+    time: {
+      addEvent: jest.fn().mockReturnValue(timerEvent),
+    },
+    ...overrides,
+  };
+
+  return { scene, timerEvent };
+}
+
+// ---------------------------------------------------------------------------
+// ContainerLite mock
+// ---------------------------------------------------------------------------
+
+jest.mock('phaser3-rex-plugins/plugins/containerlite.js', () => {
+  return class MockContainerLite {
+    name = '';
+    depth = 0;
+    private children: unknown[] = [];
+
+    constructor(
+      public scene: unknown,
+      public x: number,
+      public y: number
+    ) {}
+
+    setSize(_w: number, _h: number): this {
+      return this;
+    }
+
+    setDepth(d: number): this {
+      this.depth = d;
+      return this;
+    }
+
+    add(child: unknown): this {
+      this.children.push(child);
+      return this;
+    }
+
+    getChildren(): unknown[] {
+      return this.children;
+    }
+
+    destroy(): void {}
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Sample fixtures
+// ---------------------------------------------------------------------------
+
+const sampleCard: EventCard = {
+  id: 125,
+  type: EventCardType.Derailment,
+  title: 'Derailment!',
+  description: 'All trains within 3 mileposts of Praha lose 1 turn and 1 load.',
+  effectConfig: {
+    type: EventCardType.Derailment,
+    cities: ['Praha'],
+    radius: 3,
+  },
+};
+
+const samplePayload: EventCardDrawnPayload = {
+  gameId: 'game-abc',
+  card: sampleCard,
+  drawingPlayerId: 'player-1',
+  drawingPlayerName: 'Alice',
+  affectedZone: [],
+  affectedPlayerIds: ['player-2', 'player-3'],
+  effectSummary: 'Players near Praha derailed.',
+  duration: 'persistent',
+  timestamp: new Date().toISOString(),
+};
+
+// ---------------------------------------------------------------------------
+// EventCard component tests
+// ---------------------------------------------------------------------------
+
+describe('EventCard component', () => {
+  it('creates a background rectangle', () => {
+    const { scene } = makeScene();
+    new EventCardComponent(scene as unknown as Phaser.Scene, 0, 0, sampleCard);
+
+    expect(scene.add.rectangle).toHaveBeenCalledWith(
+      0,
+      0,
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number)
+    );
+  });
+
+  it('renders card ID in the header text', () => {
+    const { scene } = makeScene();
+    new EventCardComponent(scene as unknown as Phaser.Scene, 0, 0, sampleCard);
+
+    const textCalls: string[][] = scene.add.text.mock.calls.map(
+      (call: unknown[]) => [String(call[2])]
+    );
+    const headerCall = textCalls.find(([text]) => text.includes('#125'));
+    expect(headerCall).toBeDefined();
+  });
+
+  it('renders card title in uppercase', () => {
+    const { scene } = makeScene();
+    new EventCardComponent(scene as unknown as Phaser.Scene, 0, 0, sampleCard);
+
+    const textCalls: string[] = scene.add.text.mock.calls.map(
+      (call: unknown[]) => String(call[2])
+    );
+    const titleCall = textCalls.find(t => t.includes('DERAILMENT!'));
+    expect(titleCall).toBeDefined();
+  });
+
+  it('renders card description', () => {
+    const { scene } = makeScene();
+    new EventCardComponent(scene as unknown as Phaser.Scene, 0, 0, sampleCard);
+
+    const textCalls: string[] = scene.add.text.mock.calls.map(
+      (call: unknown[]) => String(call[2])
+    );
+    const descCall = textCalls.find(t =>
+      t.includes('All trains within 3 mileposts')
+    );
+    expect(descCall).toBeDefined();
+  });
+
+  it('sets the component name based on card id', () => {
+    const { scene } = makeScene();
+    const component = new EventCardComponent(
+      scene as unknown as Phaser.Scene,
+      0,
+      0,
+      sampleCard
+    );
+    expect(component.name).toBe('event-card-125');
+  });
+
+  it('includes the type icon in the header text', () => {
+    const { scene } = makeScene();
+    new EventCardComponent(scene as unknown as Phaser.Scene, 0, 0, sampleCard);
+
+    const textCalls: string[] = scene.add.text.mock.calls.map(
+      (call: unknown[]) => String(call[2])
+    );
+    // Derailment uses the ⚠️ icon
+    const iconCall = textCalls.find(t => t.includes('⚠️'));
+    expect(iconCall).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventCardOverlay component tests
+// ---------------------------------------------------------------------------
+
+describe('EventCardOverlay component', () => {
+  it('creates a full-screen backdrop rectangle', () => {
+    const { scene } = makeScene();
+    new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      jest.fn()
+    );
+
+    // The backdrop uses the full camera width/height
+    const rectCalls = scene.add.rectangle.mock.calls;
+    const backdropCall = rectCalls.find(
+      (call: unknown[]) =>
+        call[2] === scene.cameras.main.width &&
+        call[3] === scene.cameras.main.height
+    );
+    expect(backdropCall).toBeDefined();
+  });
+
+  it('renders the drawing player name in metadata', () => {
+    const { scene } = makeScene();
+    new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      jest.fn()
+    );
+
+    const textCalls: string[] = scene.add.text.mock.calls.map(
+      (call: unknown[]) => String(call[2])
+    );
+    const metaCall = textCalls.find(t => t.includes('Alice'));
+    expect(metaCall).toBeDefined();
+  });
+
+  it('renders affected player IDs in metadata', () => {
+    const { scene } = makeScene();
+    new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      jest.fn()
+    );
+
+    const textCalls: string[] = scene.add.text.mock.calls.map(
+      (call: unknown[]) => String(call[2])
+    );
+    const metaCall = textCalls.find(
+      t => t.includes('player-2') && t.includes('player-3')
+    );
+    expect(metaCall).toBeDefined();
+  });
+
+  it('creates a dismiss button that is interactive', () => {
+    const { scene } = makeScene();
+    new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      jest.fn()
+    );
+
+    // One of the rectangles should be interactive (the dismiss button bg)
+    const allRects = (scene.add.rectangle.mock.results as { value: ReturnType<typeof makeRectangle> }[]);
+    const interactiveRect = allRects.find(r => r.value.setInteractive.mock.calls.length > 0);
+    expect(interactiveRect).toBeDefined();
+  });
+
+  it('calls onDismiss when the dismiss button is clicked', () => {
+    const { scene } = makeScene();
+    const onDismiss = jest.fn();
+    new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      onDismiss
+    );
+
+    // Find the button rectangle with a pointerdown listener
+    const allRects = (scene.add.rectangle.mock.results as { value: ReturnType<typeof makeRectangle> }[]);
+    const buttonRect = allRects
+      .map(r => r.value)
+      .find(rect => rect.setInteractive.mock.calls.length > 0);
+
+    expect(buttonRect).toBeDefined();
+    if (!buttonRect) return;
+
+    // Extract the pointerdown handler and invoke it
+    const pointerdownCall = (buttonRect.on.mock.calls as unknown[][]).find(
+      (call) => call[0] === 'pointerdown'
+    );
+    expect(pointerdownCall).toBeDefined();
+    if (!pointerdownCall) return;
+
+    const fakePointer = { event: { stopPropagation: jest.fn() } };
+    (pointerdownCall[1] as (p: unknown) => void)(fakePointer);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts the 30-second auto-dismiss timer on creation', () => {
+    const { scene } = makeScene();
+    new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      jest.fn()
+    );
+
+    expect(scene.time.addEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ delay: 30_000 })
+    );
+  });
+
+  it('calls onDismiss via auto-dismiss timer callback', () => {
+    const { scene } = makeScene();
+    const onDismiss = jest.fn();
+    new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      onDismiss
+    );
+
+    // Retrieve and invoke the timer callback directly
+    const addEventCall = scene.time.addEvent.mock.calls[0][0] as {
+      callback: () => void;
+      callbackScope: unknown;
+    };
+    addEventCall.callback.call(addEventCall.callbackScope);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels auto-dismiss timer when dismiss button is clicked', () => {
+    const { scene, timerEvent } = makeScene();
+    const onDismiss = jest.fn();
+    new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      onDismiss
+    );
+
+    // Simulate dismiss button click
+    const allRects = (scene.add.rectangle.mock.results as { value: ReturnType<typeof makeRectangle> }[]);
+    const buttonRect = allRects
+      .map(r => r.value)
+      .find(rect => rect.setInteractive.mock.calls.length > 0);
+
+    if (!buttonRect) throw new Error('Button rect not found');
+
+    const pointerdownCall = (buttonRect.on.mock.calls as unknown[][]).find(
+      (call) => call[0] === 'pointerdown'
+    );
+    if (!pointerdownCall) throw new Error('pointerdown handler not found');
+
+    const fakePointer = { event: { stopPropagation: jest.fn() } };
+    (pointerdownCall[1] as (p: unknown) => void)(fakePointer);
+
+    // Timer should have been cleared
+    expect((timerEvent as unknown as { remove: jest.Mock }).remove).toHaveBeenCalledWith(false);
+  });
+
+  it('sets a high depth value to render above other game objects', () => {
+    const { scene } = makeScene();
+    const overlay = new EventCardOverlay(
+      scene as unknown as Phaser.Scene,
+      samplePayload,
+      jest.fn()
+    );
+
+    expect(overlay.depth).toBeGreaterThanOrEqual(100);
+  });
+});

--- a/src/client/__tests__/EventCard.test.ts
+++ b/src/client/__tests__/EventCard.test.ts
@@ -21,11 +21,13 @@ import {
 function makeText() {
   return {
     setOrigin: jest.fn().mockReturnThis(),
+    setPosition: jest.fn().mockReturnThis(),
     setStroke: jest.fn().mockReturnThis(),
     setVisible: jest.fn().mockReturnThis(),
     setDepth: jest.fn().mockReturnThis(),
     on: jest.fn().mockReturnThis(),
     destroy: jest.fn(),
+    height: 16,
   };
 }
 
@@ -48,7 +50,16 @@ function makeTimerEvent(): Phaser.Time.TimerEvent {
 }
 
 function makeCamera(width = 1280, height = 720) {
-  return { main: { width, height, scrollX: 0, scrollY: 0, zoom: 1 } };
+  return {
+    main: {
+      width,
+      height,
+      scrollX: 0,
+      scrollY: 0,
+      zoom: 1,
+      worldView: { x: 0, y: 0, width, height },
+    },
+  };
 }
 
 function makeScene(overrides: Record<string, unknown> = {}) {

--- a/src/client/__tests__/EventCard.test.ts
+++ b/src/client/__tests__/EventCard.test.ts
@@ -48,17 +48,25 @@ function makeTimerEvent(): Phaser.Time.TimerEvent {
 }
 
 function makeCamera(width = 1280, height = 720) {
-  return { main: { width, height } };
+  return { main: { width, height, scrollX: 0, scrollY: 0, zoom: 1 } };
 }
 
 function makeScene(overrides: Record<string, unknown> = {}) {
   const timerEvent = makeTimerEvent();
 
+  const mockContainer = {
+    setDepth: jest.fn().mockReturnThis(),
+    add: jest.fn().mockReturnThis(),
+    destroy: jest.fn(),
+    name: '',
+  };
+
   const scene = {
     add: {
-      rectangle: jest.fn().mockReturnValue(makeRectangle()),
-      text: jest.fn().mockReturnValue(makeText()),
+      rectangle: jest.fn().mockImplementation(() => makeRectangle()),
+      text: jest.fn().mockImplementation(() => makeText()),
       existing: jest.fn(),
+      container: jest.fn().mockReturnValue(mockContainer),
     },
     cameras: makeCamera(),
     time: {
@@ -101,6 +109,10 @@ jest.mock('phaser3-rex-plugins/plugins/containerlite.js', () => {
     }
 
     getChildren(): unknown[] {
+      return this.children;
+    }
+
+    getAllChildren(): unknown[] {
       return this.children;
     }
 
@@ -291,11 +303,12 @@ describe('EventCardOverlay component', () => {
       onDismiss
     );
 
-    // Find the button rectangle with a pointerdown listener
+    // Find the dismiss button rectangle (last interactive rect — first is backdrop)
     const allRects = (scene.add.rectangle.mock.results as { value: ReturnType<typeof makeRectangle> }[]);
-    const buttonRect = allRects
+    const interactiveRects = allRects
       .map(r => r.value)
-      .find(rect => rect.setInteractive.mock.calls.length > 0);
+      .filter(rect => rect.setInteractive.mock.calls.length > 0);
+    const buttonRect = interactiveRects[interactiveRects.length - 1];
 
     expect(buttonRect).toBeDefined();
     if (!buttonRect) return;
@@ -354,11 +367,12 @@ describe('EventCardOverlay component', () => {
       onDismiss
     );
 
-    // Simulate dismiss button click
+    // Find the dismiss button rectangle (last interactive rect — first is backdrop)
     const allRects = (scene.add.rectangle.mock.results as { value: ReturnType<typeof makeRectangle> }[]);
-    const buttonRect = allRects
+    const interactiveRects = allRects
       .map(r => r.value)
-      .find(rect => rect.setInteractive.mock.calls.length > 0);
+      .filter(rect => rect.setInteractive.mock.calls.length > 0);
+    const buttonRect = interactiveRects[interactiveRects.length - 1];
 
     if (!buttonRect) throw new Error('Button rect not found');
 
@@ -374,14 +388,17 @@ describe('EventCardOverlay component', () => {
     expect((timerEvent as unknown as { remove: jest.Mock }).remove).toHaveBeenCalledWith(false);
   });
 
-  it('sets a high depth value to render above other game objects', () => {
+  it('creates a root container with high depth to render above other game objects', () => {
     const { scene } = makeScene();
-    const overlay = new EventCardOverlay(
+    new EventCardOverlay(
       scene as unknown as Phaser.Scene,
       samplePayload,
       jest.fn()
     );
 
-    expect(overlay.depth).toBeGreaterThanOrEqual(100);
+    // The root container is created via scene.add.container and setDepth(1000)
+    expect(scene.add.container).toHaveBeenCalled();
+    const containerResult = (scene.add.container as jest.Mock).mock.results[0];
+    expect(containerResult.value.setDepth).toHaveBeenCalledWith(1000);
   });
 });

--- a/src/client/__tests__/MapHighlighter.test.ts
+++ b/src/client/__tests__/MapHighlighter.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for MapHighlighter.
+ *
+ * All Phaser objects are mocked so these tests run in Node/JSDOM without a canvas.
+ */
+import { MapHighlighter } from '../components/MapHighlighter';
+import { EventCardType } from '../../shared/types/EventCard';
+
+// ---------------------------------------------------------------------------
+// Phaser mock helpers
+// ---------------------------------------------------------------------------
+
+function makeTween() {
+  return {
+    stop: jest.fn(),
+    onComplete: null as null | (() => void),
+  };
+}
+
+function makeGraphics() {
+  return {
+    fillStyle: jest.fn().mockReturnThis(),
+    fillCircle: jest.fn().mockReturnThis(),
+    setAlpha: jest.fn().mockReturnThis(),
+    destroy: jest.fn(),
+    alpha: 1,
+  };
+}
+
+function makeTweenInstance(onComplete?: () => void) {
+  return { stop: jest.fn(), _onComplete: onComplete };
+}
+
+function makeScene() {
+  const tweenAdd = jest.fn().mockImplementation((config: {
+    onComplete?: () => void;
+    targets: unknown;
+    alpha: number;
+    duration: number;
+    ease: string;
+  }) => {
+    const t = makeTweenInstance(config.onComplete);
+    if (config.onComplete) {
+      // Simulate immediate completion for tests
+      config.onComplete();
+    }
+    return t;
+  });
+
+  const graphicsAdd = jest.fn().mockImplementation(() => makeGraphics());
+
+  return {
+    scene: {
+      add: {
+        graphics: graphicsAdd,
+      },
+      tweens: {
+        add: tweenAdd,
+      },
+    },
+    tweenAdd,
+    graphicsAdd,
+  };
+}
+
+function makeContainer() {
+  return {
+    add: jest.fn(),
+    remove: jest.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Zone fixtures
+// ---------------------------------------------------------------------------
+const zone1 = ['10,5', '10,6', '11,5'];
+const zone2 = ['20,10', '20,11'];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MapHighlighter', () => {
+  let highlighter: MapHighlighter;
+  let sceneFixture: ReturnType<typeof makeScene>;
+  let container: ReturnType<typeof makeContainer>;
+
+  beforeEach(() => {
+    sceneFixture = makeScene();
+    container = makeContainer();
+    highlighter = new MapHighlighter(
+      sceneFixture.scene as unknown as Phaser.Scene,
+      container as unknown as Phaser.GameObjects.Container
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── activate ──────────────────────────────────────────────────────────────
+
+  describe('activate', () => {
+    it('creates a Graphics object and adds it to the map container', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+
+      expect(sceneFixture.graphicsAdd).toHaveBeenCalledTimes(1);
+      expect(container.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('draws one circle per zone milepost', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+
+      const gfx = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+      expect(gfx.fillCircle).toHaveBeenCalledTimes(zone1.length);
+    });
+
+    it('uses red color for Derailment events', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+
+      const gfx = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+      const [color] = (gfx.fillStyle.mock.calls[0] as [number, number]);
+      expect(color).toBe(0xff0000);
+    });
+
+    it('uses blue color for Flood events', () => {
+      highlighter.activate(zone1, EventCardType.Flood, 126);
+
+      const gfx = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+      const [color] = (gfx.fillStyle.mock.calls[0] as [number, number]);
+      expect(color).toBe(0x0000ff);
+    });
+
+    it('uses white color for Snow events', () => {
+      highlighter.activate(zone1, EventCardType.Snow, 130);
+
+      const gfx = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+      const [color] = (gfx.fillStyle.mock.calls[0] as [number, number]);
+      expect(color).toBe(0xffffff);
+    });
+
+    it('uses gold color for Strike events', () => {
+      highlighter.activate(zone1, EventCardType.Strike, 121);
+
+      const gfx = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+      const [color] = (gfx.fillStyle.mock.calls[0] as [number, number]);
+      expect(color).toBe(0xffd700);
+    });
+
+    it('starts a fade-in tween from alpha 0', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+
+      const gfx = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+      expect(gfx.setAlpha).toHaveBeenCalledWith(0);
+      expect(sceneFixture.tweenAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ alpha: 0.3, duration: expect.any(Number) })
+      );
+    });
+
+    it('replaces an existing highlight for the same cardId', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      // First graphics object
+      const firstGfx = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+
+      highlighter.activate(zone2, EventCardType.Flood, 125);
+
+      // Old graphics should be destroyed immediately (skip fade on replace)
+      expect(firstGfx.destroy).toHaveBeenCalled();
+      // A second graphics object should now be active
+      expect(sceneFixture.graphicsAdd).toHaveBeenCalledTimes(2);
+    });
+
+    it('tracks the highlight as active after activation', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      expect(highlighter.hasHighlight(125)).toBe(true);
+    });
+
+    it('skips malformed zone keys without throwing', () => {
+      const badZone = ['invalid', '', '10,abc', '10,6'];
+      expect(() =>
+        highlighter.activate(badZone, EventCardType.Derailment, 125)
+      ).not.toThrow();
+    });
+  });
+
+  // ── deactivate ────────────────────────────────────────────────────────────
+
+  describe('deactivate', () => {
+    it('removes the highlight entry after deactivation', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      highlighter.deactivate(125);
+
+      expect(highlighter.hasHighlight(125)).toBe(false);
+    });
+
+    it('destroys the graphics object after the fade-out completes', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      const gfx = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+
+      highlighter.deactivate(125);
+
+      // Our mock scene immediately calls onComplete, so destroy should be called
+      expect(gfx.destroy).toHaveBeenCalled();
+    });
+
+    it('starts a fade-out tween targeting alpha 0', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      // Clear previous tween calls (fade-in)
+      sceneFixture.tweenAdd.mockClear();
+
+      highlighter.deactivate(125);
+
+      expect(sceneFixture.tweenAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ alpha: 0, duration: expect.any(Number) })
+      );
+    });
+
+    it('does nothing if no highlight exists for the given cardId', () => {
+      expect(() => highlighter.deactivate(999)).not.toThrow();
+    });
+
+    it('does not affect highlights for other card IDs', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      highlighter.activate(zone2, EventCardType.Flood, 126);
+
+      highlighter.deactivate(125);
+
+      expect(highlighter.hasHighlight(125)).toBe(false);
+      expect(highlighter.hasHighlight(126)).toBe(true);
+    });
+  });
+
+  // ── clear ─────────────────────────────────────────────────────────────────
+
+  describe('clear', () => {
+    it('removes all highlights', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      highlighter.activate(zone2, EventCardType.Flood, 126);
+
+      highlighter.clear();
+
+      expect(highlighter.hasHighlight(125)).toBe(false);
+      expect(highlighter.hasHighlight(126)).toBe(false);
+    });
+
+    it('destroys all graphics objects immediately', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      highlighter.activate(zone2, EventCardType.Flood, 126);
+
+      const gfx1 = sceneFixture.graphicsAdd.mock.results[0].value as ReturnType<typeof makeGraphics>;
+      const gfx2 = sceneFixture.graphicsAdd.mock.results[1].value as ReturnType<typeof makeGraphics>;
+
+      highlighter.clear();
+
+      expect(gfx1.destroy).toHaveBeenCalled();
+      expect(gfx2.destroy).toHaveBeenCalled();
+    });
+  });
+
+  // ── z-ordering ────────────────────────────────────────────────────────────
+
+  describe('z-ordering', () => {
+    it('adds the graphics object to the map container (not the root scene)', () => {
+      highlighter.activate(zone1, EventCardType.Derailment, 125);
+      // container.add should be called, not scene.add (beyond creating the graphics)
+      expect(container.add).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/client/components/EventCard.ts
+++ b/src/client/components/EventCard.ts
@@ -35,6 +35,7 @@ export class EventCard extends ContainerLite {
       .rectangle(0, 0, CARD_WIDTH, CARD_HEIGHT, 0x1a1a2e)
       .setOrigin(0.5)
       .setStrokeStyle(2, 0xf0a500);
+    bg.name = 'EventCard_bg';
     this.add(bg);
 
     // Header row: type icon + card ID
@@ -52,12 +53,14 @@ export class EventCard extends ContainerLite {
         }
       )
       .setOrigin(0, 0);
+    headerText.name = 'EventCard_header';
     this.add(headerText);
 
     // Horizontal divider beneath header
     const divider = scene.add
       .rectangle(0, -(CARD_HEIGHT / 2) + 36, CARD_WIDTH - 16, 1, 0xf0a500)
       .setOrigin(0.5, 0.5);
+    divider.name = 'EventCard_divider';
     this.add(divider);
 
     // Title
@@ -71,6 +74,7 @@ export class EventCard extends ContainerLite {
         wordWrap: { width: CARD_WIDTH - 24 },
       })
       .setOrigin(0.5, 0);
+    titleText.name = 'EventCard_title';
     this.add(titleText);
 
     // Description
@@ -83,6 +87,7 @@ export class EventCard extends ContainerLite {
         wordWrap: { width: CARD_WIDTH - 32 },
       })
       .setOrigin(0.5, 0);
+    descText.name = 'EventCard_description';
     this.add(descText);
   }
 }

--- a/src/client/components/EventCard.ts
+++ b/src/client/components/EventCard.ts
@@ -1,0 +1,88 @@
+import { Scene } from 'phaser';
+import ContainerLite from 'phaser3-rex-plugins/plugins/containerlite.js';
+import { EventCard as EventCardType, EventCardType as EventCardTypeEnum } from '../../shared/types/EventCard';
+import { UI_FONT_FAMILY } from '../config/uiFont';
+
+/** Visual dimensions of the event card panel */
+const CARD_WIDTH = 320;
+const CARD_HEIGHT = 300;
+
+/** Maps EventCardType enum values to display icons (emoji/text) */
+const EVENT_TYPE_ICONS: Record<EventCardTypeEnum, string> = {
+  [EventCardTypeEnum.Strike]: '🚫',
+  [EventCardTypeEnum.Derailment]: '⚠️',
+  [EventCardTypeEnum.Snow]: '❄️',
+  [EventCardTypeEnum.Flood]: '🌊',
+  [EventCardTypeEnum.ExcessProfitTax]: '💰',
+};
+
+/**
+ * Presentational Phaser component for displaying a single event card's details.
+ * Follows the ContainerLite pattern established by DemandCard.ts.
+ */
+export class EventCard extends ContainerLite {
+  constructor(scene: Scene, x: number, y: number, card: EventCardType) {
+    super(scene, x, y);
+    this.setSize(CARD_WIDTH, CARD_HEIGHT);
+    this.name = `event-card-${card.id}`;
+
+    this.buildLayout(scene, card);
+  }
+
+  private buildLayout(scene: Scene, card: EventCardType): void {
+    // Background panel
+    const bg = scene.add
+      .rectangle(0, 0, CARD_WIDTH, CARD_HEIGHT, 0x1a1a2e)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0xf0a500);
+    this.add(bg);
+
+    // Header row: type icon + card ID
+    const icon = EVENT_TYPE_ICONS[card.type] ?? '📋';
+    const headerText = scene.add
+      .text(
+        -(CARD_WIDTH / 2) + 16,
+        -(CARD_HEIGHT / 2) + 14,
+        `${icon}  EVENT CARD #${card.id}`,
+        {
+          fontSize: '13px',
+          color: '#f0a500',
+          fontFamily: UI_FONT_FAMILY,
+          fontStyle: 'bold',
+        }
+      )
+      .setOrigin(0, 0);
+    this.add(headerText);
+
+    // Horizontal divider beneath header
+    const divider = scene.add
+      .rectangle(0, -(CARD_HEIGHT / 2) + 36, CARD_WIDTH - 16, 1, 0xf0a500)
+      .setOrigin(0.5, 0.5);
+    this.add(divider);
+
+    // Title
+    const titleText = scene.add
+      .text(0, -(CARD_HEIGHT / 2) + 60, card.title.toUpperCase(), {
+        fontSize: '20px',
+        color: '#ffffff',
+        fontFamily: UI_FONT_FAMILY,
+        fontStyle: 'bold',
+        align: 'center',
+        wordWrap: { width: CARD_WIDTH - 24 },
+      })
+      .setOrigin(0.5, 0);
+    this.add(titleText);
+
+    // Description
+    const descText = scene.add
+      .text(0, -(CARD_HEIGHT / 2) + 100, card.description, {
+        fontSize: '13px',
+        color: '#cccccc',
+        fontFamily: UI_FONT_FAMILY,
+        align: 'center',
+        wordWrap: { width: CARD_WIDTH - 32 },
+      })
+      .setOrigin(0.5, 0);
+    this.add(descText);
+  }
+}

--- a/src/client/components/EventCardOverlay.ts
+++ b/src/client/components/EventCardOverlay.ts
@@ -1,56 +1,127 @@
 import { Scene } from 'phaser';
-import ContainerLite from 'phaser3-rex-plugins/plugins/containerlite.js';
-import { EventCardDrawnPayload } from '../../shared/types/EventCard';
-import { EventCard } from './EventCard';
+import { EventCardDrawnPayload, EventCardType as EventCardTypeEnum } from '../../shared/types/EventCard';
 import { UI_FONT_FAMILY } from '../config/uiFont';
 
 /** Auto-dismiss delay in milliseconds */
 const AUTO_DISMISS_DELAY_MS = 30_000;
 
-/** Vertical gap between the event card panel and the dismiss button */
-const BUTTON_GAP = 20;
 /** Dismiss button dimensions */
 const BUTTON_WIDTH = 200;
 const BUTTON_HEIGHT = 44;
+
+/** Card panel width */
+const CARD_WIDTH = 340;
+
+/** Internal padding */
+const PAD = 16;
+
+/** Maps EventCardType enum values to display icons */
+const EVENT_TYPE_ICONS: Record<EventCardTypeEnum, string> = {
+  [EventCardTypeEnum.Strike]: '🚫',
+  [EventCardTypeEnum.Derailment]: '⚠️',
+  [EventCardTypeEnum.Snow]: '❄️',
+  [EventCardTypeEnum.Flood]: '🌊',
+  [EventCardTypeEnum.ExcessProfitTax]: '💰',
+};
 
 /**
  * Full-screen modal overlay that displays an event card to all players.
  * Blocks all underlying game interaction while visible.
  * Auto-dismisses after 30 seconds if not manually dismissed.
  *
- * Follows the ContainerLite pattern from DemandCard.ts / EventCard.ts.
+ * All elements are built directly in a native Phaser Container positioned
+ * at the camera's worldView origin, matching the pattern used by PlayerHandScene
+ * modals.
  */
-export class EventCardOverlay extends ContainerLite {
+export class EventCardOverlay {
   private autoDismissTimer: Phaser.Time.TimerEvent | null = null;
   private readonly onDismiss: () => void;
+  private readonly root: Phaser.GameObjects.Container;
+  private readonly scene: Scene;
 
   constructor(
     scene: Scene,
     payload: EventCardDrawnPayload,
     onDismiss: () => void
   ) {
-    // Position at top-left; we fill the full camera viewport manually
-    super(scene, 0, 0);
+    this.scene = scene;
     this.onDismiss = onDismiss;
 
-    const { width, height } = scene.cameras.main;
+    const cam = scene.cameras.main;
+    const worldView = cam.worldView;
+    const viewW = worldView.width;
+    const viewH = worldView.height;
+    const originX = worldView.x;
+    const originY = worldView.y;
+
+    this.root = scene.add.container(originX, originY);
+    this.root.setDepth(1000);
+    this.root.name = 'EventCardOverlay';
+
+    const cx = viewW / 2;
 
     // ── Backdrop ──────────────────────────────────────────────────────────────
-    // Semi-transparent black rectangle covering the full viewport.
     const backdrop = scene.add
-      .rectangle(width / 2, height / 2, width, height, 0x000000, 0.72)
+      .rectangle(cx, viewH / 2, viewW, viewH, 0x000000, 0.72)
       .setOrigin(0.5)
-      .setInteractive(); // Swallow all pointer events beneath the overlay
-    this.add(backdrop);
+      .setInteractive();
+    backdrop.name = 'EventCardOverlay_backdrop';
+    backdrop.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      pointer.event?.stopPropagation();
+    });
+    this.root.add(backdrop);
 
-    // ── Event card panel ─────────────────────────────────────────────────────
-    const cardComponent = new EventCard(scene, width / 2, height / 2 - 30, payload.card);
-    scene.add.existing(cardComponent);
-    this.add(cardComponent);
+    // ── Build card content top-down, measuring as we go ─────────────────────
+    // We'll place elements relative to a running cursor `y`, then size the
+    // background to fit afterwards.
 
-    // ── Metadata text (drawer, duration, affected players) ──────────────────
-    const cardBottom = height / 2 - 30 + 150; // card center + half card height
+    const cardLeft = cx - CARD_WIDTH / 2;
+    let cursorY = 0; // relative to card top
 
+    // Header
+    const icon = EVENT_TYPE_ICONS[payload.card.type] ?? '📋';
+    const headerText = scene.add
+      .text(0, 0, `${icon}  EVENT CARD #${payload.card.id}`, {
+        fontSize: '13px',
+        color: '#f0a500',
+        fontFamily: UI_FONT_FAMILY,
+        fontStyle: 'bold',
+      })
+      .setOrigin(0, 0);
+    headerText.name = 'EventCard_header';
+    cursorY += PAD;
+
+    // Divider (placed after header)
+    const dividerY = cursorY + headerText.height + 8;
+
+    // Title
+    const titleText = scene.add
+      .text(0, 0, payload.card.title.toUpperCase(), {
+        fontSize: '20px',
+        color: '#ffffff',
+        fontFamily: UI_FONT_FAMILY,
+        fontStyle: 'bold',
+        align: 'center',
+        wordWrap: { width: CARD_WIDTH - PAD * 2 },
+      })
+      .setOrigin(0.5, 0);
+    titleText.name = 'EventCard_title';
+    const titleY = dividerY + 12;
+
+    // Description
+    const descText = scene.add
+      .text(0, 0, payload.card.description, {
+        fontSize: '13px',
+        color: '#cccccc',
+        fontFamily: UI_FONT_FAMILY,
+        align: 'center',
+        wordWrap: { width: CARD_WIDTH - PAD * 2 },
+      })
+      .setOrigin(0.5, 0);
+    descText.name = 'EventCard_description';
+    const descY = titleY + titleText.height + 12;
+
+    // Meta text
     const metaLines: string[] = [
       `Drawn by: ${payload.drawingPlayerName}`,
       `Duration: ${payload.duration === 'immediate' ? 'Immediate effect' : 'Until end of next turn'}`,
@@ -63,23 +134,80 @@ export class EventCardOverlay extends ContainerLite {
     }
 
     const metaText = scene.add
-      .text(width / 2, cardBottom + 12, metaLines.join('\n'), {
-        fontSize: '12px',
-        color: '#aaaaaa',
+      .text(0, 0, metaLines.join('\n'), {
+        fontSize: '11px',
+        color: '#999999',
         fontFamily: UI_FONT_FAMILY,
         align: 'center',
-        wordWrap: { width: 320 },
+        wordWrap: { width: CARD_WIDTH - PAD * 2 },
       })
       .setOrigin(0.5, 0);
-    this.add(metaText);
+    metaText.name = 'EventCardOverlay_meta';
+    const metaY = descY + descText.height + 16;
 
-    // ── Dismiss button ───────────────────────────────────────────────────────
-    const buttonY = cardBottom + 12 + 60 + BUTTON_GAP;
-    this.buildDismissButton(scene, width / 2, buttonY);
+    // Dismiss button
+    const buttonY = metaY + metaText.height + 16;
 
-    // ── Z-ordering: bring entire overlay to the top ──────────────────────────
-    // setDepth ensures this container renders above all other game objects.
-    this.setDepth(1000);
+    // Total card height
+    const cardHeight = buttonY + BUTTON_HEIGHT + PAD;
+
+    // ── Now position everything with the card centered on screen ────────────
+    const cardTop = (viewH - cardHeight) / 2;
+
+    // Card background
+    const cardBg = scene.add
+      .rectangle(cx, cardTop + cardHeight / 2, CARD_WIDTH, cardHeight, 0x1a1a2e)
+      .setOrigin(0.5)
+      .setStrokeStyle(2, 0xf0a500);
+    cardBg.name = 'EventCard_bg';
+    this.root.add(cardBg);
+
+    // Position all text elements
+    headerText.setPosition(cardLeft + PAD, cardTop + cursorY);
+    this.root.add(headerText);
+
+    const divider = scene.add
+      .rectangle(cx, cardTop + dividerY, CARD_WIDTH - PAD, 1, 0xf0a500)
+      .setOrigin(0.5, 0.5);
+    divider.name = 'EventCard_divider';
+    this.root.add(divider);
+
+    titleText.setPosition(cx, cardTop + titleY);
+    this.root.add(titleText);
+
+    descText.setPosition(cx, cardTop + descY);
+    this.root.add(descText);
+
+    metaText.setPosition(cx, cardTop + metaY);
+    this.root.add(metaText);
+
+    // Dismiss button
+    const btnAbsY = cardTop + buttonY + BUTTON_HEIGHT / 2;
+    const btnBg = scene.add
+      .rectangle(cx, btnAbsY, BUTTON_WIDTH, BUTTON_HEIGHT, 0xf0a500)
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+    btnBg.name = 'EventCardOverlay_btnBg';
+    this.root.add(btnBg);
+
+    const btnLabel = scene.add
+      .text(cx, btnAbsY, 'OK — Dismiss', {
+        fontSize: '15px',
+        color: '#1a1a2e',
+        fontFamily: UI_FONT_FAMILY,
+        fontStyle: 'bold',
+        align: 'center',
+      })
+      .setOrigin(0.5);
+    btnLabel.name = 'EventCardOverlay_btnLabel';
+    this.root.add(btnLabel);
+
+    btnBg.on('pointerover', () => btnBg.setFillStyle(0xffc200));
+    btnBg.on('pointerout', () => btnBg.setFillStyle(0xf0a500));
+    btnBg.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      pointer.event?.stopPropagation();
+      this.dismiss();
+    });
 
     // ── Auto-dismiss timer ───────────────────────────────────────────────────
     this.autoDismissTimer = scene.time.addEvent({
@@ -89,45 +217,10 @@ export class EventCardOverlay extends ContainerLite {
     });
   }
 
-  // ── Private helpers ──────────────────────────────────────────────────────
-
-  private buildDismissButton(scene: Scene, x: number, y: number): void {
-    // Button background
-    const btnBg = scene.add
-      .rectangle(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, 0xf0a500)
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true });
-    this.add(btnBg);
-
-    // Button label
-    const btnLabel = scene.add
-      .text(x, y, 'OK — Dismiss', {
-        fontSize: '15px',
-        color: '#1a1a2e',
-        fontFamily: UI_FONT_FAMILY,
-        fontStyle: 'bold',
-        align: 'center',
-      })
-      .setOrigin(0.5);
-    this.add(btnLabel);
-
-    // Hover effects
-    btnBg.on('pointerover', () => btnBg.setFillStyle(0xffc200));
-    btnBg.on('pointerout', () => btnBg.setFillStyle(0xf0a500));
-
-    // Click triggers dismissal
-    btnBg.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
-      pointer.event?.stopPropagation();
-      this.dismiss();
-    });
-  }
-
-  /** Clears the auto-dismiss timer and invokes the provided onDismiss callback. */
   private dismiss(): void {
     this.clearTimer();
     this.onDismiss();
-    // Destroy the overlay once dismissed so Phaser cleans up resources
-    this.destroy();
+    this.root.destroy(true);
   }
 
   private clearTimer(): void {
@@ -137,9 +230,12 @@ export class EventCardOverlay extends ContainerLite {
     }
   }
 
-  /** Call this if you need to manually cancel the overlay without triggering onDismiss. */
   public cancel(): void {
     this.clearTimer();
-    this.destroy();
+    this.root.destroy(true);
+  }
+
+  public destroy(): void {
+    this.cancel();
   }
 }

--- a/src/client/components/EventCardOverlay.ts
+++ b/src/client/components/EventCardOverlay.ts
@@ -1,0 +1,145 @@
+import { Scene } from 'phaser';
+import ContainerLite from 'phaser3-rex-plugins/plugins/containerlite.js';
+import { EventCardDrawnPayload } from '../../shared/types/EventCard';
+import { EventCard } from './EventCard';
+import { UI_FONT_FAMILY } from '../config/uiFont';
+
+/** Auto-dismiss delay in milliseconds */
+const AUTO_DISMISS_DELAY_MS = 30_000;
+
+/** Vertical gap between the event card panel and the dismiss button */
+const BUTTON_GAP = 20;
+/** Dismiss button dimensions */
+const BUTTON_WIDTH = 200;
+const BUTTON_HEIGHT = 44;
+
+/**
+ * Full-screen modal overlay that displays an event card to all players.
+ * Blocks all underlying game interaction while visible.
+ * Auto-dismisses after 30 seconds if not manually dismissed.
+ *
+ * Follows the ContainerLite pattern from DemandCard.ts / EventCard.ts.
+ */
+export class EventCardOverlay extends ContainerLite {
+  private autoDismissTimer: Phaser.Time.TimerEvent | null = null;
+  private readonly onDismiss: () => void;
+
+  constructor(
+    scene: Scene,
+    payload: EventCardDrawnPayload,
+    onDismiss: () => void
+  ) {
+    // Position at top-left; we fill the full camera viewport manually
+    super(scene, 0, 0);
+    this.onDismiss = onDismiss;
+
+    const { width, height } = scene.cameras.main;
+
+    // ── Backdrop ──────────────────────────────────────────────────────────────
+    // Semi-transparent black rectangle covering the full viewport.
+    const backdrop = scene.add
+      .rectangle(width / 2, height / 2, width, height, 0x000000, 0.72)
+      .setOrigin(0.5)
+      .setInteractive(); // Swallow all pointer events beneath the overlay
+    this.add(backdrop);
+
+    // ── Event card panel ─────────────────────────────────────────────────────
+    const cardComponent = new EventCard(scene, width / 2, height / 2 - 30, payload.card);
+    scene.add.existing(cardComponent);
+    this.add(cardComponent);
+
+    // ── Metadata text (drawer, duration, affected players) ──────────────────
+    const cardBottom = height / 2 - 30 + 150; // card center + half card height
+
+    const metaLines: string[] = [
+      `Drawn by: ${payload.drawingPlayerName}`,
+      `Duration: ${payload.duration === 'immediate' ? 'Immediate effect' : 'Until end of next turn'}`,
+    ];
+    if (payload.affectedPlayerIds.length > 0) {
+      metaLines.push(`Affected: ${payload.affectedPlayerIds.join(', ')}`);
+    }
+    if (payload.effectSummary) {
+      metaLines.push(payload.effectSummary);
+    }
+
+    const metaText = scene.add
+      .text(width / 2, cardBottom + 12, metaLines.join('\n'), {
+        fontSize: '12px',
+        color: '#aaaaaa',
+        fontFamily: UI_FONT_FAMILY,
+        align: 'center',
+        wordWrap: { width: 320 },
+      })
+      .setOrigin(0.5, 0);
+    this.add(metaText);
+
+    // ── Dismiss button ───────────────────────────────────────────────────────
+    const buttonY = cardBottom + 12 + 60 + BUTTON_GAP;
+    this.buildDismissButton(scene, width / 2, buttonY);
+
+    // ── Z-ordering: bring entire overlay to the top ──────────────────────────
+    // setDepth ensures this container renders above all other game objects.
+    this.setDepth(1000);
+
+    // ── Auto-dismiss timer ───────────────────────────────────────────────────
+    this.autoDismissTimer = scene.time.addEvent({
+      delay: AUTO_DISMISS_DELAY_MS,
+      callback: this.dismiss,
+      callbackScope: this,
+    });
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────
+
+  private buildDismissButton(scene: Scene, x: number, y: number): void {
+    // Button background
+    const btnBg = scene.add
+      .rectangle(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, 0xf0a500)
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+    this.add(btnBg);
+
+    // Button label
+    const btnLabel = scene.add
+      .text(x, y, 'OK — Dismiss', {
+        fontSize: '15px',
+        color: '#1a1a2e',
+        fontFamily: UI_FONT_FAMILY,
+        fontStyle: 'bold',
+        align: 'center',
+      })
+      .setOrigin(0.5);
+    this.add(btnLabel);
+
+    // Hover effects
+    btnBg.on('pointerover', () => btnBg.setFillStyle(0xffc200));
+    btnBg.on('pointerout', () => btnBg.setFillStyle(0xf0a500));
+
+    // Click triggers dismissal
+    btnBg.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      pointer.event?.stopPropagation();
+      this.dismiss();
+    });
+  }
+
+  /** Clears the auto-dismiss timer and invokes the provided onDismiss callback. */
+  private dismiss(): void {
+    this.clearTimer();
+    this.onDismiss();
+    // Destroy the overlay once dismissed so Phaser cleans up resources
+    this.destroy();
+  }
+
+  private clearTimer(): void {
+    if (this.autoDismissTimer) {
+      this.autoDismissTimer.remove(false);
+      this.autoDismissTimer = null;
+    }
+  }
+
+  /** Call this if you need to manually cancel the overlay without triggering onDismiss. */
+  public cancel(): void {
+    this.clearTimer();
+    this.destroy();
+  }
+}

--- a/src/client/components/MapHighlighter.ts
+++ b/src/client/components/MapHighlighter.ts
@@ -1,0 +1,196 @@
+import 'phaser';
+import { EventCardType } from '../../shared/types/EventCard';
+import {
+  HORIZONTAL_SPACING,
+  VERTICAL_SPACING,
+  GRID_MARGIN,
+} from '../config/mapConfig';
+
+/** Radius of each hex highlight circle in pixels */
+const HEX_RADIUS = 22;
+
+/** Fade-in/out duration in milliseconds */
+const FADE_DURATION_MS = 350;
+
+/** Alpha value for active highlights (semi-transparent fill) */
+const HIGHLIGHT_ALPHA = 0.3;
+
+/**
+ * ARGB color for each event card type.
+ * Stored as 24-bit RGB hex — alpha is applied separately via Graphics.fillStyle.
+ */
+const EVENT_TYPE_COLORS: Record<EventCardType, number> = {
+  [EventCardType.Derailment]: 0xff0000, // red
+  [EventCardType.Flood]: 0x0000ff,      // blue
+  [EventCardType.Snow]: 0xffffff,        // white
+  [EventCardType.Strike]: 0xffd700,     // yellow/gold
+  [EventCardType.ExcessProfitTax]: 0xff8c00, // orange (no map zone effect, but handled gracefully)
+};
+
+/**
+ * Parse a zone key ("row,col") into numeric row and column.
+ * Returns null if the key is malformed.
+ */
+function parseZoneKey(key: string): { row: number; col: number } | null {
+  const parts = key.split(',');
+  if (parts.length !== 2) return null;
+  const row = parseInt(parts[0], 10);
+  const col = parseInt(parts[1], 10);
+  if (isNaN(row) || isNaN(col)) return null;
+  return { row, col };
+}
+
+/**
+ * Convert grid (row, col) to world pixel coordinates within the map container.
+ * Mirrors the logic in mapConfig.ts / calculateWorldCoordinates.
+ */
+function gridToPixel(row: number, col: number): { x: number; y: number } {
+  const isOffsetRow = row % 2 === 1;
+  const x =
+    col * HORIZONTAL_SPACING +
+    GRID_MARGIN +
+    (isOffsetRow ? HORIZONTAL_SPACING / 2 : 0);
+  const y = row * VERTICAL_SPACING + GRID_MARGIN;
+  return { x, y };
+}
+
+/**
+ * Represents a single active highlight layer (one Graphics object per card).
+ */
+interface HighlightEntry {
+  cardId: number;
+  graphics: Phaser.GameObjects.Graphics;
+  tween: Phaser.Tweens.Tween | null;
+}
+
+/**
+ * MapHighlighter manages semi-transparent color-coded overlays on the hex map.
+ *
+ * Responsibilities:
+ * - Activate highlight polygons for a zone + event type, keyed by cardId
+ * - Deactivate highlights by cardId with fade-out
+ * - Z-ordered above tracks but below trains/UI (managed by the caller via container depth)
+ *
+ * This component uses one Graphics object per active card, avoiding full map re-renders.
+ */
+export class MapHighlighter {
+  private readonly scene: Phaser.Scene;
+  private readonly mapContainer: Phaser.GameObjects.Container;
+  /** Active highlight entries keyed by cardId */
+  private readonly highlights: Map<number, HighlightEntry> = new Map();
+
+  constructor(scene: Phaser.Scene, mapContainer: Phaser.GameObjects.Container) {
+    this.scene = scene;
+    this.mapContainer = mapContainer;
+  }
+
+  /**
+   * Draw semi-transparent, color-coded hex circles for all mileposts in `zone`.
+   * If a highlight for `cardId` already exists, it is replaced.
+   *
+   * @param zone     Array of milepost keys ("row,col")
+   * @param eventType Determines overlay color
+   * @param cardId   Unique identifier used to deactivate this overlay later
+   */
+  public activate(zone: string[], eventType: EventCardType, cardId: number): void {
+    // Replace any existing highlight for this card
+    if (this.highlights.has(cardId)) {
+      this.removeEntry(cardId, /* skipFade */ true);
+    }
+
+    const color = EVENT_TYPE_COLORS[eventType] ?? 0xffffff;
+    const graphics = this.scene.add.graphics();
+
+    this.drawZone(graphics, zone, color);
+
+    // Add to the map container above background/tracks (z-order managed externally)
+    this.mapContainer.add(graphics);
+
+    // Fade in from transparent
+    graphics.setAlpha(0);
+    const tween = this.scene.tweens.add({
+      targets: graphics,
+      alpha: HIGHLIGHT_ALPHA,
+      duration: FADE_DURATION_MS,
+      ease: 'Linear',
+    });
+
+    this.highlights.set(cardId, { cardId, graphics, tween });
+  }
+
+  /**
+   * Fade out and remove the highlight overlay for the given `cardId`.
+   * Does nothing if no highlight exists for that card.
+   */
+  public deactivate(cardId: number): void {
+    const entry = this.highlights.get(cardId);
+    if (!entry) return;
+
+    // Stop any in-progress fade-in tween
+    entry.tween?.stop();
+    entry.tween = null;
+
+    const { graphics } = entry;
+
+    // Fade out, then destroy
+    this.scene.tweens.add({
+      targets: graphics,
+      alpha: 0,
+      duration: FADE_DURATION_MS,
+      ease: 'Linear',
+      onComplete: () => {
+        graphics.destroy();
+      },
+    });
+
+    this.highlights.delete(cardId);
+  }
+
+  /**
+   * Remove all active highlights immediately (no fade).
+   * Useful for scene teardown.
+   */
+  public clear(): void {
+    for (const cardId of Array.from(this.highlights.keys())) {
+      this.removeEntry(cardId, /* skipFade */ true);
+    }
+  }
+
+  /** Returns true if there is an active highlight for the given cardId. */
+  public hasHighlight(cardId: number): boolean {
+    return this.highlights.has(cardId);
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private drawZone(
+    graphics: Phaser.GameObjects.Graphics,
+    zone: string[],
+    color: number
+  ): void {
+    graphics.fillStyle(color, HIGHLIGHT_ALPHA);
+
+    for (const key of zone) {
+      const coords = parseZoneKey(key);
+      if (!coords) continue;
+
+      const { x, y } = gridToPixel(coords.row, coords.col);
+      // Draw a circle approximating the hex milepost footprint
+      graphics.fillCircle(x, y, HEX_RADIUS);
+    }
+  }
+
+  /** Immediately remove an entry (with optional tween stop). */
+  private removeEntry(cardId: number, skipFade: boolean): void {
+    const entry = this.highlights.get(cardId);
+    if (!entry) return;
+
+    entry.tween?.stop();
+
+    if (skipFade) {
+      entry.graphics.destroy();
+    }
+
+    this.highlights.delete(cardId);
+  }
+}

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -681,6 +681,19 @@ export class GameScene extends Phaser.Scene {
         this.socketUnsubWhisperTurnHistory?.();
         this.socketUnsubAutoRunStatus?.();
 
+        // Wire event card socket listeners → Zustand store
+        // (The store's own connect() is not called from GameScene, so we must
+        // register these here so the overlay/highlight subscriptions fire.)
+        svc.onEventCardDrawn((payload) => {
+          useGameStore.getState().showEventOverlay(payload);
+        });
+        svc.onEventEffectExpired((payload) => {
+          useGameStore.getState().removeActiveEffect(payload.cardId);
+        });
+        svc.onActiveEffects((effects) => {
+          useGameStore.getState().setActiveEffects(effects);
+        });
+
         // F9 key listener — toggle auto-run
         this.input.keyboard?.on('keydown-F9', () => {
           svc.emitAutoRunToggle(this.gameState.id);
@@ -1458,13 +1471,14 @@ export class GameScene extends Phaser.Scene {
       if (overlay === prevOverlay) return;
 
       if (overlay && !prevOverlay) {
-        // New overlay — show EventCardOverlay and activate map highlighting
+        // New overlay — show EventCardOverlay and activate map highlighting.
+        // EventCardOverlay positions itself at the camera's scroll offset
+        // so it appears centered on screen (same pattern as PlayerHandScene modals).
         this.eventCardOverlay = new EventCardOverlay(
           this,
           overlay,
           () => useGameStore.getState().dismissEventOverlay(),
         );
-        this.add.existing(this.eventCardOverlay);
 
         // Activate map highlights for the affected zone (regardless of affectedPlayerIds)
         if (overlay.affectedZone.length > 0 && this.mapHighlighter) {
@@ -1473,6 +1487,7 @@ export class GameScene extends Phaser.Scene {
         }
       } else if (!overlay && prevOverlay) {
         // Overlay dismissed — destroy it (MapHighlighter stays active until effect expires)
+        this.eventCardOverlay?.destroy();
         this.eventCardOverlay = undefined;
       }
 

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -18,8 +18,12 @@ import { BotTrainAnimator } from "../components/BotTrainAnimator";
 import { GameToastManager } from "../components/GameToastManager";
 import { WhisperPanel, WhisperTurnEntry } from "../components/WhisperPanel";
 import { AutoRunBadge } from "../components/AutoRunBadge";
+import { MapHighlighter } from "../components/MapHighlighter";
+import { EventCardOverlay } from "../components/EventCardOverlay";
 import { UI_FONT_FAMILY } from "../config/uiFont";
 import { MAP_BACKGROUND_CALIBRATION, MAP_BOARD_CALIBRATION } from "../config/mapConfig";
+import { useGameStore } from "../lobby/store/game.store";
+import { EventCardType } from "../../shared/types/EventCard";
 
 // Add type declaration for Phaser.Scene
 declare module "phaser" {
@@ -63,6 +67,12 @@ export class GameScene extends Phaser.Scene {
   private socketUnsubAutoRunStatus?: () => void;
   private llmTranscriptOverlay?: LLMTranscriptOverlay;
   private socketUnsubLLMTranscript?: () => void;
+
+  // Event card UI components
+  private mapHighlighter?: MapHighlighter;
+  private eventCardOverlay?: EventCardOverlay;
+  private unsubEventOverlay?: () => void;
+  private unsubActiveEffects?: () => void;
 
   // Game state
   public gameState: FullGameState; // Keep public for compatibility with SettingsScene
@@ -654,6 +664,11 @@ export class GameScene extends Phaser.Scene {
 
     // Auto-run badge (hidden by default)
     this.autoRunBadge = new AutoRunBadge(this);
+
+    // Event card overlay & map highlighting
+    this.mapHighlighter = new MapHighlighter(this, this.mapContainer);
+    this.setupEventOverlaySubscription();
+    this.setupActiveEffectsSubscription();
 
     try {
       const { socketService: svc } = await import('../lobby/shared/socket');
@@ -1431,6 +1446,63 @@ export class GameScene extends Phaser.Scene {
     return player?.name ?? 'Unknown Player';
   }
 
+  /**
+   * Subscribe to pendingEventOverlay store state.
+   * Shows/hides EventCardOverlay and activates MapHighlighter when an event card is drawn.
+   */
+  private setupEventOverlaySubscription(): void {
+    let prevOverlay = useGameStore.getState().pendingEventOverlay;
+
+    this.unsubEventOverlay = useGameStore.subscribe((state) => {
+      const overlay = state.pendingEventOverlay;
+      if (overlay === prevOverlay) return;
+
+      if (overlay && !prevOverlay) {
+        // New overlay — show EventCardOverlay and activate map highlighting
+        this.eventCardOverlay = new EventCardOverlay(
+          this,
+          overlay,
+          () => useGameStore.getState().dismissEventOverlay(),
+        );
+        this.add.existing(this.eventCardOverlay);
+
+        // Activate map highlights for the affected zone (regardless of affectedPlayerIds)
+        if (overlay.affectedZone.length > 0 && this.mapHighlighter) {
+          const eventType = overlay.card.type as EventCardType;
+          this.mapHighlighter.activate(overlay.affectedZone, eventType, overlay.card.id);
+        }
+      } else if (!overlay && prevOverlay) {
+        // Overlay dismissed — destroy it (MapHighlighter stays active until effect expires)
+        this.eventCardOverlay = undefined;
+      }
+
+      prevOverlay = overlay;
+    });
+  }
+
+  /**
+   * Subscribe to activeEffects store state.
+   * Deactivates MapHighlighter zones when effects expire.
+   */
+  private setupActiveEffectsSubscription(): void {
+    let previousCardIds = new Set(
+      useGameStore.getState().activeEffects.map(e => e.cardId)
+    );
+
+    this.unsubActiveEffects = useGameStore.subscribe((state) => {
+      const currentCardIds = new Set(state.activeEffects.map(e => e.cardId));
+
+      // Find removed effects and deactivate their highlights
+      for (const cardId of previousCardIds) {
+        if (!currentCardIds.has(cardId) && this.mapHighlighter) {
+          this.mapHighlighter.deactivate(cardId);
+        }
+      }
+
+      previousCardIds = currentCardIds;
+    });
+  }
+
   // Clean up resources when scene is destroyed
   destroy(fromScene?: boolean): void {
     // Stop polling for turn changes
@@ -1486,6 +1558,15 @@ export class GameScene extends Phaser.Scene {
     this.socketUnsubAutoRunStatus?.();
     this.socketUnsubAutoRunStatus = undefined;
     this.autoRunBadge?.destroy();
+
+    // Clean up event card UI subscriptions and components
+    this.unsubEventOverlay?.();
+    this.unsubEventOverlay = undefined;
+    this.unsubActiveEffects?.();
+    this.unsubActiveEffects = undefined;
+    this.mapHighlighter?.clear();
+    this.mapHighlighter = undefined;
+    this.eventCardOverlay = undefined;
   }
 
   /**

--- a/src/client/scenes/GameScene.ts
+++ b/src/client/scenes/GameScene.ts
@@ -23,7 +23,7 @@ import { EventCardOverlay } from "../components/EventCardOverlay";
 import { UI_FONT_FAMILY } from "../config/uiFont";
 import { MAP_BACKGROUND_CALIBRATION, MAP_BOARD_CALIBRATION } from "../config/mapConfig";
 import { useGameStore } from "../lobby/store/game.store";
-import { EventCardType } from "../../shared/types/EventCard";
+import { EventCardDrawnPayload, EventCardType } from "../../shared/types/EventCard";
 
 // Add type declaration for Phaser.Scene
 declare module "phaser" {
@@ -1472,19 +1472,11 @@ export class GameScene extends Phaser.Scene {
 
       if (overlay && !prevOverlay) {
         // New overlay — show EventCardOverlay and activate map highlighting.
-        // EventCardOverlay positions itself at the camera's scroll offset
-        // so it appears centered on screen (same pattern as PlayerHandScene modals).
-        this.eventCardOverlay = new EventCardOverlay(
-          this,
-          overlay,
-          () => useGameStore.getState().dismissEventOverlay(),
-        );
-
-        // Activate map highlights for the affected zone (regardless of affectedPlayerIds)
-        if (overlay.affectedZone.length > 0 && this.mapHighlighter) {
-          const eventType = overlay.card.type as EventCardType;
-          this.mapHighlighter.activate(overlay.affectedZone, eventType, overlay.card.id);
-        }
+        this.showEventOverlay(overlay);
+      } else if (overlay && prevOverlay) {
+        // Another card arrived before the first was dismissed — replace it.
+        this.eventCardOverlay?.destroy();
+        this.showEventOverlay(overlay);
       } else if (!overlay && prevOverlay) {
         // Overlay dismissed — destroy it (MapHighlighter stays active until effect expires)
         this.eventCardOverlay?.destroy();
@@ -1495,9 +1487,24 @@ export class GameScene extends Phaser.Scene {
     });
   }
 
+  /** Create and display an EventCardOverlay, activating map highlights if applicable. */
+  private showEventOverlay(overlay: EventCardDrawnPayload): void {
+    this.eventCardOverlay = new EventCardOverlay(
+      this,
+      overlay,
+      () => useGameStore.getState().dismissEventOverlay(),
+    );
+
+    if (overlay.affectedZone.length > 0 && this.mapHighlighter) {
+      const eventType = overlay.card.type as EventCardType;
+      this.mapHighlighter.activate(overlay.affectedZone, eventType, overlay.card.id);
+    }
+  }
+
   /**
    * Subscribe to activeEffects store state.
-   * Deactivates MapHighlighter zones when effects expire.
+   * Activates MapHighlighter zones for newly added effects (e.g. on reconnect)
+   * and deactivates zones when effects expire.
    */
   private setupActiveEffectsSubscription(): void {
     let previousCardIds = new Set(
@@ -1507,7 +1514,14 @@ export class GameScene extends Phaser.Scene {
     this.unsubActiveEffects = useGameStore.subscribe((state) => {
       const currentCardIds = new Set(state.activeEffects.map(e => e.cardId));
 
-      // Find removed effects and deactivate their highlights
+      // Activate highlights for newly added effects (e.g. restored on reconnect)
+      for (const effect of state.activeEffects) {
+        if (!previousCardIds.has(effect.cardId) && this.mapHighlighter && effect.affectedZone.length > 0) {
+          this.mapHighlighter.activate(effect.affectedZone, effect.cardType as EventCardType, effect.cardId);
+        }
+      }
+
+      // Deactivate highlights for removed effects
       for (const cardId of previousCardIds) {
         if (!currentCardIds.has(cardId) && this.mapHighlighter) {
           this.mapHighlighter.deactivate(cardId);


### PR DESCRIPTION
## Summary
- Add EventCard and EventCardOverlay Phaser components for displaying event cards to all players
- Add MapHighlighter component for color-coded event zone overlays on the game map
- Wire event card socket listeners (card drawn, effect expired, active effects) directly in GameScene
- Fix EventCardOverlay positioning to use camera.worldView for correct rendering in scrolled/zoomed scenes
- Auto-sizing card layout and 30-second auto-dismiss timer

## Test plan
- [x] EventCard component unit tests (6 tests)
- [x] EventCardOverlay component unit tests (9 tests)
- [x] MapHighlighter component unit tests (13 tests)
- [ ] Manual: trigger event card via API, verify overlay appears centered on screen
- [ ] Manual: verify dismiss button and auto-dismiss timer work correctly
- [ ] Manual: verify map zone highlighting appears for affected areas

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds a complete event card UI system for the EuroRails multiplayer game, consisting of EventCard and EventCardOverlay Phaser components for displaying event cards with a modal overlay, a MapHighlighter component for color-coded zone overlays on the hex map, and socket wiring in GameScene to drive these components from the Zustand game store state. The overlay correctly positions itself using camera.worldView for proper rendering in scrolled/zoomed game views, and includes a 30-second auto-dismiss timer with manual dismiss button.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces EventCardOverlay as a full-screen modal (depth 1000) with camera.worldView positioning, auto-sizing layout, backdrop blocking, and a 30-second auto-dismiss timer that can be manually dismissed via button (with hover states) — in EventCardOverlay.ts.</li>

<li>Adds MapHighlighter component using one Graphics object per active card with fade-in/out tweens, color-coded by EventCardType (Derailment=red, Flood=blue, Snow=white, Strike=gold, ExcessProfitTax=orange) — in MapHighlighter.ts.</li>

<li>Wires three socket event listeners in GameScene (onEventCardDrawn, onEventEffectExpired, onActiveEffects) that feed into Zustand store actions to show/dismiss the overlay and activate/deactivate map highlights — in GameScene.ts.</li>

<li>Adds two test files covering 28 unit tests (6 for EventCard, 9 for EventCardOverlay, 13 for MapHighlighter) using mocked Phaser objects and verifying component creation, positioning, timer behavior, color mapping, and store-driven state transitions.</li>

<li>Adds EventCard presentational component as a ContainerLite with 320×300px dark panel (#1a1a2e) and gold border (#f0a500), rendering type icon, card ID, uppercase title, and description text — in EventCard.ts.</li>

</ul>
</details>

</div>