### PR TITLE
feat(fe-004): active effects HUD in player hand panel

### DIFF
--- a/src/client/__tests__/ActiveEffectHUD.test.ts
+++ b/src/client/__tests__/ActiveEffectHUD.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Unit tests for ActiveEffectHUD Phaser component.
+ *
+ * Phaser objects cannot be instantiated in Node/JSDOM, so we mock the scene
+ * and verify the correct text content and sizer calls are made.
+ */
+
+import { ActiveEffectHUD } from '../components/ActiveEffectHUD';
+import { ActiveEffectSummary } from '../../shared/types/EventCard';
+import { EventCardType } from '../../shared/types/EventCard';
+
+// ---------------------------------------------------------------------------
+// Scene mock factory
+// ---------------------------------------------------------------------------
+
+interface MockText {
+  text: string;
+  name: string;
+  setName: jest.Mock;
+  setOrigin: jest.Mock;
+  setVisible: jest.Mock;
+  destroy: jest.Mock;
+}
+
+function makeText(content = ''): MockText {
+  const obj: MockText = {
+    text: content,
+    name: '',
+    setName: jest.fn().mockImplementation((n: string) => {
+      obj.name = n;
+      return obj;
+    }),
+    setOrigin: jest.fn().mockReturnThis(),
+    setVisible: jest.fn().mockReturnThis(),
+    destroy: jest.fn(),
+  };
+  return obj;
+}
+
+interface MockSizer {
+  name: string;
+  setName: jest.Mock;
+  add: jest.Mock;
+  clear: jest.Mock;
+  destroy: jest.Mock;
+  _items: unknown[];
+}
+
+function makeSizer(): MockSizer {
+  const addedItems: unknown[] = [];
+  const obj: MockSizer = {
+    name: '',
+    setName: jest.fn().mockImplementation((n: string) => {
+      obj.name = n;
+      return obj;
+    }),
+    add: jest.fn().mockImplementation((item: unknown) => {
+      addedItems.push(item);
+      return obj;
+    }),
+    clear: jest.fn(),
+    destroy: jest.fn(),
+    _items: addedItems,
+  };
+  return obj;
+}
+
+function makeScene() {
+  const textObjects: ReturnType<typeof makeText>[] = [];
+  const sizerObject = makeSizer();
+
+  const scene = {
+    add: {
+      text: jest.fn().mockImplementation((_x: number, _y: number, content: string) => {
+        const t = makeText(content);
+        textObjects.push(t);
+        return t;
+      }),
+    },
+    rexUI: {
+      add: {
+        sizer: jest.fn().mockImplementation(() => sizerObject),
+      },
+    },
+    _textObjects: textObjects,
+    _sizer: sizerObject,
+  };
+
+  return scene;
+}
+
+// ---------------------------------------------------------------------------
+// Sample fixtures
+// ---------------------------------------------------------------------------
+
+function makeEffect(overrides: Partial<ActiveEffectSummary> = {}): ActiveEffectSummary {
+  return {
+    cardId: 130,
+    cardType: EventCardType.Snow,
+    drawingPlayerId: 'player-1',
+    drawingPlayerName: 'Alice',
+    expiresAfterTurnNumber: 5,
+    affectedZone: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ActiveEffectHUD', () => {
+  let scene: ReturnType<typeof makeScene>;
+  let hud: ActiveEffectHUD;
+
+  beforeEach(() => {
+    scene = makeScene();
+    hud = new ActiveEffectHUD(scene as unknown as Phaser.Scene);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getSizer', () => {
+    it('returns the rexUI sizer for parent integration', () => {
+      const sizer = hud.getSizer();
+      expect(sizer).toBeDefined();
+      expect(sizer).toBe(scene._sizer);
+    });
+
+    it('sizer is named active-effects-hud-sizer', () => {
+      hud.getSizer();
+      expect(scene.rexUI.add.sizer).toHaveBeenCalledWith(
+        expect.objectContaining({ orientation: 'y' })
+      );
+    });
+  });
+
+  describe('updateEffects — empty state', () => {
+    it('renders empty state text when no effects are provided', () => {
+      hud.updateEffects([]);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('No active effects'))).toBe(true);
+    });
+
+    it('names the empty state text object correctly', () => {
+      hud.updateEffects([]);
+      const emptyText = scene._textObjects.find((t) =>
+        t.text.includes('No active effects')
+      );
+      expect(emptyText).toBeDefined();
+      expect(emptyText!.name).toBe('active-effects-empty');
+    });
+
+    it('adds the empty state text to the sizer', () => {
+      hud.updateEffects([]);
+      expect(scene._sizer.add).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateEffects — single effect', () => {
+    it('renders snow icon for Snow effect', () => {
+      hud.updateEffects([makeEffect({ cardType: EventCardType.Snow })]);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('❄️'))).toBe(true);
+    });
+
+    it('renders flood icon for Flood effect', () => {
+      hud.updateEffects([makeEffect({ cardType: EventCardType.Flood, cardId: 133 })]);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('🌊'))).toBe(true);
+    });
+
+    it('renders strike icon for Strike effect', () => {
+      hud.updateEffects([makeEffect({ cardType: EventCardType.Strike, cardId: 121 })]);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('🚫'))).toBe(true);
+    });
+
+    it('renders derailment icon for Derailment effect', () => {
+      hud.updateEffects([makeEffect({ cardType: EventCardType.Derailment, cardId: 125 })]);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('⚠️'))).toBe(true);
+    });
+
+    it('renders the effect type label', () => {
+      hud.updateEffects([makeEffect({ cardType: EventCardType.Snow })]);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('Snow'))).toBe(true);
+    });
+
+    it('names the row text with card ID', () => {
+      hud.updateEffects([makeEffect({ cardId: 130 })]);
+      const rowText = scene._textObjects.find((t) =>
+        t.name === 'active-effect-row-130'
+      );
+      expect(rowText).toBeDefined();
+    });
+
+    it('adds the effect row to the sizer', () => {
+      hud.updateEffects([makeEffect()]);
+      expect(scene._sizer.add).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateEffects — duration formatting', () => {
+    it('shows "active" when no current turn number provided', () => {
+      hud.updateEffects([makeEffect({ expiresAfterTurnNumber: 5 })]);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('active'))).toBe(true);
+    });
+
+    it('shows "1 turn" when one turn remains', () => {
+      hud.updateEffects([makeEffect({ expiresAfterTurnNumber: 5 })], 4);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('1 turn'))).toBe(true);
+    });
+
+    it('shows "2 turns" when two turns remain', () => {
+      hud.updateEffects([makeEffect({ expiresAfterTurnNumber: 5 })], 3);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('2 turns'))).toBe(true);
+    });
+
+    it('shows "expiring" when turns left is zero or negative', () => {
+      hud.updateEffects([makeEffect({ expiresAfterTurnNumber: 3 })], 4);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('expiring'))).toBe(true);
+    });
+  });
+
+  describe('updateEffects — multiple effects', () => {
+    it('renders multiple effect rows', () => {
+      const effects = [
+        makeEffect({ cardId: 130, cardType: EventCardType.Snow }),
+        makeEffect({ cardId: 133, cardType: EventCardType.Flood }),
+      ];
+      hud.updateEffects(effects);
+      // Two rows should be created
+      const rowTexts = scene._textObjects.filter(
+        (t) => t.name.startsWith('active-effect-row-')
+      );
+      expect(rowTexts).toHaveLength(2);
+    });
+
+    it('renders both icons when two effects are active', () => {
+      const effects = [
+        makeEffect({ cardId: 130, cardType: EventCardType.Snow }),
+        makeEffect({ cardId: 121, cardType: EventCardType.Strike }),
+      ];
+      hud.updateEffects(effects);
+      const textContent = scene._textObjects.map((t) => t.text);
+      expect(textContent.some((t) => t.includes('❄️'))).toBe(true);
+      expect(textContent.some((t) => t.includes('🚫'))).toBe(true);
+    });
+
+    it('adds all rows to the sizer', () => {
+      const effects = [
+        makeEffect({ cardId: 130, cardType: EventCardType.Snow }),
+        makeEffect({ cardId: 133, cardType: EventCardType.Flood }),
+        makeEffect({ cardId: 121, cardType: EventCardType.Strike }),
+      ];
+      hud.updateEffects(effects);
+      // sizer.add called once per effect row
+      expect(scene._sizer.add).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('updateEffects — reactive updates (replace)', () => {
+    it('clears sizer when re-rendering from populated to empty', () => {
+      hud.updateEffects([makeEffect()]);
+      hud.updateEffects([]);
+      // sizer.clear should have been called on the second update
+      expect(scene._sizer.clear).toHaveBeenCalled();
+    });
+
+    it('destroys old row text objects when updating', () => {
+      hud.updateEffects([makeEffect({ cardId: 130 })]);
+      const firstRowText = scene._textObjects.find(
+        (t) => t.name === 'active-effect-row-130'
+      );
+      expect(firstRowText).toBeDefined();
+      // Second update replaces the content
+      hud.updateEffects([makeEffect({ cardId: 131, cardType: EventCardType.Flood })]);
+      expect(firstRowText!.destroy).toHaveBeenCalled();
+    });
+
+    it('renders new effects after update', () => {
+      hud.updateEffects([makeEffect({ cardId: 130, cardType: EventCardType.Snow })]);
+      hud.updateEffects([makeEffect({ cardId: 121, cardType: EventCardType.Strike })]);
+      const lastRowText = scene._textObjects.find(
+        (t) => t.name === 'active-effect-row-121'
+      );
+      expect(lastRowText).toBeDefined();
+    });
+  });
+
+  describe('destroy', () => {
+    it('destroys all effect row text objects', () => {
+      hud.updateEffects([makeEffect({ cardId: 130 })]);
+      const rowText = scene._textObjects.find((t) => t.name === 'active-effect-row-130');
+      hud.destroy();
+      expect(rowText!.destroy).toHaveBeenCalled();
+    });
+
+    it('clears and destroys the sizer', () => {
+      hud.destroy();
+      expect(scene._sizer.clear).toHaveBeenCalled();
+      expect(scene._sizer.destroy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/client/__tests__/ActiveEffectHUD.test.ts
+++ b/src/client/__tests__/ActiveEffectHUD.test.ts
@@ -39,7 +39,9 @@ function makeText(content = ''): MockText {
 
 interface MockSizer {
   name: string;
+  visible: boolean;
   setName: jest.Mock;
+  setVisible: jest.Mock;
   add: jest.Mock;
   clear: jest.Mock;
   destroy: jest.Mock;
@@ -50,12 +52,17 @@ function makeSizer(): MockSizer {
   const addedItems: unknown[] = [];
   const obj: MockSizer = {
     name: '',
+    visible: true,
     setName: jest.fn().mockImplementation((n: string) => {
       obj.name = n;
       return obj;
     }),
     add: jest.fn().mockImplementation((item: unknown) => {
       addedItems.push(item);
+      return obj;
+    }),
+    setVisible: jest.fn().mockImplementation((v: boolean) => {
+      obj.visible = v;
       return obj;
     }),
     clear: jest.fn(),
@@ -138,24 +145,25 @@ describe('ActiveEffectHUD', () => {
   });
 
   describe('updateEffects — empty state', () => {
-    it('renders empty state text when no effects are provided', () => {
+    it('hides the sizer when no effects are provided', () => {
       hud.updateEffects([]);
-      const textContent = scene._textObjects.map((t) => t.text);
-      expect(textContent.some((t) => t.includes('No active effects'))).toBe(true);
+      expect(scene._sizer.setVisible).toHaveBeenCalledWith(false);
     });
 
-    it('names the empty state text object correctly', () => {
+    it('does not create any text objects when empty', () => {
       hud.updateEffects([]);
-      const emptyText = scene._textObjects.find((t) =>
-        t.text.includes('No active effects')
-      );
-      expect(emptyText).toBeDefined();
-      expect(emptyText!.name).toBe('active-effects-empty');
+      expect(scene._textObjects).toHaveLength(0);
     });
 
-    it('adds the empty state text to the sizer', () => {
+    it('does not add any items to the sizer when empty', () => {
       hud.updateEffects([]);
-      expect(scene._sizer.add).toHaveBeenCalled();
+      expect(scene._sizer.add).not.toHaveBeenCalled();
+    });
+
+    it('shows the sizer again when effects are added after empty', () => {
+      hud.updateEffects([]);
+      hud.updateEffects([makeEffect()]);
+      expect(scene._sizer.setVisible).toHaveBeenCalledWith(true);
     });
   });
 

--- a/src/client/components/ActiveEffectHUD.ts
+++ b/src/client/components/ActiveEffectHUD.ts
@@ -68,22 +68,12 @@ export class ActiveEffectHUD {
     this.sizer.clear(true);
 
     if (effects.length === 0) {
-      // Empty state: render a placeholder text
-      const emptyText = this.scene.add.text(0, 0, 'No active effects', {
-        color: '#888888',
-        fontSize: EFFECT_FONT_SIZE,
-        fontFamily: UI_FONT_FAMILY,
-        fontStyle: 'italic',
-      });
-      emptyText.setName('active-effects-empty');
-      this.sizer.add(emptyText, {
-        proportion: 0,
-        align: 'left',
-        expand: false,
-      });
-      this.effectRows.push(emptyText);
+      // Hide entirely when no active effects
+      this.sizer.setVisible(false);
       return;
     }
+
+    this.sizer.setVisible(true);
 
     for (const effect of effects) {
       const row = this.createEffectRow(effect, currentTurnNumber);

--- a/src/client/components/ActiveEffectHUD.ts
+++ b/src/client/components/ActiveEffectHUD.ts
@@ -1,0 +1,147 @@
+import { Scene } from 'phaser';
+import { ActiveEffectSummary } from '../../shared/types/EventCard';
+import { EventCardType } from '../../shared/types/EventCard';
+import { UI_FONT_FAMILY } from '../config/uiFont';
+
+/** Maps EventCardType string values to display icons */
+const EVENT_TYPE_ICONS: Record<string, string> = {
+  [EventCardType.Strike]: '🚫',
+  [EventCardType.Derailment]: '⚠️',
+  [EventCardType.Snow]: '❄️',
+  [EventCardType.Flood]: '🌊',
+  [EventCardType.ExcessProfitTax]: '💰',
+};
+
+/** Short human-readable labels for each event type */
+const EVENT_TYPE_LABELS: Record<string, string> = {
+  [EventCardType.Strike]: 'Strike',
+  [EventCardType.Derailment]: 'Derailment',
+  [EventCardType.Snow]: 'Snow',
+  [EventCardType.Flood]: 'Flood',
+  [EventCardType.ExcessProfitTax]: 'Tax',
+};
+
+/** Font size for active effect rows */
+const EFFECT_FONT_SIZE = '13px';
+
+/** Color for effect row text */
+const EFFECT_TEXT_COLOR = '#ffdd88';
+
+/**
+ * HUD component that displays active event effects within the PlayerHandScene infoSizer.
+ *
+ * Follows the RexUI sizer pattern used throughout PlayerHandScene.
+ * Returns a sizer that can be added directly to any parent sizer.
+ */
+export class ActiveEffectHUD {
+  private scene: Scene;
+  private sizer: any;
+  private effectRows: Phaser.GameObjects.Text[] = [];
+
+  constructor(scene: Scene) {
+    this.scene = scene;
+    this.sizer = (scene as any).rexUI.add
+      .sizer({
+        orientation: 'y',
+        space: { item: 2 },
+      })
+      .setName('active-effects-hud-sizer');
+  }
+
+  /**
+   * Returns the RexUI sizer to be added to a parent sizer.
+   */
+  public getSizer(): any {
+    return this.sizer;
+  }
+
+  /**
+   * Update the displayed effects, rebuilding all rows.
+   * Call this whenever activeEffects changes in the store.
+   */
+  public updateEffects(effects: ActiveEffectSummary[], currentTurnNumber?: number): void {
+    // Destroy existing rows
+    this.effectRows.forEach((row) => row.destroy());
+    this.effectRows = [];
+
+    // Clear sizer children
+    this.sizer.clear(true);
+
+    if (effects.length === 0) {
+      // Empty state: render a placeholder text
+      const emptyText = this.scene.add.text(0, 0, 'No active effects', {
+        color: '#888888',
+        fontSize: EFFECT_FONT_SIZE,
+        fontFamily: UI_FONT_FAMILY,
+        fontStyle: 'italic',
+      });
+      emptyText.setName('active-effects-empty');
+      this.sizer.add(emptyText, {
+        proportion: 0,
+        align: 'left',
+        expand: false,
+      });
+      this.effectRows.push(emptyText);
+      return;
+    }
+
+    for (const effect of effects) {
+      const row = this.createEffectRow(effect, currentTurnNumber);
+      this.sizer.add(row, {
+        proportion: 0,
+        align: 'left',
+        expand: false,
+      });
+      this.effectRows.push(row);
+    }
+  }
+
+  /**
+   * Build a text object for a single active effect row.
+   * Format: "[icon] [label] - [duration]"
+   */
+  private createEffectRow(effect: ActiveEffectSummary, currentTurnNumber?: number): Phaser.GameObjects.Text {
+    const icon = EVENT_TYPE_ICONS[effect.cardType] ?? '📋';
+    const label = EVENT_TYPE_LABELS[effect.cardType] ?? effect.cardType;
+    const durationText = this.formatDuration(effect, currentTurnNumber);
+
+    const rowText = this.scene.add.text(0, 0, `${icon} ${label} - ${durationText}`, {
+      color: EFFECT_TEXT_COLOR,
+      fontSize: EFFECT_FONT_SIZE,
+      fontFamily: UI_FONT_FAMILY,
+      fontStyle: 'bold',
+    });
+    rowText.setName(`active-effect-row-${effect.cardId}`);
+    return rowText;
+  }
+
+  /**
+   * Format the duration label for an effect.
+   * Uses expiresAfterTurnNumber when available.
+   */
+  private formatDuration(effect: ActiveEffectSummary, currentTurnNumber?: number): string {
+    if (currentTurnNumber !== undefined && currentTurnNumber !== null) {
+      const turnsLeft = effect.expiresAfterTurnNumber - currentTurnNumber;
+      if (turnsLeft <= 0) {
+        return 'expiring';
+      }
+      return turnsLeft === 1 ? '1 turn' : `${turnsLeft} turns`;
+    }
+    // Fallback: just show "active" when we don't have a current turn number
+    return 'active';
+  }
+
+  /**
+   * Destroy this HUD and all its children.
+   */
+  public destroy(): void {
+    this.effectRows.forEach((row) => row.destroy());
+    this.effectRows = [];
+    try {
+      this.sizer.clear(true);
+      this.sizer.destroy();
+    } catch {
+      // Non-critical
+    }
+  }
+}

--- a/src/client/lobby/store/game.store.ts
+++ b/src/client/lobby/store/game.store.ts
@@ -94,8 +94,13 @@ export const useGameStore = create<GameStore>((set, get) => ({
       // Set up event listeners
       socketService.onInit((data) => {
         get().applyStateInit(data.gameState, data.serverSeq);
-        set({ 
-          isConnected: true, 
+        // Restore active effects from state:init (server includes them on reconnect)
+        const initData = data as Record<string, unknown>;
+        if (Array.isArray(initData.activeEffects)) {
+          get().setActiveEffects(initData.activeEffects as ActiveEffectSummary[]);
+        }
+        set({
+          isConnected: true,
           isLoading: false,
           connectionStatus: 'connected'
         });
@@ -306,6 +311,21 @@ export const useGameStore = create<GameStore>((set, get) => ({
     }
 
     set({ pendingEventOverlay: payload });
+
+    // For persistent effects, immediately add to activeEffects so the HUD updates.
+    // The server only broadcasts event:active-effects on reconnect, so we derive
+    // an ActiveEffectSummary from the drawn card payload here.
+    if (payload.duration === 'persistent') {
+      get().addActiveEffect({
+        cardId: payload.card.id,
+        cardType: payload.card.type,
+        drawingPlayerId: payload.drawingPlayerId,
+        drawingPlayerName: payload.drawingPlayerName,
+        expiresAfterTurnNumber: 0, // Unknown from payload; HUD shows "active" as fallback
+        affectedZone: payload.affectedZone,
+        effectSummary: payload.effectSummary,
+      });
+    }
 
     // Start a 30-second auto-dismiss timer
     overlayAutoDismissTimer = setTimeout(() => {

--- a/src/client/scenes/PlayerHandScene.ts
+++ b/src/client/scenes/PlayerHandScene.ts
@@ -9,6 +9,8 @@ import { TrainInteractionManager } from "../components/TrainInteractionManager";
 import { TrackDrawingManager } from "../components/TrackDrawingManager";
 import { UI_FONT_FAMILY } from "../config/uiFont";
 import { TrainType } from "../../shared/types/GameTypes";
+import { ActiveEffectHUD } from "../components/ActiveEffectHUD";
+import { useGameStore } from "../lobby/store/game.store";
 
 interface PlayerHandSceneData {
   gameState: FullGameState;
@@ -75,6 +77,8 @@ export class PlayerHandScene extends Phaser.Scene {
   private confirmTrainPurchaseModal: Phaser.GameObjects.Container | null = null;
   private borrowAmountModal: Phaser.GameObjects.Container | null = null;
   private toastContainer: Phaser.GameObjects.Container | null = null;
+  private activeEffectHUD: ActiveEffectHUD | null = null;
+  private unsubActiveEffects: (() => void) | null = null;
 
   // Card dimensions
   private readonly CARD_WIDTH = 170;
@@ -271,6 +275,12 @@ export class PlayerHandScene extends Phaser.Scene {
     }
     if (this.crayonHighlightCircle) {
       this.crayonHighlightCircle.setVisible(this.isDrawingMode);
+    }
+
+    // Update active effects HUD (store may have changed since last full refresh)
+    if (this.activeEffectHUD) {
+      const effects = useGameStore.getState().activeEffects;
+      this.activeEffectHUD.updateEffects(effects);
     }
 
     // Re-layout once (text size can change)
@@ -1771,6 +1781,7 @@ export class PlayerHandScene extends Phaser.Scene {
     this.createCitySelectionSection(this.infoSizer);
     this.createNameAndMoneySection(this.infoSizer);
     this.createBuildCostSection(this.infoSizer);
+    this.createActiveEffectsSection(this.infoSizer);
     this.createMoreActionsSection(this.infoSizer);
 
     this.rootSizer.add(this.infoSizer, {
@@ -1778,6 +1789,39 @@ export class PlayerHandScene extends Phaser.Scene {
       align: "center",
       padding: { left: 10, right: 10 },
       expand: false,
+    });
+  }
+
+  private createActiveEffectsSection(parentSizer: any): void {
+    // Destroy any existing HUD and store subscription before creating a new one
+    if (this.activeEffectHUD) {
+      this.activeEffectHUD.destroy();
+      this.activeEffectHUD = null;
+    }
+    if (this.unsubActiveEffects) {
+      this.unsubActiveEffects();
+      this.unsubActiveEffects = null;
+    }
+
+    this.activeEffectHUD = new ActiveEffectHUD(this);
+
+    // Initial render with current store state
+    const initialEffects = useGameStore.getState().activeEffects;
+    this.activeEffectHUD.updateEffects(initialEffects);
+
+    parentSizer.add(this.activeEffectHUD.getSizer(), {
+      proportion: 0,
+      align: "left",
+      padding: { top: 2, bottom: 2 },
+      expand: false,
+    });
+
+    // Subscribe to store changes for reactive updates
+    this.unsubActiveEffects = useGameStore.subscribe((state) => {
+      if (this.activeEffectHUD) {
+        this.activeEffectHUD.updateEffects(state.activeEffects);
+        this.rootSizer?.layout?.();
+      }
     });
   }
 
@@ -2104,6 +2148,16 @@ export class PlayerHandScene extends Phaser.Scene {
     this.closeBorrowAmountModal();
     this.closeConfirmTrainPurchaseModal();
     this.closeActionsModal();
+
+    // Unsubscribe from store and destroy active effects HUD
+    if (this.unsubActiveEffects) {
+      this.unsubActiveEffects();
+      this.unsubActiveEffects = null;
+    }
+    if (this.activeEffectHUD) {
+      this.activeEffectHUD.destroy();
+      this.activeEffectHUD = null;
+    }
 
     // Destroy train card
     if (this.trainCard) {


### PR DESCRIPTION
## Summary
- Adds `ActiveEffectHUD` component that displays active event effects (icon, label, duration) in the PlayerHandScene info panel
- Wires HUD to Zustand store subscription for reactive updates as effects are added/removed
- Fixes `showEventOverlay` to also populate `activeEffects` for persistent events (previously only populated on reconnect)
- Fixes `state:init` handler to extract `activeEffects` from server payload on reconnect
- Empty state hides the HUD entirely rather than showing placeholder text

## Test plan
- [x] 25 unit tests for ActiveEffectHUD (icons, labels, duration formatting, empty state, reactive updates, destroy)
- [x] Full suite passes (3874/3874)
- [x] TypeScript compiles cleanly
- [x] Manually verified: HUD appears in player hand when event card 123 (Strike) drawn in live game

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds an ActiveEffectHUD component to the EuroRails Phaser game client that displays active event effects in the PlayerHandScene info panel with reactive updates via Zustand store subscription, while fixing two bugs that prevented activeEffects from being properly populated on event display and reconnect.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces ActiveEffectHUD component displaying event icons (🚫⚠️❄️🌊💰), labels, and duration with RexUI sizer pattern integration in PlayerHandScene</li>

<li>Fixes showEventOverlay in game.store.ts to populate activeEffects for persistent events by deriving ActiveEffectSummary from drawn card payload</li>

<li>Fixes state:init handler in game.store.ts to extract activeEffects from server payload on reconnect, restoring state correctly</li>

<li>Wires HUD to Zustand store subscription in PlayerHandScene for reactive updates as effects are added/removed, with proper cleanup on scene shutdown</li>

<li>Implements 25 unit tests covering icon rendering, label display, duration formatting, empty state hiding, reactive updates, and destroy lifecycle</li>

</ul>
</details>

</div>