### PR TITLE
Fix multi-game shared deck state: per-game DemandDeckService (BE-001, BE-002) (#237)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,43 @@ After significant code generation Run "compounds agent-prompt cli-usage" and ind
 - Component architecture with Phaser for client, Fastify for server
 - Use proper indentation (2 spaces) and trailing commas
 
+## Refactoring Discipline (learned the hard way)
 
+A "convert singleton to per-game instances" refactor of `LoadService` was applied
+mechanically to a service that had no per-game mutable in-memory state, then a
+"fix" compounded it by inventing a third design instead of restoring the
+original. Both are avoidable. Follow these rules for ANY structural refactor:
+
+1. **Validate the refactor's premise per target before touching code.** A pattern
+   that is correct for one service is not automatically correct for its
+   neighbor. Before applying "isolate per-game state," classify each piece of a
+   service's state:
+   - **Immutable config** (loaded once from disk/constants) → static/shared. Needs
+     no isolation.
+   - **DB-backed state keyed by an id** (e.g. `WHERE game_id = $1`) → already
+     isolated at the database. Needs no in-memory isolation.
+   - **Mutable in-memory state shared across games** (e.g. an in-memory deck Map)
+     → THIS is the only kind that per-game instances fix.
+   If a target has none of the third kind, it does not belong in the refactor —
+   say so and leave it alone, even if a spec/task lists it. Specs state intent,
+   not ground truth; the code is ground truth.
+
+2. **A per-game instance must OWN its id.** If you introduce
+   `getInstanceForGame(gameId)`, the instance stores `this.gameId` and its methods
+   use it. A method that still takes `gameId` as a parameter after the instance is
+   already keyed by game (`getInstanceForGame(gameId).method(gameId)`) is a smell
+   and a correctness hazard — the two can diverge. Either the id lives on the
+   instance or the service is static; never both.
+
+3. **To undo a bad refactor, restore the known-good prior shape — do not invent a
+   third design.** `git show HEAD:<file>` and revert the consumer diffs. Inventing
+   a new shape re-touches every call site and every test mock a second time.
+
+4. **Blast radius is a design signal, not just work to grind through.** If a change
+   forces edits to a dozen consumers and a rewrite of many nested test mocks,
+   STOP and question the design before proceeding. Widespread mechanical mock
+   churn (e.g. flattening `getInstanceForGame(() => ({...}))` across 10 files)
+   usually means the abstraction is wrong, not that the tests are wrong.
 
 Use the following to inform logic for gameplay. These rules inform what is allowed logically.
 

--- a/src/server/__tests__/TurnExecutor.test.ts
+++ b/src/server/__tests__/TurnExecutor.test.ts
@@ -489,17 +489,13 @@ jest.mock('../services/loadService', () => ({
 
 jest.mock('../services/demandDeckService', () => ({
   DemandDeckService: {
-    getInstance: jest.fn().mockReturnValue({
-      getCard: jest.fn().mockReturnValue({
-        id: 99,
-        demands: [
-          { city: 'Paris', resource: 'Wine', payment: 20 },
-          { city: 'Madrid', resource: 'Iron', payment: 15 },
-          { city: 'Wien', resource: 'Oil', payment: 12 },
-        ],
-      }),
-      drawCard: jest.fn(),
-      discardCard: jest.fn(),
+    getCard: jest.fn().mockReturnValue({
+      id: 99,
+      demands: [
+        { city: 'Paris', resource: 'Wine', payment: 20 },
+        { city: 'Madrid', resource: 'Iron', payment: 15 },
+        { city: 'Wien', resource: 'Oil', payment: 12 },
+      ],
     }),
   },
 }));

--- a/src/server/__tests__/ai/WorldSnapshotService.test.ts
+++ b/src/server/__tests__/ai/WorldSnapshotService.test.ts
@@ -32,9 +32,7 @@ jest.mock('../../services/ai/connectedMajorCities', () => ({
 
 jest.mock('../../services/demandDeckService', () => ({
   DemandDeckService: {
-    getInstance: jest.fn(() => ({
-      getCard: jest.fn(() => undefined),
-    })),
+    getCard: jest.fn(() => undefined),
   },
 }));
 

--- a/src/server/__tests__/deckRoutes.events.test.ts
+++ b/src/server/__tests__/deckRoutes.events.test.ts
@@ -16,7 +16,7 @@ import { EventCardType } from '../../shared/types/EventCard';
 
 jest.mock('../services/authService');
 jest.mock('../services/demandDeckService', () => ({
-  demandDeckService: {
+  DemandDeckService: {
     getAllCards: jest.fn(() => []),
     getAllEventCards: jest.fn(() => [
       {
@@ -35,8 +35,13 @@ jest.mock('../services/demandDeckService', () => ({
       },
     ]),
     getCard: jest.fn(),
-    reset: jest.fn(),
-    getDeckState: jest.fn(() => ({ totalCards: 166, drawPileSize: 166, discardPileSize: 0, dealtCardsCount: 0 })),
+    destroyAllInstances: jest.fn(),
+    getInstanceForGame: jest.fn(() => ({
+      reset: jest.fn(),
+      reshuffle: jest.fn(),
+      pushEventCardToTop: jest.fn(),
+      getDeckState: jest.fn(() => ({ totalCards: 166, drawPileSize: 166, discardPileSize: 0, dealtCardsCount: 0 })),
+    })),
   },
 }));
 

--- a/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
+++ b/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
@@ -12,11 +12,12 @@
 import { DemandDeckService } from '../services/demandDeckService';
 import { EventCardType } from '../../shared/types/EventCard';
 
-// Get the singleton and reset it to a clean state for each test
-function getFreshService(): DemandDeckService {
-  const service = DemandDeckService.getInstance();
-  service.reset();
-  return service;
+const TEST_GAME_ID = 'unified-draw-test-game';
+
+// Get a fresh per-game deck in a clean state for each test.
+function getFreshService(gameId: string = TEST_GAME_ID): DemandDeckService {
+  DemandDeckService.destroyInstance(gameId);
+  return DemandDeckService.getInstanceForGame(gameId);
 }
 
 describe('DemandDeckService unified draw pile', () => {
@@ -24,6 +25,10 @@ describe('DemandDeckService unified draw pile', () => {
 
   beforeEach(() => {
     service = getFreshService();
+  });
+
+  afterEach(() => {
+    DemandDeckService.destroyAllInstances();
   });
 
   describe('deck initialization', () => {
@@ -318,6 +323,59 @@ describe('DemandDeckService unified draw pile', () => {
       expect(types.has(EventCardType.Snow)).toBe(true);
       expect(types.has(EventCardType.Flood)).toBe(true);
       expect(types.has(EventCardType.ExcessProfitTax)).toBe(true);
+    });
+  });
+
+  describe('per-game instance management', () => {
+    afterEach(() => {
+      DemandDeckService.destroyAllInstances();
+    });
+
+    it('should return the same instance for the same gameId', () => {
+      const a = DemandDeckService.getInstanceForGame('game-A');
+      const b = DemandDeckService.getInstanceForGame('game-A');
+      expect(a).toBe(b);
+    });
+
+    it('should return different instances for different gameIds', () => {
+      const a = DemandDeckService.getInstanceForGame('game-A');
+      const b = DemandDeckService.getInstanceForGame('game-B');
+      expect(a).not.toBe(b);
+    });
+
+    it('should isolate deck state between games', () => {
+      const a = DemandDeckService.getInstanceForGame('game-A');
+      const b = DemandDeckService.getInstanceForGame('game-B');
+
+      // Draw from game A only; game B must be unaffected.
+      a.drawCard();
+      a.drawCard();
+
+      expect(a.getDeckState().dealtCardsCount).toBe(2);
+      expect(a.getDeckState().drawPileSize).toBe(164);
+      expect(b.getDeckState().dealtCardsCount).toBe(0);
+      expect(b.getDeckState().drawPileSize).toBe(166);
+    });
+
+    it('should create a fresh instance after destroyInstance', () => {
+      const first = DemandDeckService.getInstanceForGame('game-A');
+      first.drawCard();
+      expect(first.getDeckState().dealtCardsCount).toBe(1);
+
+      DemandDeckService.destroyInstance('game-A');
+
+      const second = DemandDeckService.getInstanceForGame('game-A');
+      expect(second).not.toBe(first);
+      expect(second.getDeckState().dealtCardsCount).toBe(0);
+      expect(second.getDeckState().drawPileSize).toBe(166);
+    });
+
+    it('should treat destroyInstance for an unknown game as a no-op', () => {
+      expect(() => DemandDeckService.destroyInstance('never-created')).not.toThrow();
+    });
+
+    it('should reject an empty gameId', () => {
+      expect(() => DemandDeckService.getInstanceForGame('')).toThrow('non-empty gameId');
     });
   });
 });

--- a/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
+++ b/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
@@ -45,31 +45,31 @@ describe('DemandDeckService unified draw pile', () => {
     });
 
     it('should have 20 event cards via getAllEventCards()', () => {
-      const eventCards = service.getAllEventCards();
+      const eventCards = DemandDeckService.getAllEventCards();
       expect(eventCards).toHaveLength(20);
     });
 
     it('should have event card IDs 121–140', () => {
-      const eventCards = service.getAllEventCards();
+      const eventCards = DemandDeckService.getAllEventCards();
       const ids = eventCards.map((c) => c.id).sort((a, b) => a - b);
       const expected = Array.from({ length: 20 }, (_, i) => 121 + i);
       expect(ids).toEqual(expected);
     });
 
     it('should return all demand cards via getAllCards()', () => {
-      const demandCards = service.getAllCards();
+      const demandCards = DemandDeckService.getAllCards();
       expect(demandCards).toHaveLength(146);
     });
 
     it('should return specific demand card via getCard()', () => {
-      const card = service.getCard(1);
+      const card = DemandDeckService.getCard(1);
       expect(card).toBeDefined();
       expect(card!.id).toBe(1);
     });
 
     it('should return demand card for ID 121 via getCard() (demand cards include 121)', () => {
       // Demand card IDs go 1–146, so ID 121 is a demand card
-      const card = service.getCard(121);
+      const card = DemandDeckService.getCard(121);
       expect(card).toBeDefined();
       expect(card!.id).toBe(121);
     });
@@ -208,7 +208,7 @@ describe('DemandDeckService unified draw pile', () => {
 
   describe('ensureCardIsDealt() — both card types', () => {
     it('should mark a demand card as dealt', () => {
-      const demandCardId = service.getAllCards()[0].id;
+      const demandCardId = DemandDeckService.getAllCards()[0].id;
       const result = service.ensureCardIsDealt(demandCardId);
       expect(result).toBe(true);
       const state = service.getDeckState();
@@ -231,7 +231,7 @@ describe('DemandDeckService unified draw pile', () => {
     });
 
     it('should return true if card is already dealt', () => {
-      const cardId = service.getAllCards()[0].id;
+      const cardId = DemandDeckService.getAllCards()[0].id;
       service.ensureCardIsDealt(cardId);
       const result = service.ensureCardIsDealt(cardId); // second call
       expect(result).toBe(true);
@@ -253,7 +253,7 @@ describe('DemandDeckService unified draw pile', () => {
     });
 
     it('should return false for a card not dealt', () => {
-      const cardId = service.getAllCards()[0].id;
+      const cardId = DemandDeckService.getAllCards()[0].id;
       const result = service.returnDealtCardToTop(cardId);
       expect(result).toBe(false);
     });
@@ -288,7 +288,7 @@ describe('DemandDeckService unified draw pile', () => {
     });
 
     it('should return false if card is not in discard pile', () => {
-      const cardId = service.getAllCards()[0].id;
+      const cardId = DemandDeckService.getAllCards()[0].id;
       const result = service.returnDiscardedCardToDealt(cardId);
       expect(result).toBe(false);
     });
@@ -316,7 +316,7 @@ describe('DemandDeckService unified draw pile', () => {
 
   describe('event card type coverage', () => {
     it('should have event cards of each type in the pool', () => {
-      const eventCards = service.getAllEventCards();
+      const eventCards = DemandDeckService.getAllEventCards();
       const types = new Set(eventCards.map((c) => c.type));
       expect(types.has(EventCardType.Strike)).toBe(true);
       expect(types.has(EventCardType.Derailment)).toBe(true);

--- a/src/server/__tests__/integration/botBuildTrack.test.ts
+++ b/src/server/__tests__/integration/botBuildTrack.test.ts
@@ -124,19 +124,17 @@ jest.mock('../../../shared/services/TrackNetworkService', () => ({
 // Mock DemandDeckService (used by WorldSnapshotService for demand resolution)
 jest.mock('../../services/demandDeckService', () => ({
   DemandDeckService: {
-    getInstance: jest.fn(() => ({
-      getCard: jest.fn((cardId: number) => {
-        if (cardId === 1) {
-          return {
-            id: 1,
-            demands: [
-              { city: 'Berlin', resource: 'Steel', payment: 50 },
-            ],
-          };
-        }
-        return undefined;
-      }),
-    })),
+    getCard: jest.fn((cardId: number) => {
+      if (cardId === 1) {
+        return {
+          id: 1,
+          demands: [
+            { city: 'Berlin', resource: 'Steel', payment: 50 },
+          ],
+        };
+      }
+      return undefined;
+    }),
   },
 }));
 

--- a/src/server/__tests__/playerService.discardHand.test.ts
+++ b/src/server/__tests__/playerService.discardHand.test.ts
@@ -1,6 +1,7 @@
 import { db } from '../db/index';
 import { PlayerService } from '../services/playerService';
-import { demandDeckService } from '../services/demandDeckService';
+// DemandDeckService is mocked below; alias the shared mock instance the factory exposes.
+const demandDeckService = jest.requireMock('../services/demandDeckService').demandDeckService as Record<string, jest.Mock>;
 import { EventCardService } from '../services/EventCardService';
 
 // Mock socketService to prevent real socket emissions
@@ -28,15 +29,23 @@ jest.mock('../db/index', () => {
 });
 
 // Mock DemandDeckService
-jest.mock('../services/demandDeckService', () => ({
-  demandDeckService: {
+jest.mock('../services/demandDeckService', () => {
+  const instance = {
     discardCard: jest.fn(),
     discardEventCard: jest.fn(),
     drawCard: jest.fn(),
     returnDealtCardToTop: jest.fn(),
     returnDiscardedCardToDealt: jest.fn(),
-  },
-}));
+  };
+  return {
+    demandDeckService: instance,
+    DemandDeckService: {
+      getInstanceForGame: jest.fn(() => instance),
+      destroyInstance: jest.fn(),
+      destroyAllInstances: jest.fn(),
+    },
+  };
+});
 
 // Mock EventCardService — prevents real DB calls when event cards are drawn
 jest.mock('../services/EventCardService', () => ({

--- a/src/server/__tests__/playerService.drawLoop.test.ts
+++ b/src/server/__tests__/playerService.drawLoop.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { PlayerService } from '../services/playerService';
-import { demandDeckService } from '../services/demandDeckService';
+// DemandDeckService is mocked below; alias the shared mock instance the factory exposes.
+const demandDeckService = jest.requireMock('../services/demandDeckService').demandDeckService as Record<string, jest.Mock>;
 import { EventCardService } from '../services/EventCardService';
 import { activeEffectManager } from '../services/ActiveEffectManager';
 import { EventCardType } from '../../shared/types/EventCard';
@@ -37,16 +38,28 @@ jest.mock('../db/index', () => {
 });
 
 // Mock DemandDeckService
-jest.mock('../services/demandDeckService', () => ({
-  demandDeckService: {
+jest.mock('../services/demandDeckService', () => {
+  // getCard is a static definitional accessor; share one fn so tests that
+  // configure it (via the instance alias) also drive the static call.
+  const getCard = jest.fn();
+  const instance = {
     discardCard: jest.fn(),
     discardEventCard: jest.fn(),
     drawCard: jest.fn(),
     returnDealtCardToTop: jest.fn(),
     returnDiscardedCardToDealt: jest.fn(),
-    getCard: jest.fn(),
-  },
-}));
+    getCard,
+  };
+  return {
+    demandDeckService: instance,
+    DemandDeckService: {
+      getCard,
+      getInstanceForGame: jest.fn(() => instance),
+      destroyInstance: jest.fn(),
+      destroyAllInstances: jest.fn(),
+    },
+  };
+});
 
 // Mock EventCardService
 jest.mock('../services/EventCardService', () => ({

--- a/src/server/__tests__/playerService.eventCardIntegration.test.ts
+++ b/src/server/__tests__/playerService.eventCardIntegration.test.ts
@@ -10,7 +10,8 @@
  */
 
 import { PlayerService } from '../services/playerService';
-import { demandDeckService } from '../services/demandDeckService';
+// DemandDeckService is mocked below; alias the shared mock instance the factory exposes.
+const demandDeckService = jest.requireMock('../services/demandDeckService').demandDeckService as Record<string, jest.Mock>;
 import { EventCardService } from '../services/EventCardService';
 import { emitToGame } from '../services/socketService';
 
@@ -43,17 +44,29 @@ jest.mock('../db/index', () => {
 });
 
 // Mock DemandDeckService
-jest.mock('../services/demandDeckService', () => ({
-  demandDeckService: {
+jest.mock('../services/demandDeckService', () => {
+  // getCard is a static definitional accessor; share one fn so tests that
+  // configure it (via the instance alias) also drive the static call.
+  const getCard = jest.fn();
+  const instance = {
     discardCard: jest.fn(),
     discardEventCard: jest.fn(),
     drawCard: jest.fn(),
-    getCard: jest.fn(),
+    getCard,
     returnDealtCardToTop: jest.fn(),
     returnDiscardedCardToDealt: jest.fn(),
     returnDiscardedEventCardToDrawPile: jest.fn(),
-  },
-}));
+  };
+  return {
+    demandDeckService: instance,
+    DemandDeckService: {
+      getCard,
+      getInstanceForGame: jest.fn(() => instance),
+      destroyInstance: jest.fn(),
+      destroyAllInstances: jest.fn(),
+    },
+  };
+});
 
 // Mock EventCardService — prevents real DB calls during event card processing
 jest.mock('../services/EventCardService', () => ({

--- a/src/server/__tests__/playerService.fulfillDemand.test.ts
+++ b/src/server/__tests__/playerService.fulfillDemand.test.ts
@@ -1,6 +1,7 @@
 import { db } from '../db/index';
 import { PlayerService } from '../services/playerService';
-import { demandDeckService } from '../services/demandDeckService';
+// DemandDeckService is mocked below; alias the shared mock instance the factory exposes.
+const demandDeckService = jest.requireMock('../services/demandDeckService').demandDeckService as Record<string, jest.Mock>;
 import { EventCardService } from '../services/EventCardService';
 
 // Mock socketService to prevent real socket emissions
@@ -28,15 +29,23 @@ jest.mock('../db/index', () => {
 });
 
 // Mock DemandDeckService
-jest.mock('../services/demandDeckService', () => ({
-  demandDeckService: {
+jest.mock('../services/demandDeckService', () => {
+  const instance = {
     discardCard: jest.fn(),
     discardEventCard: jest.fn(),
     drawCard: jest.fn(),
     returnDealtCardToTop: jest.fn(),
     returnDiscardedCardToDealt: jest.fn(),
-  },
-}));
+  };
+  return {
+    demandDeckService: instance,
+    DemandDeckService: {
+      getInstanceForGame: jest.fn(() => instance),
+      destroyInstance: jest.fn(),
+      destroyAllInstances: jest.fn(),
+    },
+  };
+});
 
 // Mock EventCardService — prevents real DB calls when event cards are drawn
 jest.mock('../services/EventCardService', () => ({

--- a/src/server/__tests__/playerService.test.ts
+++ b/src/server/__tests__/playerService.test.ts
@@ -5,7 +5,7 @@ import '@jest/globals';
 import { LoadType } from '../../shared/types/LoadTypes';
 import { cleanDatabase } from '../db/index';
 import { TerrainType, TrainType } from '../../shared/types/GameTypes';
-import { demandDeckService } from '../services/demandDeckService';
+import { DemandDeckService } from '../services/demandDeckService';
 import { TrackService } from '../services/trackService';
 
 // Force Jest to run this test file serially
@@ -31,7 +31,7 @@ describe('PlayerService Integration Tests', () => {
 
     beforeEach(async () => {
         gameId = uuidv4();
-        demandDeckService.reset();
+        DemandDeckService.destroyAllInstances();
         await runQuery(async (client) => {
             await client.query(
                 'INSERT INTO games (id, status, current_player_index, max_players) VALUES ($1, $2, $3, $4)',
@@ -723,7 +723,7 @@ describe('PlayerService Integration Tests', () => {
 
     describe('Load Delivery', () => {
         it('should deliver a load immediately server-side and prevent double delivery', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId = uuidv4();
             await db.query(
@@ -752,7 +752,7 @@ describe('PlayerService Integration Tests', () => {
 
             const playerRow = await db.query('SELECT hand FROM players WHERE id = $1', [playerId]);
             const cardId: number = playerRow.rows[0].hand[0];
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             expect(card).toBeTruthy();
             if (!card) {
                 throw new Error('Expected demand card to exist');
@@ -801,7 +801,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should undo the last delivery and restore money, load, and the discarded demand card', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId = uuidv4();
             await db.query(
@@ -830,7 +830,7 @@ describe('PlayerService Integration Tests', () => {
 
             const playerRow = await db.query('SELECT hand FROM players WHERE id = $1', [playerId]);
             const cardId: number = playerRow.rows[0].hand[0];
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             expect(card).toBeTruthy();
             if (!card) throw new Error('Expected demand card to exist');
 
@@ -868,11 +868,11 @@ describe('PlayerService Integration Tests', () => {
             expect(after.rows[0].hand).not.toContain(delivered.newCard.id);
 
             // The card should no longer be considered dealt after undo.
-            expect(demandDeckService.returnDealtCardToTop(delivered.newCard.id)).toBe(false);
+            expect(DemandDeckService.getInstanceForGame(gameId).returnDealtCardToTop(delivered.newCard.id)).toBe(false);
         });
 
         it('should correctly undo delivery when debt was repaid from the payoff', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId = uuidv4();
             await db.query(
@@ -901,7 +901,7 @@ describe('PlayerService Integration Tests', () => {
 
             const playerRow = await db.query('SELECT hand FROM players WHERE id = $1', [playerId]);
             const cardId: number = playerRow.rows[0].hand[0];
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             expect(card).toBeTruthy();
             if (!card) throw new Error('Expected demand card to exist');
 
@@ -958,7 +958,7 @@ describe('PlayerService Integration Tests', () => {
 
     describe('Discard hand (skip turn)', () => {
         it('should discard all 3 cards, draw 3 new cards, and advance the turn', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId1 = uuidv4();
             const userId2 = uuidv4();
@@ -1008,7 +1008,7 @@ describe('PlayerService Integration Tests', () => {
                 hand: []
             } as any);
 
-            const beforeDeck = demandDeckService.getDeckState();
+            const beforeDeck = DemandDeckService.getInstanceForGame(gameId).getDeckState();
             const beforePlayerRow = await db.query('SELECT hand, current_turn_number FROM players WHERE id = $1', [playerId1]);
             const oldHand: number[] = beforePlayerRow.rows[0].hand;
             const oldTurnNumber: number = beforePlayerRow.rows[0].current_turn_number;
@@ -1018,7 +1018,7 @@ describe('PlayerService Integration Tests', () => {
             const result = await PlayerService.discardHandForUser(gameId, userId1);
             expect(result.currentPlayerIndex).toBe(1);
 
-            const afterDeck = demandDeckService.getDeckState();
+            const afterDeck = DemandDeckService.getInstanceForGame(gameId).getDeckState();
             // At least 3 cards discarded (old hand); may be more if event cards were drawn and discarded
             expect(afterDeck.discardPileSize).toBeGreaterThanOrEqual(beforeDeck.discardPileSize + 3);
             // All dealt cards should be accounted for (3 new hand cards dealt, same net count)
@@ -1038,7 +1038,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should reject discard when it is not your turn', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId1 = uuidv4();
             const userId2 = uuidv4();
@@ -1085,7 +1085,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should reject discard when turn_build_cost > 0', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId1 = uuidv4();
             const userId2 = uuidv4();
@@ -1136,7 +1136,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should reject discard when server-tracked actions exist this turn', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId1 = uuidv4();
             const userId2 = uuidv4();
@@ -1383,7 +1383,7 @@ describe('PlayerService Integration Tests', () => {
 
     describe('Restart (reset) - mercy rule', () => {
         it('should restart the active player: reset money/train/loads/position, replace hand, and clear track (without ending turn)', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId1 = uuidv4();
             const userId2 = uuidv4();
@@ -1508,7 +1508,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should reject restart when it is not your turn', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId1 = uuidv4();
             const userId2 = uuidv4();
@@ -1555,7 +1555,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should reject restart when turn_build_cost > 0', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId1 = uuidv4();
             const userId2 = uuidv4();
@@ -1606,7 +1606,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should reject restart when server-tracked actions exist this turn', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId1 = uuidv4();
             const userId2 = uuidv4();
@@ -2011,7 +2011,7 @@ describe('PlayerService Integration Tests', () => {
 
     describe('Mercy Borrowing - deliverLoadForUser debt repayment', () => {
         it('should apply full payment to money when no debt exists', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId = uuidv4();
             await db.query(
@@ -2042,7 +2042,7 @@ describe('PlayerService Integration Tests', () => {
 
             const playerRow = await db.query('SELECT hand FROM players WHERE id = $1', [playerId]);
             const cardId: number = playerRow.rows[0].hand[0];
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             if (!card) throw new Error('Expected demand card to exist');
             const demand = card.demands[0];
 
@@ -2067,7 +2067,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should clear debt and give excess to money when debt < payment', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId = uuidv4();
             await db.query(
@@ -2098,7 +2098,7 @@ describe('PlayerService Integration Tests', () => {
 
             const playerRow = await db.query('SELECT hand FROM players WHERE id = $1', [playerId]);
             const cardId: number = playerRow.rows[0].hand[0];
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             if (!card) throw new Error('Expected demand card to exist');
             const demand = card.demands[0];
 
@@ -2124,7 +2124,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should reduce debt and give nothing to money when debt > payment', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId = uuidv4();
             await db.query(
@@ -2155,7 +2155,7 @@ describe('PlayerService Integration Tests', () => {
 
             const playerRow = await db.query('SELECT hand FROM players WHERE id = $1', [playerId]);
             const cardId: number = playerRow.rows[0].hand[0];
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             if (!card) throw new Error('Expected demand card to exist');
             const demand = card.demands[0];
 
@@ -2181,7 +2181,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should clear debt exactly when debt == payment', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId = uuidv4();
             await db.query(
@@ -2209,7 +2209,7 @@ describe('PlayerService Integration Tests', () => {
 
             const playerRow = await db.query('SELECT hand FROM players WHERE id = $1', [playerId]);
             const cardId: number = playerRow.rows[0].hand[0];
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             if (!card) throw new Error('Expected demand card to exist');
             const demand = card.demands[0];
 
@@ -2237,7 +2237,7 @@ describe('PlayerService Integration Tests', () => {
         });
 
         it('should persist debt changes to database after delivery', async () => {
-            demandDeckService.reset();
+            DemandDeckService.destroyAllInstances();
 
             const userId = uuidv4();
             await db.query(
@@ -2268,7 +2268,7 @@ describe('PlayerService Integration Tests', () => {
 
             const playerRow = await db.query('SELECT hand FROM players WHERE id = $1', [playerId]);
             const cardId: number = playerRow.rows[0].hand[0];
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             if (!card) throw new Error('Expected demand card to exist');
             const demand = card.demands[0];
 

--- a/src/server/__tests__/setup.ts
+++ b/src/server/__tests__/setup.ts
@@ -1,7 +1,7 @@
 import { db, checkDatabase } from "../db";
 import dotenv from "dotenv";
 import "@jest/globals";
-import { demandDeckService } from "../services/demandDeckService";
+import { DemandDeckService } from "../services/demandDeckService";
 import { Pool } from "pg";
 
 // Load environment variables
@@ -71,9 +71,9 @@ beforeAll(async () => {
   }
 }, 30000);
 
-// Reset deck service before each test to ensure fresh state
+// Clear all per-game decks before each test to ensure a fresh slate.
 beforeEach(() => {
-  demandDeckService.reset();
+  DemandDeckService.destroyAllInstances();
 });
 
 // Commented out to prevent database wipes during development

--- a/src/server/routes/deckRoutes.ts
+++ b/src/server/routes/deckRoutes.ts
@@ -1,17 +1,23 @@
 import express from 'express';
-import { demandDeckService } from '../services/demandDeckService';
+import { DemandDeckService } from '../services/demandDeckService';
 import { authenticateToken } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
+// ---------------------------------------------------------------------------
+// Definitional endpoints — "what is printed on a card".
+// These are card-level data shared across all games, so they use the static
+// definitional accessors and take no gameId.
+// ---------------------------------------------------------------------------
+
 // Get all demand cards
 router.get('/demand', (req, res) => {
   try {
-    const cards = demandDeckService.getAllCards();
+    const cards = DemandDeckService.getAllCards();
     return res.status(200).json(cards);
   } catch (error: any) {
     console.error('Error fetching demand cards:', error);
-    return res.status(500).json({ 
+    return res.status(500).json({
       error: 'Server error',
       details: error.message || 'An unexpected error occurred'
     });
@@ -29,7 +35,7 @@ router.get('/demand/:cardId', (req, res) => {
       });
     }
 
-    const card = demandDeckService.getCard(cardId);
+    const card = DemandDeckService.getCard(cardId);
     if (!card) {
       return res.status(404).json({
         error: 'Not found',
@@ -40,59 +46,81 @@ router.get('/demand/:cardId', (req, res) => {
     return res.status(200).json(card);
   } catch (error: any) {
     console.error('Error fetching demand card:', error);
-    return res.status(500).json({ 
+    return res.status(500).json({
       error: 'Server error',
       details: error.message || 'An unexpected error occurred'
     });
   }
 });
 
-// Test-only endpoint to reset the deck
-// Allows reset in test environment or when called with test secret header
+// Get all event card definitions
+router.get('/events', authenticateToken, (req, res) => {
+  try {
+    const cards = DemandDeckService.getAllEventCards();
+    return res.status(200).json(cards);
+  } catch (error: any) {
+    console.error('Error fetching event cards:', error);
+    return res.status(500).json({
+      error: 'Server error',
+      details: error.message || 'An unexpected error occurred'
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Deck-operational endpoints — act on a game's live deck state.
+// Per-game debug operations require a gameId. The reset endpoint clears ALL
+// per-game decks (test hygiene) and therefore takes no gameId.
+// ---------------------------------------------------------------------------
+
+/** Guards a request to test/debug-only endpoints. */
+function isTestOrDebugRequest(req: express.Request): boolean {
+  const testSecret = req.headers['x-test-secret'] as string;
+  const isTestEnvironment = process.env.NODE_ENV === 'test';
+  return isTestEnvironment || testSecret === 'test-reset-secret';
+}
+
+// Test-only endpoint: clear every game's in-memory deck so a fresh test run
+// starts from a clean slate. Not per-game — resets all decks at once.
 router.post('/reset', (req, res) => {
   try {
-    const testSecret = req.headers['x-test-secret'] as string;
-    const isTestEnvironment = process.env.NODE_ENV === 'test';
-    const isValidTestRequest = isTestEnvironment || testSecret === 'test-reset-secret';
-    
-    // Only allow in test environment or with test secret
-    if (!isValidTestRequest) {
+    if (!isTestOrDebugRequest(req)) {
       return res.status(403).json({
         error: 'Forbidden',
         details: 'This endpoint is only available in test mode'
       });
     }
 
-    demandDeckService.reset();
+    DemandDeckService.destroyAllInstances();
     return res.status(200).json({
-      message: 'Deck reset successfully',
-      deckState: demandDeckService.getDeckState()
+      message: 'All game decks cleared'
     });
   } catch (error: any) {
-    console.error('Error resetting deck:', error);
-    return res.status(500).json({ 
+    console.error('Error resetting decks:', error);
+    return res.status(500).json({
       error: 'Server error',
       details: error.message || 'An unexpected error occurred'
     });
   }
 });
 
-// Debug endpoint: push an event card to the top of the draw pile
-// Guarded the same way as /reset — test env or test-secret header
+// Debug endpoint: push an event card to the top of a specific game's draw pile
 router.post('/debug/push-event', (req, res) => {
   try {
-    const testSecret = req.headers['x-test-secret'] as string;
-    const isTestEnvironment = process.env.NODE_ENV === 'test';
-    const isValidTestRequest = isTestEnvironment || testSecret === 'test-reset-secret';
-
-    if (!isValidTestRequest) {
+    if (!isTestOrDebugRequest(req)) {
       return res.status(403).json({
         error: 'Forbidden',
         details: 'This endpoint is only available in test/debug mode'
       });
     }
 
-    const { eventCardId } = req.body;
+    const { gameId, eventCardId } = req.body;
+    if (typeof gameId !== 'string' || gameId.length === 0) {
+      return res.status(400).json({
+        error: 'Invalid request',
+        details: 'gameId is required'
+      });
+    }
     if (typeof eventCardId !== 'number' || isNaN(eventCardId)) {
       return res.status(400).json({
         error: 'Invalid request',
@@ -100,10 +128,11 @@ router.post('/debug/push-event', (req, res) => {
       });
     }
 
-    demandDeckService.pushEventCardToTop(eventCardId);
+    const deck = DemandDeckService.getInstanceForGame(gameId);
+    deck.pushEventCardToTop(eventCardId);
     return res.status(200).json({
-      message: `Event card ${eventCardId} pushed to top of draw pile`,
-      deckState: demandDeckService.getDeckState()
+      message: `Event card ${eventCardId} pushed to top of draw pile for game ${gameId}`,
+      deckState: deck.getDeckState()
     });
   } catch (error: any) {
     return res.status(400).json({
@@ -113,43 +142,33 @@ router.post('/debug/push-event', (req, res) => {
   }
 });
 
-// Debug endpoint: reshuffle the draw+discard piles, preserving dealt cards
+// Debug endpoint: reshuffle a specific game's draw+discard piles, preserving dealt cards
 router.post('/debug/reshuffle', (req, res) => {
   try {
-    const testSecret = req.headers['x-test-secret'] as string;
-    const isTestEnvironment = process.env.NODE_ENV === 'test';
-    const isValidTestRequest = isTestEnvironment || testSecret === 'test-reset-secret';
-
-    if (!isValidTestRequest) {
+    if (!isTestOrDebugRequest(req)) {
       return res.status(403).json({
         error: 'Forbidden',
         details: 'This endpoint is only available in test/debug mode'
       });
     }
 
-    const result = demandDeckService.reshuffle();
+    const { gameId } = req.body;
+    if (typeof gameId !== 'string' || gameId.length === 0) {
+      return res.status(400).json({
+        error: 'Invalid request',
+        details: 'gameId is required'
+      });
+    }
+
+    const result = DemandDeckService.getInstanceForGame(gameId).reshuffle();
     return res.status(200).json({
-      message: 'Deck reshuffled (dealt cards preserved)',
+      message: `Deck reshuffled for game ${gameId} (dealt cards preserved)`,
       ...result,
     });
   } catch (error: any) {
     return res.status(500).json({
       error: 'Server error',
       details: error.message || 'Failed to reshuffle deck'
-    });
-  }
-});
-
-// Get all event card definitions
-router.get('/events', authenticateToken, (req, res) => {
-  try {
-    const cards = demandDeckService.getAllEventCards();
-    return res.status(200).json(cards);
-  } catch (error: any) {
-    console.error('Error fetching event cards:', error);
-    return res.status(500).json({
-      error: 'Server error',
-      details: error.message || 'An unexpected error occurred'
     });
   }
 });

--- a/src/server/services/ai/TurnExecutor.ts
+++ b/src/server/services/ai/TurnExecutor.ts
@@ -676,11 +676,10 @@ export class TurnExecutor {
       const freshPlayers = await PlayerService.getPlayers(snapshot.gameId, '');
       const freshBot = freshPlayers.find((p: any) => p.id === snapshot.bot.playerId);
       const freshHand: number[] = freshBot?.hand?.map((c: any) => c.id) ?? [];
-      const demandDeck = DemandDeckService.getInstance();
       const loadSvc = LoadService.getInstance();
       const ranking: Array<{ loadType: string; supplyCity: string; deliveryCity: string; payout: number; score: number; rank: number }> = [];
       for (const cid of freshHand) {
-        const card = demandDeck.getCard(cid);
+        const card = DemandDeckService.getCard(cid);
         if (!card) continue;
         for (const d of card.demands) {
           const sourceCities = loadSvc.getSourceCitiesForLoad(d.resource);

--- a/src/server/services/ai/WorldSnapshotService.ts
+++ b/src/server/services/ai/WorldSnapshotService.ts
@@ -84,10 +84,9 @@ export async function capture(gameId: string, botPlayerId: string): Promise<Worl
 
   // Resolve demand cards from DemandDeckService
   const demandCardIds: number[] = Array.isArray(botRow.hand) ? botRow.hand : [];
-  const demandDeck = DemandDeckService.getInstance();
   const resolvedDemands: ResolvedDemand[] = [];
   for (const cardId of demandCardIds) {
-    const card = demandDeck.getCard(cardId);
+    const card = DemandDeckService.getCard(cardId);
     if (!card) continue;
     resolvedDemands.push({
       cardId: card.id,

--- a/src/server/services/demandDeckService.ts
+++ b/src/server/services/demandDeckService.ts
@@ -40,13 +40,6 @@ export class DemandDeckService {
   // ---- Per-game instance registry ----
   private static instances: Map<string, DemandDeckService> = new Map();
 
-  /**
-   * Sentinel game id backing the deprecated {@link DemandDeckService.getInstance}
-   * / {@link demandDeckService} singleton shim. Consumers still on the singleton
-   * share this one deck until they are migrated to getInstanceForGame(gameId).
-   */
-  private static readonly LEGACY_SHARED_GAME_ID = '__legacy_shared__';
-
   // ---- Per-game mutable deck state ----
   private readonly gameId: string;
   /** Draw pile entries: positive = demand card ID, negative = -(event card ID) */
@@ -92,16 +85,6 @@ export class DemandDeckService {
    */
   public static destroyAllInstances(): void {
     DemandDeckService.instances.clear();
-  }
-
-  /**
-   * @deprecated Back-compat shim for the pre-per-game singleton. Returns a
-   * single shared deck keyed by {@link DemandDeckService.LEGACY_SHARED_GAME_ID}.
-   * Use {@link DemandDeckService.getInstanceForGame} instead; this is removed
-   * once all consumers are migrated to per-game instances (BE-002).
-   */
-  public static getInstance(): DemandDeckService {
-    return DemandDeckService.getInstanceForGame(DemandDeckService.LEGACY_SHARED_GAME_ID);
   }
 
   /**
@@ -330,18 +313,26 @@ export class DemandDeckService {
     return true;
   }
 
-  /** Returns all demand cards (legacy accessor). */
-  public getAllCards(): DemandCard[] {
+  // ---- Definitional accessors (card-level data, shared; not per-game state) ----
+  // These describe "what is printed on a card" and never touch a game's deck,
+  // so they are static: callers that only need card definitions (e.g. the
+  // definitional deck routes) must NOT construct a per-game instance.
+
+  /** Returns all demand card definitions. */
+  public static getAllCards(): DemandCard[] {
+    DemandDeckService.ensureConfigLoaded();
     return [...DemandDeckService.demandCards];
   }
 
-  /** Returns a demand card by ID, or undefined if not found. */
-  public getCard(cardId: number): DemandCard | undefined {
+  /** Returns a demand card definition by ID, or undefined if not found. */
+  public static getCard(cardId: number): DemandCard | undefined {
+    DemandDeckService.ensureConfigLoaded();
     return DemandDeckService.demandCardMap.get(cardId);
   }
 
   /** Returns all event card definitions. */
-  public getAllEventCards(): EventCard[] {
+  public static getAllEventCards(): EventCard[] {
+    DemandDeckService.ensureConfigLoaded();
     return [...DemandDeckService.eventCards];
   }
 
@@ -420,11 +411,3 @@ export class DemandDeckService {
     this.initializeDeck();
   }
 }
-
-/**
- * @deprecated Singleton shim backed by a single shared deck. Prefer
- * DemandDeckService.getInstanceForGame(gameId) so each game gets an isolated
- * deck. Retained so existing consumers compile during the per-game migration
- * (BE-002); removed once they are migrated.
- */
-export const demandDeckService = DemandDeckService.getInstance();

--- a/src/server/services/demandDeckService.ts
+++ b/src/server/services/demandDeckService.ts
@@ -17,14 +17,38 @@ function eventDrawKey(eventCardId: number): number {
   return -eventCardId;
 }
 
+/**
+ * Per-game demand/event deck.
+ *
+ * Card definitions (demand + event cards and their lookup maps) are immutable
+ * configuration loaded once from disk and shared across all games via static
+ * fields. The mutable deck state — draw pile, discard pile, and dealt set — is
+ * isolated per game: each game gets its own instance via
+ * {@link DemandDeckService.getInstanceForGame}. This prevents one game's draws
+ * and discards from corrupting another game's deck.
+ */
 export class DemandDeckService {
-  private static instance: DemandDeckService;
-  private demandCards: DemandCard[] = [];
-  private eventCards: EventCard[] = [];
+  // ---- Shared, immutable card configuration (loaded once from disk) ----
+  private static demandCards: DemandCard[] = [];
+  private static eventCards: EventCard[] = [];
   /** Lookup by real (positive) ID for demand cards */
-  private demandCardMap: Map<number, DemandCard> = new Map();
+  private static demandCardMap: Map<number, DemandCard> = new Map();
   /** Lookup by real (positive) ID for event cards */
-  private eventCardMap: Map<number, EventCard> = new Map();
+  private static eventCardMap: Map<number, EventCard> = new Map();
+  private static configLoaded = false;
+
+  // ---- Per-game instance registry ----
+  private static instances: Map<string, DemandDeckService> = new Map();
+
+  /**
+   * Sentinel game id backing the deprecated {@link DemandDeckService.getInstance}
+   * / {@link demandDeckService} singleton shim. Consumers still on the singleton
+   * share this one deck until they are migrated to getInstanceForGame(gameId).
+   */
+  private static readonly LEGACY_SHARED_GAME_ID = '__legacy_shared__';
+
+  // ---- Per-game mutable deck state ----
+  private readonly gameId: string;
   /** Draw pile entries: positive = demand card ID, negative = -(event card ID) */
   private drawPile: number[] = [];
   /** Discard pile entries: same encoding as drawPile */
@@ -32,33 +56,69 @@ export class DemandDeckService {
   /** Dealt entries: same encoding as drawPile (negative for event cards) */
   private dealtCards: Set<number> = new Set();
 
-  private constructor() {
-    this.loadCards();
+  private constructor(gameId: string) {
+    this.gameId = gameId;
+    DemandDeckService.ensureConfigLoaded();
+    this.initializeDeck();
   }
 
   /**
-   * For testing only: destroy the singleton so the next getInstance() creates a fresh one.
-   * Do NOT call this in production code.
+   * Get (or lazily create) the demand deck for a specific game. Each game owns
+   * an isolated draw/discard/dealt state; the card definitions are shared.
    */
-  public static destroyInstanceForTesting(): void {
-    DemandDeckService.instance = undefined as unknown as DemandDeckService;
-  }
-
-  public static getInstance(): DemandDeckService {
-    if (!DemandDeckService.instance) {
-      DemandDeckService.instance = new DemandDeckService();
+  public static getInstanceForGame(gameId: string): DemandDeckService {
+    if (!gameId || typeof gameId !== 'string') {
+      throw new Error('DemandDeckService.getInstanceForGame requires a non-empty gameId');
     }
-    return DemandDeckService.instance;
+    let instance = DemandDeckService.instances.get(gameId);
+    if (!instance) {
+      instance = new DemandDeckService(gameId);
+      DemandDeckService.instances.set(gameId, instance);
+    }
+    return instance;
   }
 
-  private loadCards(): void {
+  /**
+   * Remove a game's deck from the registry. Call at game end to release the
+   * in-memory deck state. Idempotent — destroying an unknown game is a no-op.
+   */
+  public static destroyInstance(gameId: string): void {
+    DemandDeckService.instances.delete(gameId);
+  }
+
+  /**
+   * Remove every game's deck from the registry. Testing only — lets a test
+   * suite start from a clean slate between cases.
+   */
+  public static destroyAllInstances(): void {
+    DemandDeckService.instances.clear();
+  }
+
+  /**
+   * @deprecated Back-compat shim for the pre-per-game singleton. Returns a
+   * single shared deck keyed by {@link DemandDeckService.LEGACY_SHARED_GAME_ID}.
+   * Use {@link DemandDeckService.getInstanceForGame} instead; this is removed
+   * once all consumers are migrated to per-game instances (BE-002).
+   */
+  public static getInstance(): DemandDeckService {
+    return DemandDeckService.getInstanceForGame(DemandDeckService.LEGACY_SHARED_GAME_ID);
+  }
+
+  /**
+   * Load the immutable card definitions from disk exactly once. Subsequent
+   * calls are no-ops. Shared across all per-game instances.
+   */
+  private static ensureConfigLoaded(): void {
+    if (DemandDeckService.configLoaded) {
+      return;
+    }
     try {
       // Load demand cards
       const demandConfigPath = path.resolve(__dirname, '../../../configuration/demand_cards.json');
       const demandRawData = fs.readFileSync(demandConfigPath, 'utf8');
       const demandJsonData = JSON.parse(demandRawData);
 
-      this.demandCards = demandJsonData.DemandCards.map((card: RawDemandCard): DemandCard => ({
+      const demandCards: DemandCard[] = demandJsonData.DemandCards.map((card: RawDemandCard): DemandCard => ({
         id: card.id,
         demands: card.demands.map(demand => ({
           city: demand.city,
@@ -68,7 +128,7 @@ export class DemandDeckService {
       }));
 
       // Validate that each demand card has exactly 3 demands
-      const invalidCards = this.demandCards.filter(card => card.demands.length !== 3);
+      const invalidCards = demandCards.filter(card => card.demands.length !== 3);
       if (invalidCards.length > 0) {
         throw new Error(`Found cards with incorrect number of demands: ${invalidCards.map(c => c.id).join(', ')}`);
       }
@@ -78,7 +138,7 @@ export class DemandDeckService {
       const eventRawData = fs.readFileSync(eventConfigPath, 'utf8');
       const rawEventCards: RawEventCard[] = JSON.parse(eventRawData);
 
-      this.eventCards = rawEventCards.map((card: RawEventCard): EventCard => ({
+      const eventCards: EventCard[] = rawEventCards.map((card: RawEventCard): EventCard => ({
         id: card.id,
         type: card.type,
         title: card.title,
@@ -87,19 +147,30 @@ export class DemandDeckService {
       }));
 
       // Build lookup maps (separate, no ID collision)
-      this.demandCardMap = new Map(this.demandCards.map(c => [c.id, c]));
-      this.eventCardMap = new Map(this.eventCards.map(c => [c.id, c]));
-
-      // Initialize unified draw pile: positive IDs for demand, negative for event
-      this.drawPile = [
-        ...this.demandCards.map(c => c.id),
-        ...this.eventCards.map(c => eventDrawKey(c.id)),
-      ];
-      this.shuffleDrawPile();
+      DemandDeckService.demandCards = demandCards;
+      DemandDeckService.eventCards = eventCards;
+      DemandDeckService.demandCardMap = new Map(demandCards.map(c => [c.id, c]));
+      DemandDeckService.eventCardMap = new Map(eventCards.map(c => [c.id, c]));
+      DemandDeckService.configLoaded = true;
     } catch (error) {
       console.error('Failed to load cards:', error);
       throw error;
     }
+  }
+
+  /**
+   * Build a fresh, shuffled draw pile for this game from the shared card
+   * definitions and clear the discard/dealt state.
+   */
+  private initializeDeck(): void {
+    // Initialize unified draw pile: positive IDs for demand, negative for event
+    this.drawPile = [
+      ...DemandDeckService.demandCards.map(c => c.id),
+      ...DemandDeckService.eventCards.map(c => eventDrawKey(c.id)),
+    ];
+    this.discardPile = [];
+    this.dealtCards = new Set();
+    this.shuffleDrawPile();
   }
 
   private shuffleDrawPile(): void {
@@ -113,11 +184,11 @@ export class DemandDeckService {
   /** Convert an internal draw-pile key to a CardDrawResult, or null if not found. */
   private resolveDrawKey(drawKey: number): CardDrawResult | null {
     if (drawKey > 0) {
-      const card = this.demandCardMap.get(drawKey);
+      const card = DemandDeckService.demandCardMap.get(drawKey);
       return card ? { type: 'demand', card } : null;
     } else {
       const realId = -drawKey;
-      const card = this.eventCardMap.get(realId);
+      const card = DemandDeckService.eventCardMap.get(realId);
       return card ? { type: 'event', card } : null;
     }
   }
@@ -139,15 +210,6 @@ export class DemandDeckService {
   }
 
   /**
-   * Ensure a card is marked as dealt in the in-memory deck state.
-   *
-   * This is used to reconcile deck state after a server restart: players' hands are persisted
-   * in Postgres, but the deck's dealtCards/drawPile/discardPile are currently in-memory only.
-   *
-   * If the card is found in the draw pile or discard pile, it is removed from that pile to
-   * prevent duplicates, then added to dealtCards.
-   */
-  /**
    * Ensure a demand card is marked as dealt in the in-memory deck state.
    *
    * This is used to reconcile deck state after a server restart: players' hands are persisted
@@ -156,7 +218,7 @@ export class DemandDeckService {
    * Only applicable to demand cards (player hands never contain event cards).
    */
   public ensureCardIsDealt(cardId: number): boolean {
-    if (!this.demandCardMap.has(cardId)) {
+    if (!DemandDeckService.demandCardMap.has(cardId)) {
       return false;
     }
     const drawKey = cardId; // Demand cards: drawKey === cardId (positive)
@@ -182,7 +244,7 @@ export class DemandDeckService {
    */
   public discardCard(cardId: number): void {
     const drawKey = cardId; // Demand cards use positive IDs as draw keys
-    if (!this.demandCardMap.has(cardId)) {
+    if (!DemandDeckService.demandCardMap.has(cardId)) {
       throw new Error(`Invalid card ID: ${cardId}`);
     }
     if (!this.dealtCards.has(drawKey)) {
@@ -203,7 +265,7 @@ export class DemandDeckService {
    */
   public discardEventCard(eventCardId: number): void {
     const drawKey = eventDrawKey(eventCardId);
-    if (!this.eventCardMap.has(eventCardId)) {
+    if (!DemandDeckService.eventCardMap.has(eventCardId)) {
       throw new Error(`Invalid event card ID: ${eventCardId}`);
     }
     if (!this.dealtCards.has(drawKey)) {
@@ -219,7 +281,7 @@ export class DemandDeckService {
    * Only applicable to demand cards.
    */
   public returnDealtCardToTop(cardId: number): boolean {
-    if (!this.demandCardMap.has(cardId)) {
+    if (!DemandDeckService.demandCardMap.has(cardId)) {
       return false;
     }
     const drawKey = cardId; // demand card: positive key
@@ -237,7 +299,7 @@ export class DemandDeckService {
    * Only applicable to demand cards.
    */
   public returnDiscardedCardToDealt(cardId: number): boolean {
-    if (!this.demandCardMap.has(cardId)) {
+    if (!DemandDeckService.demandCardMap.has(cardId)) {
       return false;
     }
     const drawKey = cardId; // demand card: positive key
@@ -255,7 +317,7 @@ export class DemandDeckService {
    * Used for rollback compensation when a transaction fails after event cards were discarded.
    */
   public returnDiscardedEventCardToDrawPile(eventCardId: number): boolean {
-    if (!this.eventCardMap.has(eventCardId)) {
+    if (!DemandDeckService.eventCardMap.has(eventCardId)) {
       return false;
     }
     const drawKey = eventDrawKey(eventCardId);
@@ -270,22 +332,22 @@ export class DemandDeckService {
 
   /** Returns all demand cards (legacy accessor). */
   public getAllCards(): DemandCard[] {
-    return [...this.demandCards];
+    return [...DemandDeckService.demandCards];
   }
 
   /** Returns a demand card by ID, or undefined if not found. */
   public getCard(cardId: number): DemandCard | undefined {
-    return this.demandCardMap.get(cardId);
+    return DemandDeckService.demandCardMap.get(cardId);
   }
 
   /** Returns all event card definitions. */
   public getAllEventCards(): EventCard[] {
-    return [...this.eventCards];
+    return [...DemandDeckService.eventCards];
   }
 
   /** Total number of unique cards in the unified pool (demand + event). */
   get totalCardCount(): number {
-    return this.demandCards.length + this.eventCards.length;
+    return DemandDeckService.demandCards.length + DemandDeckService.eventCards.length;
   }
 
   // For debugging/testing purposes
@@ -296,7 +358,7 @@ export class DemandDeckService {
     dealtCardsCount: number
   } {
     return {
-      totalCards: this.demandCards.length + this.eventCards.length,
+      totalCards: DemandDeckService.demandCards.length + DemandDeckService.eventCards.length,
       drawPileSize: this.drawPile.length,
       discardPileSize: this.discardPile.length,
       dealtCardsCount: this.dealtCards.size
@@ -310,7 +372,7 @@ export class DemandDeckService {
    * Debug/testing only.
    */
   public pushEventCardToTop(eventCardId: number): void {
-    const card = this.eventCardMap.get(eventCardId);
+    const card = DemandDeckService.eventCardMap.get(eventCardId);
     if (!card) {
       throw new Error(`Event card ${eventCardId} not found`);
     }
@@ -350,21 +412,19 @@ export class DemandDeckService {
   }
 
   /**
-   * Reset the deck state (for testing)
-   * Returns all dealt cards back to the draw pile and resets state
+   * Reset this game's deck state (for testing).
+   * Rebuilds a fresh, shuffled draw pile from the shared card definitions and
+   * clears the discard/dealt state.
    */
   public reset(): void {
-    this.loadCards(); // Reload cards from JSON configuration to ensure fresh state
-    this.dealtCards.clear();
-    this.discardPile = [];
-    // Reinitialize draw pile with all card IDs (demand + event)
-    this.drawPile = [
-      ...this.demandCards.map(c => c.id),
-      ...this.eventCards.map(c => eventDrawKey(c.id)),
-    ];
-    this.shuffleDrawPile();
+    this.initializeDeck();
   }
 }
 
-// Export a singleton instance
+/**
+ * @deprecated Singleton shim backed by a single shared deck. Prefer
+ * DemandDeckService.getInstanceForGame(gameId) so each game gets an isolated
+ * deck. Retained so existing consumers compile during the per-game migration
+ * (BE-002); removed once they are migrated.
+ */
 export const demandDeckService = DemandDeckService.getInstance();

--- a/src/server/services/playerService.ts
+++ b/src/server/services/playerService.ts
@@ -4,7 +4,7 @@ import { getTrainCapacity } from "../../shared/services/trainProperties";
 import { LoadService } from "./loadService";
 import { QueryResult } from "pg";
 import { v4 as uuidv4 } from "uuid";
-import { demandDeckService } from "./demandDeckService";
+import { DemandDeckService } from "./demandDeckService";
 import { TrackService, getRiverEdgeKeys, segmentCrossesRiver } from "./trackService";
 import { DemandCard } from "../../shared/types/DemandCard";
 import { LoadType } from "../../shared/types/LoadTypes";
@@ -330,6 +330,7 @@ export class PlayerService {
     // ALWAYS draw 3 initial cards server-side (ignore any client-provided cards)
     // Cards must be drawn server-side to ensure proper deck management and prevent duplicates
     // Event cards drawn during initial deal are discarded and replaced per game rules
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     const handCardIds: number[] = [];
     while (handCardIds.length < 3) {
       const drawResult = demandDeckService.drawCard();
@@ -556,6 +557,7 @@ export class PlayerService {
    * @returns Array of players, with hands filtered based on requestingUserId
    */
   static async getPlayers(gameId: string, requestingUserId: string): Promise<Player[]> {
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     const client = await db.connect();
     try {
       const query = `
@@ -626,7 +628,7 @@ export class PlayerService {
             // Reconcile in-memory deck state after server restarts:
             // ensure cards present in DB hands are considered dealt and removed from draw/discard piles.
             demandDeckService.ensureCardIsDealt(cardId);
-            const card = demandDeckService.getCard(cardId);
+            const card = DemandDeckService.getCard(cardId);
             if (!card) {
               console.error(`Failed to find card with ID ${cardId} for player ${row.id}`);
               return null;
@@ -1057,6 +1059,7 @@ export class PlayerService {
     loadType: string,
     cardId: number
   ): Promise<{ newCard: any }> {
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     const client = await db.connect();
     try {
       await client.query('BEGIN');
@@ -1134,6 +1137,7 @@ export class PlayerService {
     | { restricted: true; reason: string }
     | { restricted?: false; payment: number; repayment: number; updatedMoney: number; updatedDebtOwed: number; updatedLoads: LoadType[]; newCard: DemandCard }
   > {
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     const client = await db.connect();
     let drewCardId: number | null = null;
     let discardedCardId: number | null = null;
@@ -1218,7 +1222,7 @@ export class PlayerService {
         throw new Error("Demand card not in hand");
       }
 
-      const demandCard = demandDeckService.getCard(cardId);
+      const demandCard = DemandDeckService.getCard(cardId);
       if (!demandCard) {
         throw new Error("Invalid demand card");
       }
@@ -1790,6 +1794,7 @@ export class PlayerService {
     | { kind: "deliver"; updatedMoney: number; updatedDebtOwed: number; updatedLoads: LoadType[]; restoredCard: DemandCard; removedCardId: number }
     | { kind: "move"; updatedMoney: number; restoredPosition: { row: number; col: number; x?: number; y?: number }; ownersReversed: Array<{ playerId: string; amount: number }>; feeTotal: number }
   > {
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     const client = await db.connect();
     try {
       await client.query("BEGIN");
@@ -1969,7 +1974,7 @@ export class PlayerService {
         throw new Error("Invalid payment on action");
       }
 
-      const restoredCard = demandDeckService.getCard(restoredCardId);
+      const restoredCard = DemandDeckService.getCard(restoredCardId);
       if (!restoredCard) {
         throw new Error("Invalid demand card on action");
       }
@@ -2043,6 +2048,7 @@ export class PlayerService {
     drawnIds: number[],
     discardedEventIds: number[] = []
   ): Promise<{ newHandIds: number[] }> {
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     // Discard old hand (must be currently dealt).
     for (const id of handIds) {
       demandDeckService.discardCard(id);
@@ -2090,6 +2096,7 @@ export class PlayerService {
     gameId: string,
     playerId: string
   ): Promise<{ newHandIds: number[] }> {
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     const client = await db.connect();
     const discardedIds: number[] = [];
     const drawnIds: number[] = [];
@@ -2167,6 +2174,7 @@ export class PlayerService {
     gameId: string,
     userId: string
   ): Promise<{ currentPlayerIndex: number; nextPlayerId: string; nextPlayerName: string }> {
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     const client = await db.connect();
     const discardedIds: number[] = [];
     const drawnIds: number[] = [];
@@ -2358,6 +2366,7 @@ export class PlayerService {
    * Note: Does NOT advance turn or increment current_turn_number.
    */
   static async restartForUser(gameId: string, userId: string): Promise<Player> {
+    const demandDeckService = DemandDeckService.getInstanceForGame(gameId);
     const client = await db.connect();
     const discardedIds: number[] = [];
     const drawnIds: number[] = [];


### PR DESCRIPTION
## Fix multi-game shared deck state (#237) — per-game `DemandDeckService`

Converts the global-singleton demand/event deck to **per-game instances** so concurrent games no longer share draw/discard/dealt state. Covers Compounds tasks **BE-001** and **BE-002** of project *Fix Multi-Game Shared State*.

### BE-001 — `DemandDeckService` → per-game instances
- Card definitions load once into `static` shared config; mutable deck state (draw/discard/dealt) is isolated per game.
- New API: `getInstanceForGame(gameId)`, `destroyInstance(gameId)`, `destroyAllInstances()`. Each instance owns its `gameId` (no `getInstanceForGame(gameId).method(gameId)` smell).

### BE-002 — migrate consumers + definitional/operational split
- **Definitional** reads (`getAllCards` / `getCard` / `getAllEventCards`) are now **static** — "what is printed on a card" never touches a game deck, so callers that only need definitions don't construct an instance.
- **Deck-state** operations stay per-game via `getInstanceForGame(gameId)`.
- Consumers migrated: `playerService` (per-game deck per method), `WorldSnapshotService.capture` and `TurnExecutor` (definitional-only → static `getCard`, no per-game deck), `deckRoutes`.
- `deckRoutes` split: `GET /demand`, `/demand/:cardId`, `/events` are static (no `gameId`); `POST /debug/push-event` & `/debug/reshuffle` require a `gameId`; `POST /reset` clears all decks via `destroyAllInstances()`.
- Removed the transitional singleton shim (`getInstance()` / exported `demandDeckService`) entirely.

### Out of scope
`LoadService` is intentionally **not** converted — its per-game state is DB-backed and keyed by `game_id`; there is no shared in-memory state to isolate. Its consumers (`loadRoutes`, `DeterministicTripPlanner`, `InitialBuildPlanner`) are unchanged.

### Testing
- `tsc --noEmit` clean.
- Full server suite: **155/155 suites, 3376 passed, 0 failed**.
- `deckRoutes` API smoke (supertest): 7/7.
- Test mocks updated for per-game/static access; the ~180 existing `(demandDeckService.x as jest.Mock)` references are preserved via a `jest.requireMock` alias.

### Follow-ups (later tasks in this project)
- BE-003: `BotMemory` / `BotTurnTrigger` cleanup functions.
- BE-004: `cleanupGameState(gameId)` orchestration on game end (VictoryService / `PlayerService.updateGameStatus`).
- TEST-001: broader test modernization (e.g. integration deck-state introspection, remaining vestigial resets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Converts the global-singleton DemandDeckService to per-game instances, isolating draw/discard/dealt state so concurrent games no longer corrupt each other's decks. Card definitions load once into static shared config while mutable deck state is isolated per game via a new getInstanceForGame(gameId) API.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>demandDeckService.ts now uses static card definitions (loaded once) with per-game instance registry — draw/discard/dealt state is isolated per game, preventing cross-game card corruption</li>

<li>PlayerService updated to call getInstanceForGame(gameId) per method instead of using the global singleton — deck operations now respect game boundaries</li>

<li>TurnExecutor and WorldSnapshotService migrated from singleton getInstance() to static getCard() for definitional reads — no deck state required, eliminates unnecessary instance creation</li>

<li>deckRoutes split: GET /demand, /demand/:cardId, /events are now static (no gameId); POST /debug/push-event and /debug/reshuffle now require gameId; POST /reset clears all per-game instances</li>

<li>Removed transitional singleton shim (getInstance and exported demandDeckService) entirely — all consumers now use the per-game or static API</li>

</ul>
</details>

</div>