### PR TITLE
feat(ai): per-game cleanup for BotMemory and BotTurnTrigger state (BE-003)

### DIFF
--- a/src/server/__tests__/ai/BotMemory.test.ts
+++ b/src/server/__tests__/ai/BotMemory.test.ts
@@ -1,0 +1,88 @@
+/**
+ * BotMemory.clearGameMemory tests — BE-003
+ *
+ * Verifies game-scoped in-memory cleanup removes only the target game's
+ * entries, clears the persisted bot_memory for the game's bots, and is
+ * idempotent when called for a game with no remaining state.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+// ── Mock external systems ─────────────────────────────────────────────────
+
+jest.mock('../../db/index', () => ({
+  db: {
+    query: jest.fn<() => Promise<any>>(),
+  },
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────
+
+import { getMemory, updateMemory, clearGameMemory } from '../../services/ai/BotMemory';
+import { db } from '../../db/index';
+
+const mockQuery = db.query as unknown as jest.Mock<(...args: any[]) => Promise<any>>;
+
+function mockResult(rows: any[]) {
+  return { rows, command: '', rowCount: rows.length, oid: 0, fields: [] };
+}
+
+describe('BotMemory.clearGameMemory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: DB reads return no persisted memory, writes succeed.
+    mockQuery.mockResolvedValue(mockResult([]));
+  });
+
+  it('removes only the target game\'s in-memory entries, leaving other games untouched', async () => {
+    await updateMemory('game-A', 'player-1', { deliveryCount: 5 });
+    await updateMemory('game-A', 'player-2', { deliveryCount: 3 });
+    await updateMemory('game-B', 'player-1', { deliveryCount: 9 });
+
+    await clearGameMemory('game-A');
+
+    // game-A entries are gone → getMemory falls back to DB (empty) → default state
+    const clearedA1 = await getMemory('game-A', 'player-1');
+    const clearedA2 = await getMemory('game-A', 'player-2');
+    expect(clearedA1.deliveryCount).toBe(0);
+    expect(clearedA2.deliveryCount).toBe(0);
+
+    // game-B entry is preserved in the in-memory Map
+    const preservedB = await getMemory('game-B', 'player-1');
+    expect(preservedB.deliveryCount).toBe(9);
+  });
+
+  it('issues a game-scoped DB clear for the game\'s bots', async () => {
+    await updateMemory('game-C', 'player-1', { deliveryCount: 2 });
+    mockQuery.mockClear();
+
+    await clearGameMemory('game-C');
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      'UPDATE players SET bot_memory = NULL WHERE game_id = $1 AND is_bot = true',
+      ['game-C'],
+    );
+  });
+
+  it('is idempotent — clearing a game with no entries does not throw', async () => {
+    await expect(clearGameMemory('nonexistent-game')).resolves.toBeUndefined();
+    await expect(clearGameMemory('nonexistent-game')).resolves.toBeUndefined();
+  });
+
+  it('ignores an empty gameId without touching the DB', async () => {
+    mockQuery.mockClear();
+    await clearGameMemory('');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('swallows DB errors so cleanup never throws', async () => {
+    await updateMemory('game-D', 'player-1', { deliveryCount: 1 });
+    mockQuery.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(clearGameMemory('game-D')).resolves.toBeUndefined();
+
+    // In-memory entry is still removed even though the DB write failed
+    const cleared = await getMemory('game-D', 'player-1');
+    expect(cleared.deliveryCount).toBe(0);
+  });
+});

--- a/src/server/__tests__/ai/BotTurnTrigger.test.ts
+++ b/src/server/__tests__/ai/BotTurnTrigger.test.ts
@@ -71,7 +71,7 @@ jest.mock('../../services/ai/connectedMajorCities', () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────
 
-import { onTurnChange, pendingBotTurns, checkBotVictory, queuedBotTurns, onHumanReconnect } from '../../services/ai/BotTurnTrigger';
+import { onTurnChange, pendingBotTurns, checkBotVictory, queuedBotTurns, onHumanReconnect, cleanupBotTurnState } from '../../services/ai/BotTurnTrigger';
 import { AIStrategyEngine } from '../../services/ai/AIStrategyEngine';
 import { db } from '../../db/index';
 import { emitToGame, emitVictoryTriggered, emitGameOver } from '../../services/socketService';
@@ -907,5 +907,44 @@ describe('BotTurnTrigger — stuck bot recovery on reconnect', () => {
     await new Promise(resolve => setTimeout(resolve, 100));
 
     expect(mockTakeTurn).not.toHaveBeenCalled();
+  });
+});
+
+describe('BotTurnTrigger.cleanupBotTurnState — BE-003', () => {
+  beforeEach(() => {
+    pendingBotTurns.clear();
+    queuedBotTurns.clear();
+  });
+
+  it('removes both pending and queued entries for the target game', () => {
+    pendingBotTurns.add('game-A');
+    queuedBotTurns.set('game-A', { gameId: 'game-A', currentPlayerIndex: 0, currentPlayerId: 'p1' });
+
+    cleanupBotTurnState('game-A');
+
+    expect(pendingBotTurns.has('game-A')).toBe(false);
+    expect(queuedBotTurns.has('game-A')).toBe(false);
+  });
+
+  it('leaves other games\' tracking state untouched', () => {
+    pendingBotTurns.add('game-A');
+    pendingBotTurns.add('game-B');
+    queuedBotTurns.set('game-B', { gameId: 'game-B', currentPlayerIndex: 1, currentPlayerId: 'p2' });
+
+    cleanupBotTurnState('game-A');
+
+    expect(pendingBotTurns.has('game-B')).toBe(true);
+    expect(queuedBotTurns.has('game-B')).toBe(true);
+  });
+
+  it('is idempotent — cleaning a game with no tracked state does not throw', () => {
+    expect(() => cleanupBotTurnState('nonexistent-game')).not.toThrow();
+    expect(() => cleanupBotTurnState('nonexistent-game')).not.toThrow();
+  });
+
+  it('ignores an empty gameId', () => {
+    pendingBotTurns.add('game-A');
+    cleanupBotTurnState('');
+    expect(pendingBotTurns.has('game-A')).toBe(true);
   });
 });

--- a/src/server/services/ai/BotMemory.ts
+++ b/src/server/services/ai/BotMemory.ts
@@ -124,3 +124,29 @@ export async function clearMemory(gameId: string, playerId: string): Promise<voi
     console.error(`[BotMemory] Failed to clear memory in DB for player ${playerId}:`, err);
   }
 }
+
+/**
+ * Clear all bot memory for an entire game at game end.
+ * Removes every in-memory entry keyed to this game (keys are `${gameId}:${playerId}`)
+ * and best-effort clears the persisted bot_memory for the game's bots.
+ * Idempotent — a gameId with no matching entries is a no-op.
+ */
+export async function clearGameMemory(gameId: string): Promise<void> {
+  if (!gameId) return;
+
+  const prefix = `${gameId}:`;
+  for (const key of memoryStore.keys()) {
+    if (key.startsWith(prefix)) {
+      memoryStore.delete(key);
+    }
+  }
+
+  try {
+    await db.query(
+      'UPDATE players SET bot_memory = NULL WHERE game_id = $1 AND is_bot = true',
+      [gameId],
+    );
+  } catch (err) {
+    console.error(`[BotMemory] Failed to clear game memory in DB for game ${gameId}:`, err);
+  }
+}

--- a/src/server/services/ai/BotTurnTrigger.ts
+++ b/src/server/services/ai/BotTurnTrigger.ts
@@ -76,6 +76,18 @@ interface QueuedTurn {
 export const queuedBotTurns = new Map<string, QueuedTurn>();
 
 /**
+ * Remove all in-memory bot-turn tracking for a game at game end.
+ * Both collections are keyed directly by gameId, so completed/abandoned games
+ * don't leak guard-set or queued-turn entries. Idempotent — a gameId with no
+ * tracked state is a no-op.
+ */
+export function cleanupBotTurnState(gameId: string): void {
+  if (!gameId) return;
+  pendingBotTurns.delete(gameId);
+  queuedBotTurns.delete(gameId);
+}
+
+/**
  * Check whether any human player has an active socket connection to the game room.
  * Uses Socket.IO room membership — bots don't have sockets, so any connected
  * socket in the room must belong to a human player.


### PR DESCRIPTION
## Summary
Implements **BE-003** of the *Fix Multi-Game Shared State* project — dedicated cleanup functions for AI in-memory state so completed/abandoned games don't leak per-game entries.

- **`BotMemory.clearGameMemory(gameId)`** — removes every `memoryStore` entry keyed `${gameId}:${playerId}` for the game, and best-effort clears persisted rows via `UPDATE players SET bot_memory = NULL WHERE game_id = $1 AND is_bot = true` (mirrors existing `clearMemory`; errors logged, not thrown).
- **`BotTurnTrigger.cleanupBotTurnState(gameId)`** — `pendingBotTurns` (Set) and `queuedBotTurns` (Map) are keyed directly by `gameId`, so this directly deletes the game's entries in each. (Note: implemented as a direct `.delete(gameId)` rather than the iterate-and-substring-match the task described, because the collections are keyed by the gameId itself — code is ground truth.)

Both functions are idempotent and no-op on an empty `gameId`. These support the game-end cleanup orchestration coming in BE-004.

## Tests
- New `BotMemory.test.ts`: removal isolation, game-scoped DB clear, idempotency, empty-gameId guard, DB-error swallowing.
- Appended `cleanupBotTurnState` block to `BotTurnTrigger.test.ts`: removal of both collections, isolation of other games, idempotency, empty-gameId guard.

**36 passed / 36**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Implements BE-003 of the Fix Multi-Game Shared State project by adding two dedicated per-game cleanup functions to the AI module — BotMemory.clearGameMemory removes all in-memory bot entries and best-effort clears persisted database rows for a game's bots, while BotTurnTrigger.cleanupBotTurnState removes tracking entries from the pendingBotTurns Set and queuedBotTurns Map. Both functions are idempotent, guard against empty gameIds, and support the game-end cleanup orchestration coming in BE-004.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds clearGameMemory(gameId) to BotMemory.ts — iterates memoryStore Map using `${gameId}:` key prefix to remove all bot memory entries, and executes DB UPDATE to clear persisted bot_memory for the game's bots with errors logged silently</li>

<li>Adds cleanupBotTurnState(gameId) to BotTurnTrigger.ts — directly deletes gameId entries from pendingBotTurns (Set) and queuedBotTurns (Map) for efficient O(1) removal since collections are keyed by gameId</li>

<li>Adds new test suite BotMemory.test.ts with 5 test cases covering in-memory removal isolation, game-scoped DB clear, idempotency, empty-gameId guard, and DB-error swallowing</li>

<li>Appends 4 test cases to BotTurnTrigger.test.ts covering removal of both collections, isolation of other games' state, idempotency, and empty-gameId guard</li>

</ul>
</details>

</div>