### PR TITLE
feat(cleanup): orchestrate game-end cleanup for per-game services and AI state (BE-004)

### DIFF
--- a/src/server/__tests__/gameCleanupService.test.ts
+++ b/src/server/__tests__/gameCleanupService.test.ts
@@ -1,0 +1,89 @@
+import { cleanupGameState } from '../services/gameCleanupService';
+
+// Mock every per-game cleanup routine so we can assert the orchestration in
+// isolation, without a real deck, bot memory store, or database.
+jest.mock('../services/demandDeckService', () => ({
+  DemandDeckService: {
+    destroyInstance: jest.fn(),
+  },
+}));
+jest.mock('../services/ai/BotMemory', () => ({
+  clearGameMemory: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/ai/BotTurnTrigger', () => ({
+  cleanupBotTurnState: jest.fn(),
+}));
+
+import { DemandDeckService } from '../services/demandDeckService';
+import { clearGameMemory } from '../services/ai/BotMemory';
+import { cleanupBotTurnState } from '../services/ai/BotTurnTrigger';
+
+const destroyInstance = DemandDeckService.destroyInstance as jest.Mock;
+const clearGameMemoryMock = clearGameMemory as jest.Mock;
+const cleanupBotTurnStateMock = cleanupBotTurnState as jest.Mock;
+
+describe('gameCleanupService.cleanupGameState', () => {
+  const gameId = 'game-be004';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearGameMemoryMock.mockResolvedValue(undefined);
+  });
+
+  it('invokes every per-game cleanup routine with the gameId', async () => {
+    await cleanupGameState(gameId);
+
+    expect(destroyInstance).toHaveBeenCalledTimes(1);
+    expect(destroyInstance).toHaveBeenCalledWith(gameId);
+    expect(cleanupBotTurnStateMock).toHaveBeenCalledTimes(1);
+    expect(cleanupBotTurnStateMock).toHaveBeenCalledWith(gameId);
+    expect(clearGameMemoryMock).toHaveBeenCalledTimes(1);
+    expect(clearGameMemoryMock).toHaveBeenCalledWith(gameId);
+  });
+
+  it('is a no-op for an empty gameId', async () => {
+    await cleanupGameState('');
+
+    expect(destroyInstance).not.toHaveBeenCalled();
+    expect(cleanupBotTurnStateMock).not.toHaveBeenCalled();
+    expect(clearGameMemoryMock).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — calling twice for the same game does not throw and cleans each time', async () => {
+    await cleanupGameState(gameId);
+    await expect(cleanupGameState(gameId)).resolves.toBeUndefined();
+
+    expect(destroyInstance).toHaveBeenCalledTimes(2);
+    expect(cleanupBotTurnStateMock).toHaveBeenCalledTimes(2);
+    expect(clearGameMemoryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('is best-effort — a failure in one routine does not prevent the others', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    destroyInstance.mockImplementationOnce(() => {
+      throw new Error('deck boom');
+    });
+
+    await expect(cleanupGameState(gameId)).resolves.toBeUndefined();
+
+    // Even though the deck cleanup threw, the remaining routines still ran.
+    expect(cleanupBotTurnStateMock).toHaveBeenCalledWith(gameId);
+    expect(clearGameMemoryMock).toHaveBeenCalledWith(gameId);
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
+  it('swallows and logs an async bot-memory clear failure', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    clearGameMemoryMock.mockRejectedValueOnce(new Error('memory boom'));
+
+    await expect(cleanupGameState(gameId)).resolves.toBeUndefined();
+
+    expect(destroyInstance).toHaveBeenCalledWith(gameId);
+    expect(cleanupBotTurnStateMock).toHaveBeenCalledWith(gameId);
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/server/__tests__/gameCleanupWiring.test.ts
+++ b/src/server/__tests__/gameCleanupWiring.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Verifies that the game-end call sites are wired to cleanupGameState:
+ *   - VictoryService.resolveVictory() cleans up when a game is truly over.
+ *   - PlayerService.updateGameStatus() cleans up on 'completed'/'abandoned'.
+ *
+ * db and gameCleanupService are mocked so these run without a real database
+ * and assert only the orchestration wiring (the cleanup itself is covered by
+ * gameCleanupService.test.ts).
+ */
+jest.mock('../db/index', () => ({
+  db: { query: jest.fn() },
+}));
+jest.mock('../services/gameCleanupService', () => ({
+  cleanupGameState: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { db } from '../db/index';
+import { cleanupGameState } from '../services/gameCleanupService';
+import { VictoryService } from '../services/victoryService';
+import { PlayerService } from '../services/playerService';
+import { GameStatus } from '../../shared/types/GameTypes';
+
+const mockQuery = db.query as jest.Mock;
+const cleanupMock = cleanupGameState as jest.Mock;
+
+describe('game-end cleanup wiring', () => {
+  const gameId = 'game-wiring';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockResolvedValue({ rows: [] });
+  });
+
+  describe('VictoryService.resolveVictory', () => {
+    it('cleans up per-game state when there is a clear winner', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 'winner-1', name: 'Winner', money: 300, debt_owed: 0, net_worth: 300 }],
+        }) // players
+        .mockResolvedValueOnce({ rows: [{ victory_threshold: 250 }] }) // games threshold
+        .mockResolvedValueOnce({ rows: [] }); // UPDATE games ... completed
+
+      const result = await VictoryService.resolveVictory(gameId);
+
+      expect(result.gameOver).toBe(true);
+      expect(cleanupMock).toHaveBeenCalledTimes(1);
+      expect(cleanupMock).toHaveBeenCalledWith(gameId);
+    });
+
+    it('does not clean up when no player meets the threshold (game not over)', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 'p1', name: 'P1', money: 100, debt_owed: 0, net_worth: 100 }],
+        }) // players
+        .mockResolvedValueOnce({ rows: [{ victory_threshold: 250 }] }); // games threshold
+
+      const result = await VictoryService.resolveVictory(gameId);
+
+      expect(result.gameOver).toBe(false);
+      expect(cleanupMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PlayerService.updateGameStatus', () => {
+    it('cleans up when the game transitions to completed', async () => {
+      await PlayerService.updateGameStatus(gameId, 'completed' as GameStatus);
+
+      expect(cleanupMock).toHaveBeenCalledTimes(1);
+      expect(cleanupMock).toHaveBeenCalledWith(gameId);
+    });
+
+    it('cleans up when the game transitions to abandoned', async () => {
+      await PlayerService.updateGameStatus(gameId, 'abandoned' as GameStatus);
+
+      expect(cleanupMock).toHaveBeenCalledTimes(1);
+      expect(cleanupMock).toHaveBeenCalledWith(gameId);
+    });
+
+    it('does not clean up for a non-terminal status', async () => {
+      await PlayerService.updateGameStatus(gameId, 'active' as GameStatus);
+
+      expect(cleanupMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/services/gameCleanupService.ts
+++ b/src/server/services/gameCleanupService.ts
@@ -1,0 +1,41 @@
+import { DemandDeckService } from './demandDeckService';
+import { clearGameMemory } from './ai/BotMemory';
+import { cleanupBotTurnState } from './ai/BotTurnTrigger';
+
+/**
+ * Release all per-game in-memory state when a game reaches a terminal state
+ * (completed or abandoned). Consolidates every per-game cleanup routine so
+ * game-end call sites have a single hook and no cleanup step is forgotten.
+ *
+ * Idempotent: each underlying cleanup is a no-op for an unknown game, so calling
+ * this multiple times for the same `gameId` is safe. Best-effort: a failure in
+ * one cleanup is logged and does not prevent the others from running.
+ *
+ * Note: `LoadService` is intentionally NOT cleaned up here. Unlike the demand
+ * deck and bot state, its per-game state is DB-backed (rows keyed by
+ * `game_id`), not an in-memory per-game instance — there is nothing in memory
+ * to destroy. See the "Fix Multi-Game Shared State" scope decision.
+ */
+export async function cleanupGameState(gameId: string): Promise<void> {
+  if (!gameId) {
+    return;
+  }
+
+  try {
+    DemandDeckService.destroyInstance(gameId);
+  } catch (err) {
+    console.error(`[gameCleanup] Failed to destroy demand deck for game ${gameId}:`, err);
+  }
+
+  try {
+    cleanupBotTurnState(gameId);
+  } catch (err) {
+    console.error(`[gameCleanup] Failed to clean bot turn state for game ${gameId}:`, err);
+  }
+
+  try {
+    await clearGameMemory(gameId);
+  } catch (err) {
+    console.error(`[gameCleanup] Failed to clear bot memory for game ${gameId}:`, err);
+  }
+}

--- a/src/server/services/playerService.ts
+++ b/src/server/services/playerService.ts
@@ -15,6 +15,7 @@ import { TrackSegment } from "../../shared/types/TrackTypes";
 import { EventCardService } from "./EventCardService";
 import { activeEffectManager } from "./ActiveEffectManager";
 import { EventCardType, EventCardResult, EventCard } from "../../shared/types/EventCard";
+import { cleanupGameState } from "./gameCleanupService";
 
 type TurnActionDeliver = {
   kind: "deliver";
@@ -1030,11 +1031,18 @@ export class PlayerService {
     }
 
     const query = `
-            UPDATE games 
+            UPDATE games
             SET status = $1, updated_at = CURRENT_TIMESTAMP
             WHERE id = $2
         `;
     await db.query(query, [finalStatus, gameId]);
+
+    // When a game reaches a terminal state, release its per-game in-memory
+    // state. Idempotent, so it is safe even if the game was already cleaned up
+    // via another path (e.g. VictoryService.resolveVictory).
+    if (finalStatus === "completed" || finalStatus === "abandoned") {
+      await cleanupGameState(gameId);
+    }
   }
 
   static async endAllActiveGames(): Promise<void> {

--- a/src/server/services/victoryService.ts
+++ b/src/server/services/victoryService.ts
@@ -2,6 +2,7 @@ import { db } from '../db';
 import { VictoryState, VICTORY_INITIAL_THRESHOLD, VICTORY_TIE_THRESHOLD } from '../../shared/types/GameTypes';
 import { TrackService } from './trackService';
 import { TrackSegment } from '../../shared/types/TrackTypes';
+import { cleanupGameState } from './gameCleanupService';
 
 export interface MajorCityCoordinate {
   name: string;
@@ -237,6 +238,9 @@ export class VictoryService {
         [gameId, winner.id]
       );
 
+      // Game is over — release per-game in-memory state.
+      await cleanupGameState(gameId);
+
       return {
         gameOver: true,
         winnerId: winner.id,
@@ -270,6 +274,9 @@ export class VictoryService {
       `UPDATE games SET status = 'completed', winner_id = $2 WHERE id = $1`,
       [gameId, winner.id]
     );
+
+    // Game is over — release per-game in-memory state.
+    await cleanupGameState(gameId);
 
     return {
       gameOver: true,


### PR DESCRIPTION
## Summary

BE-004 of the **Fix Multi-Game Shared State** project (#237). Adds a single game-end cleanup hook that releases per-game in-memory state so completed/abandoned games don't leak deck, bot-turn, or bot-memory state across the process.

- **New `src/server/services/gameCleanupService.ts`** — `cleanupGameState(gameId)` orchestrates the three per-game cleanups that exist:
  - `DemandDeckService.destroyInstance(gameId)`
  - `cleanupBotTurnState(gameId)`
  - `await clearGameMemory(gameId)`
  - Idempotent, guards empty `gameId`, and best-effort (each call wrapped so one failure logs and doesn't block the others).
- **Wired into two game-end call sites:**
  - `VictoryService.resolveVictory()` — after both `status='completed'` UPDATE branches.
  - `PlayerService.updateGameStatus()` — on `completed` / `abandoned`.

## Two deviations from the task spec (code was ground truth)

1. **Dropped `LoadService.destroyInstance(gameId)`.** `LoadService` is still a plain singleton with DB-backed per-game state (keyed by `game_id`); it has no `destroyInstance` and was deliberately excluded from the per-game refactor (BE-001 scope). Calling it would not compile. The exclusion is documented in the new file's header.
2. **Hooked `resolveVictory()`, not `declareVictory()`.** The spec named `declareVictory()` "~line 236," but line 236 is inside `resolveVictory()`. `declareVictory()` only sets `victory_triggered`; `resolveVictory()` is where `status='completed'` is set and the game truly ends.

## Tests

- `gameCleanupService.test.ts` — orchestration, idempotency, empty-id no-op, best-effort resilience (sync + async failure paths).
- `gameCleanupWiring.test.ts` — both call sites invoke cleanup with the gameId; negative cases (game-not-over, non-terminal status) do not.
- Full typecheck clean. Service-layer only — no routes changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
