### PR TITLE
test(ai): TEST-001 — per-game instance test coverage + build hygiene

### DIFF
--- a/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
+++ b/src/server/__tests__/demandDeckService.unifiedDraw.test.ts
@@ -370,6 +370,20 @@ describe('DemandDeckService unified draw pile', () => {
       expect(second.getDeckState().drawPileSize).toBe(166);
     });
 
+    it('should leave other games untouched when one game is destroyed', () => {
+      const a = DemandDeckService.getInstanceForGame('game-A');
+      const b = DemandDeckService.getInstanceForGame('game-B');
+      b.drawCard();
+      b.drawCard();
+
+      DemandDeckService.destroyInstance('game-A');
+
+      // game-B's instance and its deck state must survive game-A's teardown.
+      expect(DemandDeckService.getInstanceForGame('game-B')).toBe(b);
+      expect(b.getDeckState().dealtCardsCount).toBe(2);
+      expect(b.getDeckState().drawPileSize).toBe(164);
+    });
+
     it('should treat destroyInstance for an unknown game as a no-op', () => {
       expect(() => DemandDeckService.destroyInstance('never-created')).not.toThrow();
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
     "sourceRoot": "./src",
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]
 } 


### PR DESCRIPTION
## Summary

Closes out **TEST-001** (final task of the *Fix Multi-Game Shared State* project, `61dca06c`).

Investigation found TEST-001's substance was already delivered incrementally alongside BE-001–BE-004 (per-game `DemandDeckService` instance mgmt + deck-state isolation, `BotMemory.clearGameMemory` / `BotTurnTrigger.cleanupBotTurnState` cleanup, `gameCleanupService` wiring, and 7 consumer test files using `getInstanceForGame`). This PR fills the one genuine gap plus a build-hygiene fix.

## Changes

- **`demandDeckService.unifiedDraw.test.ts`** — new test asserting `destroyInstance('game-A')` leaves game-B's instance and deck state intact (the destroy-path cross-game isolation that `BotMemory` already covered but `DemandDeckService` did not).
- **`tsconfig.json`** — exclude `__tests__` / `*.test.ts(x)` from the build so `npm run build` no longer emits compiled test files into `dist/`. Those stale compiled artifacts were surfacing as phantom IDE errors (`LoadService.getSourceCitiesForLoad is not a function`) from a pre-refactor cached run.

## Not done, by design

`LoadService` per-game subtasks were **not** implemented — it is DB-isolated (state keyed by `game_id` in SQL) with no per-game in-memory instance and no `getInstanceForGame`. Building those tests would require inventing a non-existent API, violating the project's refactor-discipline rule (code is ground truth).

## Verification

- `npm run build` — clean; `dist/` now contains zero compiled test files, production entry intact.
- `npm test` — **3905 passed, 24 skipped, 0 failed** across 194 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Completes TEST-001 by adding test coverage for cross-game instance isolation in DemandDeckService and fixing build configuration to exclude test files from TypeScript compilation. The new test verifies that destroying one game's DemandDeckService instance does not affect another game's instance or its deck state.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds test 'should leave other games untouched when one game is destroyed' in demandDeckService.unifiedDraw.test.ts that verifies calling destroyInstance('game-A') preserves game-B's DemandDeckService instance reference and its deck state (dealtCardsCount and drawPileSize).</li>

<li>Updates tsconfig.json exclude array to include '**/__tests__/**', '**/*.test.ts', and '**/*.test.tsx' patterns, preventing test files from being compiled into dist/ and resolving phantom IDE errors from stale artifacts.</li>

<li>Confirms test suite runs clean at 3905 passed, 24 skipped, 0 failed across 194 suites.</li>

</ul>
</details>

</div>