### PR TITLE
fix: queue back-to-back event card overlays instead of overwriting

### DIFF
--- a/src/client/__tests__/lobby/game.store.event.test.ts
+++ b/src/client/__tests__/lobby/game.store.event.test.ts
@@ -83,6 +83,7 @@ const resetStore = () => {
   useGameStore.setState({
     activeEffects: [],
     pendingEventOverlay: null,
+    eventOverlayQueue: [],
     pendingVisualUpdates: [],
     eventCardCache: new Map(),
     gameState: null,
@@ -110,6 +111,10 @@ describe('Game Store — Event Management (FE-001)', () => {
 
     it('initializes pendingEventOverlay as null', () => {
       expect(useGameStore.getState().pendingEventOverlay).toBeNull();
+    });
+
+    it('initializes eventOverlayQueue as empty array', () => {
+      expect(useGameStore.getState().eventOverlayQueue).toEqual([]);
     });
 
     it('initializes pendingVisualUpdates as empty array', () => {
@@ -148,31 +153,62 @@ describe('Game Store — Event Management (FE-001)', () => {
       expect(useGameStore.getState().pendingEventOverlay).toBeNull();
     });
 
-    it('replaces an existing overlay (resets auto-dismiss timer)', () => {
+    it('queues a second overlay behind the first instead of overwriting it', () => {
+      const payload1 = makeDrawnPayload(125);
+      const payload2 = makeDrawnPayload(126);
+
+      act(() => {
+        useGameStore.getState().showEventOverlay(payload1);
+        useGameStore.getState().showEventOverlay(payload2);
+      });
+
+      // First card stays visible; second is queued (not swallowed).
+      expect(useGameStore.getState().pendingEventOverlay?.card.id).toBe(125);
+      expect(useGameStore.getState().eventOverlayQueue).toHaveLength(1);
+      expect(useGameStore.getState().eventOverlayQueue[0].card.id).toBe(126);
+    });
+
+    it('does NOT reset the current card\'s auto-dismiss timer when a second is queued', () => {
       const payload1 = makeDrawnPayload(125);
       const payload2 = makeDrawnPayload(126);
 
       act(() => {
         useGameStore.getState().showEventOverlay(payload1);
       });
-      // Advance 15s — should NOT dismiss yet
+      // Advance 15s, then queue a second card.
       act(() => {
         jest.advanceTimersByTime(15_000);
+        useGameStore.getState().showEventOverlay(payload2);
       });
       expect(useGameStore.getState().pendingEventOverlay?.card.id).toBe(125);
 
-      // Show a second overlay — timer should reset
-      act(() => {
-        useGameStore.getState().showEventOverlay(payload2);
-      });
-      expect(useGameStore.getState().pendingEventOverlay?.card.id).toBe(126);
-
-      // Advance another 15s (total 30s from first show, 15s from second show)
+      // Advance another 15s → 30s total from the first show. The first card's
+      // timer fires (it was NOT reset), auto-dismissing it and promoting the queued card.
       act(() => {
         jest.advanceTimersByTime(15_000);
       });
-      // Overlay should still be visible (30s from second show not elapsed)
-      expect(useGameStore.getState().pendingEventOverlay).not.toBeNull();
+      expect(useGameStore.getState().pendingEventOverlay?.card.id).toBe(126);
+      expect(useGameStore.getState().eventOverlayQueue).toHaveLength(0);
+    });
+
+    it('adds a persistent card to activeEffects immediately even while queued behind another', () => {
+      const immediate = makeDrawnPayload(124); // duration: 'immediate' by default
+      const persistent: EventCardDrawnPayload = {
+        ...makeDrawnPayload(130),
+        card: { ...makeDrawnPayload(130).card, id: 130, type: EventCardType.Snow },
+        duration: 'persistent',
+      };
+
+      act(() => {
+        useGameStore.getState().showEventOverlay(immediate);
+        useGameStore.getState().showEventOverlay(persistent);
+      });
+
+      // Persistent card is still queued for its popup...
+      expect(useGameStore.getState().pendingEventOverlay?.card.id).toBe(124);
+      expect(useGameStore.getState().eventOverlayQueue[0].card.id).toBe(130);
+      // ...but its effect is already reflected in the HUD-driving activeEffects.
+      expect(useGameStore.getState().activeEffects.some(e => e.cardId === 130)).toBe(true);
     });
   });
 
@@ -211,6 +247,62 @@ describe('Game Store — Event Management (FE-001)', () => {
         useGameStore.getState().dismissEventOverlay();
       });
       expect(useGameStore.getState().pendingVisualUpdates).toHaveLength(0);
+    });
+
+    it('promotes the next queued overlay on dismiss, then clears on the final dismiss', () => {
+      const payload1 = makeDrawnPayload(125);
+      const payload2 = makeDrawnPayload(126);
+
+      act(() => {
+        useGameStore.getState().showEventOverlay(payload1);
+        useGameStore.getState().showEventOverlay(payload2);
+      });
+
+      // Dismiss first → second is promoted.
+      act(() => {
+        useGameStore.getState().dismissEventOverlay();
+      });
+      expect(useGameStore.getState().pendingEventOverlay?.card.id).toBe(126);
+      expect(useGameStore.getState().eventOverlayQueue).toHaveLength(0);
+
+      // Dismiss second → nothing left.
+      act(() => {
+        useGameStore.getState().dismissEventOverlay();
+      });
+      expect(useGameStore.getState().pendingEventOverlay).toBeNull();
+    });
+
+    it('does not flush queued visual updates until the last overlay is dismissed', () => {
+      useGameStore.setState({ gameState: makeGameState() });
+
+      const payload1 = makeDrawnPayload(125);
+      const payload2 = makeDrawnPayload(126);
+      act(() => {
+        useGameStore.getState().showEventOverlay(payload1);
+        useGameStore.getState().showEventOverlay(payload2);
+      });
+
+      // Queue a visual update while overlays are showing.
+      act(() => {
+        useGameStore.getState().enqueueVisualUpdate({
+          kind: 'generic_patch',
+          patch: { currentTurnUserId: 'u2' },
+        });
+      });
+
+      // Dismiss the first — an overlay is still active, so updates must remain queued.
+      act(() => {
+        useGameStore.getState().dismissEventOverlay();
+      });
+      expect(useGameStore.getState().pendingVisualUpdates).toHaveLength(1);
+      expect(useGameStore.getState().gameState?.currentTurnUserId).toBe('u1');
+
+      // Dismiss the last — now updates flush and apply.
+      act(() => {
+        useGameStore.getState().dismissEventOverlay();
+      });
+      expect(useGameStore.getState().pendingVisualUpdates).toHaveLength(0);
+      expect(useGameStore.getState().gameState?.currentTurnUserId).toBe('u2');
     });
 
     it('cancels the auto-dismiss timer on manual dismiss', () => {

--- a/src/client/lobby/store/game.store.ts
+++ b/src/client/lobby/store/game.store.ts
@@ -26,6 +26,8 @@ interface GameStoreState {
   activeEffects: ActiveEffectSummary[];
   /** Event card overlay awaiting player acknowledgment */
   pendingEventOverlay: EventCardDrawnPayload | null;
+  /** Event overlays drawn while another is still showing, shown FIFO after dismissal */
+  eventOverlayQueue: EventCardDrawnPayload[];
   /** Visual mutations queued while an event overlay is visible */
   pendingVisualUpdates: QueuedUpdate[];
   /** Client-side cache of event card definitions, keyed by card ID */
@@ -66,6 +68,17 @@ type GameStore = GameStoreState & GameStoreActions;
 /** Module-level timer handle for auto-dismiss (cleared on manual dismiss) */
 let overlayAutoDismissTimer: ReturnType<typeof setTimeout> | null = null;
 
+/**
+ * (Re)start the auto-dismiss timer for the currently shown event overlay.
+ * Clears any existing timer first so only one is ever pending.
+ */
+function startOverlayAutoDismiss(dismiss: () => void): void {
+  if (overlayAutoDismissTimer !== null) {
+    clearTimeout(overlayAutoDismissTimer);
+  }
+  overlayAutoDismissTimer = setTimeout(dismiss, EVENT_OVERLAY_AUTO_DISMISS_MS);
+}
+
 export const useGameStore = create<GameStore>((set, get) => ({
   // Initial state
   gameState: null,
@@ -76,6 +89,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   connectionStatus: 'disconnected',
   activeEffects: [],
   pendingEventOverlay: null,
+  eventOverlayQueue: [],
   pendingVisualUpdates: [],
   eventCardCache: new Map(),
 
@@ -173,6 +187,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
       connectionStatus: 'disconnected',
       clientSeq: 0,
       pendingEventOverlay: null,
+      eventOverlayQueue: [],
       pendingVisualUpdates: [],
       activeEffects: [],
     });
@@ -305,16 +320,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
   },
 
   showEventOverlay: (payload: EventCardDrawnPayload) => {
-    // Clear any existing auto-dismiss timer
-    if (overlayAutoDismissTimer !== null) {
-      clearTimeout(overlayAutoDismissTimer);
-    }
-
-    set({ pendingEventOverlay: payload });
-
-    // For persistent effects, immediately add to activeEffects so the HUD updates.
-    // The server only broadcasts event:active-effects on reconnect, so we derive
-    // an ActiveEffectSummary from the drawn card payload here.
+    // For persistent effects, immediately add to activeEffects so the HUD updates,
+    // regardless of the card's position in the popup queue. The server only
+    // broadcasts event:active-effects on reconnect, so we derive an
+    // ActiveEffectSummary from the drawn card payload here.
     if (payload.duration === 'persistent') {
       get().addActiveEffect({
         cardId: payload.card.id,
@@ -327,10 +336,19 @@ export const useGameStore = create<GameStore>((set, get) => ({
       });
     }
 
-    // Start a 30-second auto-dismiss timer
-    overlayAutoDismissTimer = setTimeout(() => {
-      get().dismissEventOverlay();
-    }, EVENT_OVERLAY_AUTO_DISMISS_MS);
+    // If an overlay is already showing, enqueue this one (FIFO) rather than
+    // overwriting the current popup — back-to-back event cards must each be
+    // shown and acknowledged. Do not touch the current card's dismiss timer.
+    if (get().pendingEventOverlay !== null) {
+      set(state => ({
+        eventOverlayQueue: [...state.eventOverlayQueue, payload],
+      }));
+      return;
+    }
+
+    // No overlay showing — display this one and start its auto-dismiss timer.
+    set({ pendingEventOverlay: payload });
+    startOverlayAutoDismiss(() => get().dismissEventOverlay());
   },
 
   dismissEventOverlay: () => {
@@ -340,9 +358,19 @@ export const useGameStore = create<GameStore>((set, get) => ({
       overlayAutoDismissTimer = null;
     }
 
+    // Promote the next queued overlay, if any. An overlay remains active, so
+    // visual mutations stay gated — do NOT flush pending visual updates yet.
+    const queue = get().eventOverlayQueue;
+    if (queue.length > 0) {
+      const [next, ...rest] = queue;
+      set({ pendingEventOverlay: next, eventOverlayQueue: rest });
+      startOverlayAutoDismiss(() => get().dismissEventOverlay());
+      return;
+    }
+
     set({ pendingEventOverlay: null });
 
-    // Flush all queued visual updates now that overlay is dismissed
+    // No overlay remains — flush all queued visual updates now.
     get().flushPendingVisualUpdates();
   },
 


### PR DESCRIPTION
## Problem

During a live game, two bots took turns after the player. Bot 1 drew **Snow #130** (persistent) via a `DiscardHand` fallback; Bot 2 then drew **Excess Profit Tax #124** (immediate) via `deliverLoad` moments later. The player saw the #124 popup but **not** the #130 popup — even though #130 was recorded as the active event and showed in the hand-area HUD.

## Root cause

The client held a single event-overlay slot. When a second `event:card-drawn` arrived while the first popup was still undismissed (30s auto-dismiss window), the subscription at `GameScene.ts:1481-1484` destroyed the first overlay and showed the second — and `EventCardOverlay.destroy()` bypasses `onDismiss`, so the swallowed card was never acknowledged and its gated visual patches were never flushed. Snow (persistent) still appeared in the HUD because persistent effects populate `activeEffects` independently — that part is by design.

This is a general "back-to-back events collide in a single overlay slot with no queue" defect, not specific to one draw loop and **not** caused by the AI code path (bot redraw uses the same `discardHandCore` → `flushEventEmissions` → `emitEventCardDrawn` path as a human).

## Fix (client-only, `src/client/lobby/store/game.store.ts`)

- Add `eventOverlayQueue: EventCardDrawnPayload[]` store state.
- `showEventOverlay`: if a popup is already showing, **enqueue** the new card (FIFO) instead of overwriting; do not reset the current card's timer. Persistent effects still update the HUD immediately even while queued.
- `dismissEventOverlay`: **promote** the next queued card (fresh timer), keeping visual mutations gated; only when the queue empties does it clear `pendingEventOverlay` and flush queued visual updates.
- Extract `startOverlayAutoDismiss` helper (DRY).
- No `GameScene` change needed — its existing `null→A` / `A→B` / `B→null` transitions handle the queue correctly.

## Tests

`game.store.event.test.ts`: rewrote the stale "replaces an existing overlay" test (it encoded the old, buggy behavior) and added queue coverage — enqueue-not-overwrite, current-timer-not-reset, persistent-added-to-HUD-while-queued, dismiss-promotes-then-clears, and visual-updates-flush-only-on-final-dismiss. All 28 tests pass.

## Out of scope
- Event-card distribution fairness / shuffle randomness (separate follow-up).
- AI event handling (ruled out; existing PRs cover it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Fixes a bug where back-to-back event cards overwrite a single overlay slot, causing the second card's popup to replace the first without acknowledgment. The solution adds a FIFO queue (`eventOverlayQueue`) to the game store so that when a second event arrives while an overlay is showing, it's enqueued rather than overwriting. Each overlay maintains its own auto-dismiss timer (not reset), and visual updates remain gated until the final overlay is dismissed.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added `eventOverlayQueue` state and modified `showEventOverlay` in `game.store.ts` to queue new cards (FIFO) when an overlay is already showing, preventing overwrites and preserving the current card's timer.</li>

<li>Modified `dismissEventOverlay` in `game.store.ts` to promote the next queued overlay with a fresh 30s timer, only flushing `pendingVisualUpdates` when the queue becomes empty.</li>

<li>Extracted `startOverlayAutoDismiss` helper in `game.store.ts` to eliminate timer management duplication and ensure only one timer is ever active.</li>

<li>Added 6 new test cases in `game.store.event.test.ts` covering enqueue-not-overwrite, timer-not-reset, persistent effects updating HUD while queued, dismiss-promotes-then-clears, and visual updates gating behavior.</li>

<li>Rewrote the stale 'replaces an existing overlay' test in `game.store.event.test.ts` (it encoded the buggy overwriting behavior) to validate the correct queue-first behavior.</li>

</ul>
</details>

</div>