### PR TITLE
fix: resolve 8 pre-existing client TypeScript errors

### DIFF
--- a/src/client/components/CitySelectionManager.ts
+++ b/src/client/components/CitySelectionManager.ts
@@ -6,7 +6,7 @@ export class CitySelectionManager extends SimpleDropDownList {
   public scene: Phaser.Scene;
   private gameState: FullGameState;
   private mapRenderer: MapRenderer;
-  private onCitySelected: (
+  private onCitySelected!: (
     playerId: string,
     x: number,
     y: number,
@@ -15,7 +15,6 @@ export class CitySelectionManager extends SimpleDropDownList {
   ) => Promise<void>;
   private dropdownDomElement: any | null = null; // RexUI DropDownList type
   private isHandCollapsed: () => boolean;
-  private dropdown: Phaser.GameObjects.GameObject;
   private static style = {
     list: {
       maxHeight: 200,
@@ -26,7 +25,7 @@ export class CitySelectionManager extends SimpleDropDownList {
       // createTrackCallback: function (scene) {
       //   return scene.rexUI.add.roundRectangle({ width: 10, color: 0x808588 });
       // },
-      createThumbCallback: function (scene) {
+      createThumbCallback: function (scene: any) {
         return scene.rexUI.add.roundRectangle({
           width: 14,
           height: 24,
@@ -89,7 +88,7 @@ export class CitySelectionManager extends SimpleDropDownList {
       return;
     }
     this.onCitySelected = onCitySelected;
-    this.on("button.click", (_dropDownList, _listPanel, selectedOption) => {
+    this.on("button.click", (_dropDownList: any, _listPanel: any, selectedOption: any) => {
       const selectedCity = selectedOption.value;
       this.onCitySelected(
         playerId,

--- a/src/client/scenes/LoadDialogScene.ts
+++ b/src/client/scenes/LoadDialogScene.ts
@@ -30,8 +30,8 @@ export class LoadDialogScene extends Scene {
     private uiManager!: UIManager;
     private turnActionManager: TurnActionManager | null = null;
     private loadService: LoadService;
-    private gameStateService: GameStateService;
-    private playerStateService: PlayerStateService;
+    private gameStateService!: GameStateService;
+    private playerStateService!: PlayerStateService;
     private dialogContainer!: Phaser.GameObjects.Container;
     private errorText: Phaser.GameObjects.Text | null = null;
 


### PR DESCRIPTION
## Summary

Clears the 8 pre-existing TypeScript errors in the client bundle (`tsc -p tsconfig.webpack.json --noEmit`). These predate and are unrelated to the event-overlay-queue fix (PR #280) — surfaced during typecheck while verifying that change. Type-only; no runtime behavior change.

## Changes

**`src/client/scenes/LoadDialogScene.ts`**
- Added definite-assignment assertions (`!`) to `gameStateService` and `playerStateService`. Both are assigned in the Phaser `init()` lifecycle hook, not the constructor — matching the file's existing convention for its other init-assigned fields (`city!`, `player!`, `gameState!`, …).

**`src/client/components/CitySelectionManager.ts`**
- `onCitySelected` → `!` (assigned in the constructor, but after a conditional early `return`, so TS can't prove assignment).
- Removed the dead `dropdown` field — declared but never assigned or read anywhere (the live field is `dropdownDomElement`).
- Annotated implicit-`any` rexUI callback params: `createThumbCallback(scene: any)` and the `button.click` handler `(_dropDownList: any, _listPanel: any, selectedOption: any)` — these types are not present on `Phaser.Scene`.

## Verification
- `npx tsc -p tsconfig.webpack.json --noEmit` → 0 errors (was 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes 8 pre-existing TypeScript compilation errors in the client bundle by adding definite-assignment assertions and removing dead code. The changes affect two client-side TypeScript files with no runtime behavior modification.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>In `LoadDialogScene.ts`, adds definite-assignment assertions (`!`) to `gameStateService` and `playerStateService` fields, matching the existing pattern for other init-assigned fields like `city!` and `gameState!`.</li>

<li>In `CitySelectionManager.ts`, adds definite-assignment assertion to `onCitySelected` callback field (assigned after a conditional early return), and removes the dead unused `dropdown` field.</li>

<li>In `CitySelectionManager.ts`, annotates rexUI callback parameters with explicit `any` types: `createThumbCallback(scene: any)` and `button.click` handler parameters, since these types are not available on `Phaser.Scene`.</li>

</ul>
</details>

</div>